### PR TITLE
Update FFI delegates.

### DIFF
--- a/sources/Valkey.Glide/BaseClient.cs
+++ b/sources/Valkey.Glide/BaseClient.cs
@@ -138,6 +138,11 @@ public abstract partial class BaseClient : IDisposable, IAsyncDisposable
     ~BaseClient() => Dispose();
 
     internal void SetInfo(string info) => _clientInfo = info;
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void SuccessAction(ulong index, IntPtr ptr);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void FailureAction(ulong index, IntPtr strPtr, RequestErrorType err);
     #endregion private methods
 
     #region private fields
@@ -157,26 +162,4 @@ public abstract partial class BaseClient : IDisposable, IAsyncDisposable
     private string _clientInfo = ""; // used to distinguish and identify clients during tests
 
     #endregion private fields
-
-    #region FFI function declarations
-
-    private delegate void SuccessAction(ulong index, IntPtr ptr);
-    private delegate void FailureAction(ulong index, IntPtr strPtr, RequestErrorType err);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "command")]
-    private static extern void CommandFfi(IntPtr client, ulong index, IntPtr cmdInfo, IntPtr routeInfo);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "batch")]
-    private static extern void BatchFfi(IntPtr client, ulong index, IntPtr batch, [MarshalAs(UnmanagedType.U1)] bool raiseOnError, IntPtr opts);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_response")]
-    private static extern void FreeResponse(IntPtr response);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "create_client")]
-    private static extern void CreateClientFfi(IntPtr config, IntPtr successCallback, IntPtr failureCallback);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "close_client")]
-    private static extern void CloseClientFfi(IntPtr client);
-
-    #endregion
 }

--- a/sources/Valkey.Glide/Internals/FFI.methods.cs
+++ b/sources/Valkey.Glide/Internals/FFI.methods.cs
@@ -1,0 +1,47 @@
+﻿// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+// check https://stackoverflow.com/a/77455034 if you're getting analyzer error (using is unnecessary)
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Valkey.Glide.Internals;
+
+internal partial class FFI
+{
+#if NET8_0_OR_GREATER
+    [LibraryImport("libglide_rs", EntryPoint = "command")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial void CommandFfi(IntPtr client, ulong index, IntPtr cmdInfo, IntPtr routeInfo);
+
+    [LibraryImport("libglide_rs", EntryPoint = "batch")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial void BatchFfi(IntPtr client, ulong index, IntPtr batch, [MarshalAs(UnmanagedType.U1)] bool raiseOnError, IntPtr opts);
+
+    [LibraryImport("libglide_rs", EntryPoint = "free_response")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial void FreeResponse(IntPtr response);
+
+    [LibraryImport("libglide_rs", EntryPoint = "create_client")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial void CreateClientFfi(IntPtr config, IntPtr successCallback, IntPtr failureCallback);
+
+    [LibraryImport("libglide_rs", EntryPoint = "close_client")]
+    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static partial void CloseClientFfi(IntPtr client);
+#else
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "command")]
+    public static extern void CommandFfi(IntPtr client, ulong index, IntPtr cmdInfo, IntPtr routeInfo);
+
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "batch")]
+    public static extern void BatchFfi(IntPtr client, ulong index, IntPtr batch, [MarshalAs(UnmanagedType.U1)] bool raiseOnError, IntPtr opts);
+
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_response")]
+    public static extern void FreeResponse(IntPtr response);
+
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "create_client")]
+    public static extern void CreateClientFfi(IntPtr config, IntPtr successCallback, IntPtr failureCallback);
+
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "close_client")]
+    public static extern void CloseClientFfi(IntPtr client);
+#endif
+}

--- a/sources/Valkey.Glide/Internals/FFI.methods.cs
+++ b/sources/Valkey.Glide/Internals/FFI.methods.cs
@@ -10,23 +10,23 @@ internal partial class FFI
 {
 #if NET8_0_OR_GREATER
     [LibraryImport("libglide_rs", EntryPoint = "command")]
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void CommandFfi(IntPtr client, ulong index, IntPtr cmdInfo, IntPtr routeInfo);
 
     [LibraryImport("libglide_rs", EntryPoint = "batch")]
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void BatchFfi(IntPtr client, ulong index, IntPtr batch, [MarshalAs(UnmanagedType.U1)] bool raiseOnError, IntPtr opts);
 
     [LibraryImport("libglide_rs", EntryPoint = "free_response")]
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void FreeResponse(IntPtr response);
 
     [LibraryImport("libglide_rs", EntryPoint = "create_client")]
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void CreateClientFfi(IntPtr config, IntPtr successCallback, IntPtr failureCallback);
 
     [LibraryImport("libglide_rs", EntryPoint = "close_client")]
-    [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void CloseClientFfi(IntPtr client);
 #else
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "command")]

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -9,7 +9,7 @@ using static Valkey.Glide.Route;
 namespace Valkey.Glide.Internals;
 
 // FFI-ready structs, helper methods and wrappers
-internal class FFI
+internal partial class FFI
 {
     internal abstract class Marshallable : IDisposable
     {


### PR DESCRIPTION
Read about `LibraryImport`: [one](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/pinvoke-source-generation) [two](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/calling-conventions) [three](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices) and [examples](https://github.com/search?q=%5BLibraryImport&type=code)

UPD
This was mostly done to address a code style analyzer notice. As far I understand things, it can provide better performance in a multi-thread application. Performance wasn't measured.