### PR TITLE
Ignore StackExchange.Redis version updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
           day: "monday"
           time: "09:00"
       open-pull-requests-limit: 10
+      ignore:
+          - dependency-name: "StackExchange.Redis"
       groups:
           patch-updates:
               update-types:


### PR DESCRIPTION
Fixes #76

## Changes
- Updated `.github/dependabot.yml` to ignore StackExchange.Redis version updates
- Maintains compatibility with version 2.8.58 as required by the project

## Testing
- Dependabot will no longer create PRs for StackExchange.Redis updates
- Other NuGet package updates will continue to work normally