### PR TITLE
Fix ORT

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -37,7 +37,7 @@ jobs:
         name: Check condition
         # workaround https://github.com/orgs/community/discussions/54860
         if: >
-            ((github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-') || github.event_name != 'create')
+            ((github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-')) || github.event_name != 'create')
         runs-on: ubuntu-latest
         steps:
             - run:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -7,8 +7,10 @@ permissions:
 
 on:
     create:
-        ref_type: branch
-        ref: "refs/heads/release-*"
+        #ref_type: branch
+        ref:
+            - refs/heads/release-*
+            - refs/tags/*
     push:
         paths:
             - .github/workflows/ort.yml
@@ -25,7 +27,7 @@ jobs:
     run-ort:
         name: Create attribution files
         runs-on: ubuntu-latest
-        if: github.repository_owner == 'valkey-io'
+        #if: github.repository_owner == 'valkey-io'
         env:
             ATTRIBUTIONS_FILE: THIRD_PARTY_LICENSES
         steps:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -7,10 +7,10 @@ permissions:
 
 on:
     create:
-        #ref_type: branch
-        ref:
-            - refs/heads/release-*
-            - refs/tags/*
+        branches:
+            - 'release-*'
+        tags:
+            - '*'
     push:
         paths:
             - .github/workflows/ort.yml

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -28,6 +28,7 @@ jobs:
         #if: github.repository_owner == 'valkey-io'
         if: >
             (github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-') || github.event_name != 'create')
+        runs-on: ubuntu-latest
         steps:
 
     run-ort:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -24,16 +24,22 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    check-condition:
-        #if: github.repository_owner == 'valkey-io'
-        name: Check condition
-        if: >
-            (github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-') || github.event_name != 'create')
+    log:
+        name: Log
         runs-on: ubuntu-latest
         steps:
             - run: |
                   echo '${{ github.event_name }}'
                   echo '${{ toJson(github.event) }}'
+
+    check-condition:
+        #if: github.repository_owner == 'valkey-io'
+        name: Check condition
+        # workaround https://github.com/orgs/community/discussions/54860
+        if: >
+            ((github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-') || github.event_name != 'create')
+        runs-on: ubuntu-latest
+        steps:
             - run:
 
     run-ort:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -32,8 +32,8 @@ jobs:
             ATTRIBUTIONS_FILE: THIRD_PARTY_LICENSES
         steps:
             - run: |
-                  echo ${{ github.event_name }} 
-                  echo ${{ toJson(github.event) }} 
+                  echo '${{ github.event_name }}'
+                  echo '${{ toJson(github.event) }}'
 
             - uses: actions/checkout@v5
               with:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -7,13 +7,13 @@ permissions:
 
 on:
     create:
+    push:
+        paths:
+            - .github/workflows/ort.yml
         branches:
             - 'release-*'
         tags:
             - '*'
-    push:
-        paths:
-            - .github/workflows/ort.yml
     pull_request:
         paths:
             - .github/workflows/ort.yml
@@ -24,10 +24,16 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    check-condition:
+        #if: github.repository_owner == 'valkey-io'
+        if: >
+            (github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-') || github.event_name != 'create')
+        steps:
+
     run-ort:
+        needs: [check-condition]
         name: Create attribution files
         runs-on: ubuntu-latest
-        #if: github.repository_owner == 'valkey-io'
         env:
             ATTRIBUTIONS_FILE: THIRD_PARTY_LICENSES
         steps:
@@ -203,7 +209,7 @@ jobs:
 
               ### Create PR, Note a potential race on the source branch ###
             - name: Create or update pull request
-              if: ${{ env.FOUND_DIFF  == 'true' && github.event_name != 'pull_request' }}
+              if: ${{ env.FOUND_DIFF  == 'true' }}
               run: |
                   TARGET_BRANCH=`git branch --show-current`
                   ORT_DIFF_BRANCH_NAME="ort-diff-for-$TARGET_BRANCH"

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -30,6 +30,7 @@ jobs:
             (github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-') || github.event_name != 'create')
         runs-on: ubuntu-latest
         steps:
+            - run:
 
     run-ort:
         needs: [check-condition]

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -11,9 +11,9 @@ on:
         paths:
             - .github/workflows/ort.yml
         branches:
-            - 'release-*'
+            - "release-*"
         tags:
-            - '*'
+            - "*"
     pull_request:
         paths:
             - .github/workflows/ort.yml

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -26,10 +26,14 @@ concurrency:
 jobs:
     check-condition:
         #if: github.repository_owner == 'valkey-io'
+        name: Check condition
         if: >
             (github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-') || github.event_name != 'create')
         runs-on: ubuntu-latest
         steps:
+            - run: |
+                  echo '${{ github.event_name }}'
+                  echo '${{ toJson(github.event) }}'
             - run:
 
     run-ort:
@@ -39,10 +43,6 @@ jobs:
         env:
             ATTRIBUTIONS_FILE: THIRD_PARTY_LICENSES
         steps:
-            - run: |
-                  echo '${{ github.event_name }}'
-                  echo '${{ toJson(github.event) }}'
-
             - uses: actions/checkout@v5
               with:
                   submodules: true

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -12,8 +12,6 @@ on:
             - .github/workflows/ort.yml
         branches:
             - "release-*"
-        tags:
-            - "*"
     pull_request:
         paths:
             - .github/workflows/ort.yml
@@ -24,20 +22,17 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    log:
-        name: Log
-        runs-on: ubuntu-latest
-        steps:
-            - run: |
-                  echo '${{ github.event_name }}'
-                  echo '${{ toJson(github.event) }}'
-
     check-condition:
-        #if: github.repository_owner == 'valkey-io'
         name: Check condition
-        # workaround https://github.com/orgs/community/discussions/54860
+        # workaround for https://github.com/orgs/community/discussions/54860 (`create` event filter)
         if: >
-            ((github.event_name == 'create' && github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-')) || github.event_name != 'create')
+            github.repository_owner == 'valkey-io' &&
+            (github.event_name != 'create' ||
+                (github.event_name == 'create' &&
+                    ((github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release-')) ||
+                    github.event.ref_type == 'tag')
+                )
+            )
         runs-on: ubuntu-latest
         steps:
             - run:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -8,8 +8,6 @@ permissions:
 on:
     create:
     push:
-        paths:
-            - .github/workflows/ort.yml
         branches:
             - "release-*"
     pull_request:

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -31,6 +31,10 @@ jobs:
         env:
             ATTRIBUTIONS_FILE: THIRD_PARTY_LICENSES
         steps:
+            - run: |
+                  echo ${{ github.event_name }} 
+                  echo ${{ toJson(github.event) }} 
+
             - uses: actions/checkout@v5
               with:
                   submodules: true


### PR DESCRIPTION
fixes #49

Added condition check for `create` event. Tested on fork - ORT isn't triggered automatically anymore on arbitrary branches.
ORT is triggered:
* manually
* automatically
  * On branches named `release-*` on branch creation or push
  * On any PR which updates ORT pipeline