### PR TITLE
Revert "Bump dependencies."

### DIFF
--- a/tests/Valkey.Glide.IntegrationTests/Valkey.Glide.IntegrationTests.csproj
+++ b/tests/Valkey.Glide.IntegrationTests/Valkey.Glide.IntegrationTests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.v3" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Valkey.Glide.UnitTests/Valkey.Glide.UnitTests.csproj
+++ b/tests/Valkey.Glide.UnitTests/Valkey.Glide.UnitTests.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.v3" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Reverts valkey-io/valkey-glide-csharp#23

Newer version is incompatible with dotnet 6. Tests don't run.
https://github.com/valkey-io/valkey-glide-csharp/actions/runs/16898076868/job/47871651108#step:7:17
```
/home/runner/.nuget/packages/microsoft.net.test.sdk/17.14.1/build/netcoreapp2.0/Microsoft.NET.Test.Sdk.targets(4,5): error : Microsoft.NET.Test.Sdk doesn't support net6.0 and has not been tested with it. Consider upgrading your TargetFramework to net8.0 or later. You may also set <SuppressTfmSupportBuildErrors>true</SuppressTfmSupportBuildErrors> in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk. [/home/runner/work/valkey-glide-csharp/valkey-glide-csharp/tests/Valkey.Glide.IntegrationTests/Valkey.Glide.IntegrationTests.csproj::TargetFramework=net6.0]
```