### PR TITLE
Add reporting to GHA pipeline

### DIFF
--- a/tests/Valkey.Glide.IntegrationTests/TestFailureHandler.cs
+++ b/tests/Valkey.Glide.IntegrationTests/TestFailureHandler.cs
@@ -21,7 +21,6 @@ public static class TestFailureHandler
                 return;
             }
             s_initialized = true;
-
             string? output = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
             if (output is null)
             {
@@ -37,22 +36,41 @@ public static class TestFailureHandler
                         s_firstFailure = false;
                         File.AppendAllText(output, $"## Failed tests in CI pipeline:\n");
                     }
-                    string testName = ExtractTestName(ex.StackTrace ?? "");
-                    File.AppendAllText(output, $"### {testName}\n```\n{ex.Message}\n```\n\n");
+                    string permalink = BuildPermalink(ex.StackTrace ?? "");
+                    File.AppendAllText(output, $"### {permalink}\n```\n{ex.Message}\n```\n\n");
                 }
             };
 
         }
     }
 
-    private static string ExtractTestName(string stackTrace)
+    private static string BuildPermalink(string stackTrace)
     {
-        if (string.IsNullOrEmpty(stackTrace))
+        string? repo = Environment.GetEnvironmentVariable("GITHUB_REPOSITORY");
+        string? sha = Environment.GetEnvironmentVariable("GITHUB_SHA");
+
+        if (repo is null || sha is null)
         {
             return "Unknown";
         }
 
-        Match match = Regex.Match(stackTrace, @"at Valkey\.Glide\.(.+)\(");
-        return match.Success ? match.Groups[1].Value : "Unknown";
+        Match match = Regex.Match(stackTrace, @"at Valkey\.Glide\.(.+) in (.+Valkey\.Glide.+):line (\d+)");
+        if (!match.Success)
+        {
+            return "Unknown";
+        }
+
+        string testName = match.Groups[1].Value;
+        string filePath = match.Groups[2].Value;
+        string lineNumber = match.Groups[3].Value;
+
+        // Convert absolute path to relative path
+        string? workspace = Environment.GetEnvironmentVariable("GITHUB_WORKSPACE");
+        if (workspace is not null && filePath.StartsWith(workspace))
+        {
+            filePath = filePath.Substring(workspace.Length).TrimStart('/');
+        }
+
+        return $"[{testName}](https://github.com/{repo}/blob/{sha}/{filePath}#L{lineNumber})";
     }
 }

--- a/tests/Valkey.Glide.UnitTests/TestFailureHandler.cs
+++ b/tests/Valkey.Glide.UnitTests/TestFailureHandler.cs
@@ -74,12 +74,3 @@ public static class TestFailureHandler
         return $"[{testName}](https://github.com/{repo}/blob/{sha}/{filePath}#L{lineNumber})";
     }
 }
-
-public class FailFailTests
-{
-    [Fact]
-    public void FailFail()
-    {
-        Assert.Fail("This test always fails");
-    }
-}


### PR DESCRIPTION
This adds logging of failed tests in MD format to the Summary page of a GHA job.

See example https://github.com/valkey-io/valkey-glide-csharp/actions/runs/17145596664?pr=41