### PR TITLE
Temporary workaround: disable SelectAsync and ClientSetNameAsync (see valkey-glide#4691)

### DIFF
--- a/sources/Valkey.Glide/Commands/IServerManagementClusterCommands.cs
+++ b/sources/Valkey.Glide/Commands/IServerManagementClusterCommands.cs
@@ -187,5 +187,6 @@ public interface IServerManagementClusterCommands
     /// </code>
     /// </example>
     /// </remarks>
-    Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None);
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None);
 }

--- a/sources/Valkey.Glide/Commands/IServerManagementCommands.cs
+++ b/sources/Valkey.Glide/Commands/IServerManagementCommands.cs
@@ -72,5 +72,6 @@ public interface IServerManagementCommands
     /// </code>
     /// </example>
     /// </remarks>
-    Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None);
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None);
 }

--- a/sources/Valkey.Glide/GlideClient.cs
+++ b/sources/Valkey.Glide/GlideClient.cs
@@ -115,9 +115,10 @@ public class GlideClient : BaseClient, IGenericCommands, IServerManagementComman
         return await Command(Request.ClientId());
     }
 
-    public async Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None)
-    {
-        Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
-        return await Command(Request.Select(index));
-    }
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // public async Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None)
+    // {
+    //     Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
+    //     return await Command(Request.Select(index));
+    // }
 }

--- a/sources/Valkey.Glide/GlideClusterClient.cs
+++ b/sources/Valkey.Glide/GlideClusterClient.cs
@@ -130,9 +130,10 @@ public sealed class GlideClusterClient : BaseClient, IGenericClusterCommands, IS
         return await Command(Request.ClientId().ToClusterValue(route is SingleNodeRoute), route);
     }
 
-    public async Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None)
-    {
-        Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
-        return await Command(Request.Select(index), Route.Random);
-    }
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // public async Task<string> SelectAsync(long index, CommandFlags flags = CommandFlags.None)
+    // {
+    //     Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
+    //     return await Command(Request.Select(index), Route.Random);
+    // }
 }

--- a/sources/Valkey.Glide/Pipeline/BaseBatch.ConnectionManagement.cs
+++ b/sources/Valkey.Glide/Pipeline/BaseBatch.ConnectionManagement.cs
@@ -21,13 +21,16 @@ public abstract partial class BaseBatch<T> : IBatchConnectionManagementCommands 
     /// <inheritdoc cref="IBatchConnectionManagementCommands.ClientIdAsync()" />
     public T ClientIdAsync() => AddCmd(Request.ClientId());
 
-    /// <inheritdoc cref="IBatchConnectionManagementCommands.SelectAsync(long)" />
-    public T SelectAsync(long index) => AddCmd(Request.Select(index));
+    // <inheritdoc cref="IBatchConnectionManagementCommands.SelectAsync(long)" />
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // public T SelectAsync(long index) => AddCmd(Request.Select(index));
 
     IBatch IBatchConnectionManagementCommands.Ping() => Ping();
     IBatch IBatchConnectionManagementCommands.Ping(ValkeyValue message) => Ping(message);
     IBatch IBatchConnectionManagementCommands.Echo(ValkeyValue message) => Echo(message);
     IBatch IBatchConnectionManagementCommands.ClientGetNameAsync() => ClientGetNameAsync();
     IBatch IBatchConnectionManagementCommands.ClientIdAsync() => ClientIdAsync();
-    IBatch IBatchConnectionManagementCommands.SelectAsync(long index) => SelectAsync(index);
+
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // IBatch IBatchConnectionManagementCommands.SelectAsync(long index) => SelectAsync(index);
 }

--- a/sources/Valkey.Glide/Pipeline/IBatchConnectionManagementCommands.cs
+++ b/sources/Valkey.Glide/Pipeline/IBatchConnectionManagementCommands.cs
@@ -28,5 +28,6 @@ internal interface IBatchConnectionManagementCommands
 
     /// <inheritdoc cref="IServerManagementCommands.SelectAsync(long, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
     /// <returns>Command Response - <inheritdoc cref="IServerManagementCommands.SelectAsync(long, CommandFlags)" /></returns>
-    IBatch SelectAsync(long index);
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // IBatch SelectAsync(long index);
 }

--- a/tests/Valkey.Glide.IntegrationTests/BatchTestUtils.cs
+++ b/tests/Valkey.Glide.IntegrationTests/BatchTestUtils.cs
@@ -1166,11 +1166,12 @@ internal class BatchTestUtils
         testData.Add(new(1L, "ClientIdAsync()", true)); // Check type only since ID is dynamic
 
         // SELECT - 9.0.0 allows both standalone and cluster, else just run standalone
