### PR TITLE
Bump dependencies.

### DIFF
--- a/tests/Valkey.Glide.IntegrationTests/Valkey.Glide.IntegrationTests.csproj
+++ b/tests/Valkey.Glide.IntegrationTests/Valkey.Glide.IntegrationTests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit.v3" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Valkey.Glide.UnitTests/Valkey.Glide.UnitTests.csproj
+++ b/tests/Valkey.Glide.UnitTests/Valkey.Glide.UnitTests.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit.v3" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Note, xunit dependencies cannot be updated, becase newer versions don't support .net6. Current versions are most recent ones which support .net6.
<img width="787" height="168" alt="image" src="https://github.com/user-attachments/assets/f73ffc9a-7669-4c4c-bced-f1e620cdbb08" />
See release notes for
* [xunit.runner.visualstudio](https://xunit.net/releases/visualstudio/3.1.0)
* [xunit.v3](https://xunit.net/releases/v3/2.0.0#target-framework-and-dependency-updates)

We can update these dependencies when/if we remove support for .net6.