-        if (batch is Pipeline.Batch || TestConfiguration.SERVER_VERSION >= new Version("9.0.0"))
-        {
-            _ = batch.SelectAsync(0); // Select database 0 (default)
-            testData.Add(new("OK", "SelectAsync(0)"));
-        }
+        // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+        // if (batch is Pipeline.Batch || TestConfiguration.SERVER_VERSION >= new Version("9.0.0"))
+        // {
+        //     _ = batch.SelectAsync(0); // Select database 0 (default)
+        //     testData.Add(new("OK", "SelectAsync(0)"));
+        // }
 
         return testData;
     }

--- a/tests/Valkey.Glide.IntegrationTests/ClusterClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClusterClientTests.cs
@@ -317,15 +317,16 @@ public class ClusterClientTests(TestConfiguration config)
         }
     }
 
-    [Theory(DisableDiscoveryEnumeration = true)]
-    [MemberData(nameof(Config.TestClusterClients), MemberType = typeof(TestConfiguration))]
-    public async Task TestSelect(GlideClusterClient client)
-    {
-        Assert.SkipWhen(
-            TestConfiguration.SERVER_VERSION < new Version("9.0.0"),
-            "SELECT for Cluster Client is supported since 9.0.0"
-        );
-        string result = await client.SelectAsync(0);
-        Assert.Equal("OK", result);
-    }
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // [Theory(DisableDiscoveryEnumeration = true)]
+    // [MemberData(nameof(Config.TestClusterClients), MemberType = typeof(TestConfiguration))]
+    // public async Task TestSelect(GlideClusterClient client)
+    // {
+    //     Assert.SkipWhen(
+    //         TestConfiguration.SERVER_VERSION < new Version("9.0.0"),
+    //         "SELECT for Cluster Client is supported since 9.0.0"
+    //     );
+    //     string result = await client.SelectAsync(0);
+    //     Assert.Equal("OK", result);
+    // }
 }

--- a/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
@@ -3,7 +3,6 @@
 using Valkey.Glide.Pipeline;
 
 using static Valkey.Glide.Commands.Options.InfoOptions;
-using static Valkey.Glide.Errors;
 
 namespace Valkey.Glide.IntegrationTests;
 
@@ -211,18 +210,19 @@ public class StandaloneClientTests(TestConfiguration config)
         Assert.Equal(ValkeyValue.Null, clientName);
     }
 
-    [Theory(DisableDiscoveryEnumeration = true)]
-    [MemberData(nameof(Config.TestStandaloneClients), MemberType = typeof(TestConfiguration))]
-    public async Task TestSelect(GlideClient client)
-    {
-        // Test selecting database 0 (default)
-        string result = await client.SelectAsync(0);
-        Assert.Equal("OK", result);
+    // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+    // [Theory(DisableDiscoveryEnumeration = true)]
+    // [MemberData(nameof(Config.TestStandaloneClients), MemberType = typeof(TestConfiguration))]
+    // public async Task TestSelect(GlideClient client)
+    // {
+    //     // Test selecting database 0 (default)
+    //     string result = await client.SelectAsync(0);
+    //     Assert.Equal("OK", result);
 
-        // Switching to a valid database causes issue to tests running in parallel. So instead, we test
-        // that using an invalid value to ensure different values can still be sent through.
-        await Assert.ThrowsAsync<RequestException>(async () => _ = await client.SelectAsync(-1));
-    }
+    //     // Switching to a valid database causes issue to tests running in parallel. So instead, we test
+    //     // that using an invalid value to ensure different values can still be sent through.
+    //     await Assert.ThrowsAsync<RequestException>(async () => _ = await client.SelectAsync(-1));
+    // }
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestStandaloneClients), MemberType = typeof(TestConfiguration))]
@@ -235,8 +235,9 @@ public class StandaloneClientTests(TestConfiguration config)
         ValkeyValue clientName = await client.ClientGetNameAsync(CommandFlags.None);
         Assert.Equal(ValkeyValue.Null, clientName);
 
-        string selectResult = await client.SelectAsync(0, CommandFlags.None);
-        Assert.Equal("OK", selectResult);
+        // TODO: Re-enable when https://github.com/valkey-io/valkey-glide/issues/4691 is resolved.
+        // string selectResult = await client.SelectAsync(0, CommandFlags.None);
+        // Assert.Equal("OK", selectResult);
     }
 
     [Theory(DisableDiscoveryEnumeration = true)]


### PR DESCRIPTION
This PR applies a temporary solution to disable SelectAsync and ClientSetNameAsync as discussed in https://github.com/valkey-io/valkey-glide/issues/4691. See issue #69 in this repo for tracking the workaround.