### PR TITLE
Add `git-secrets-scan` workflow

### DIFF
--- a/.github/workflows/git-secrets-scan.yml
+++ b/.github/workflows/git-secrets-scan.yml
@@ -1,33 +1,33 @@
 name: Git Secrets Scan
 
 permissions:
-  contents: read
+    contents: read
 
 on:
-  pull_request:
-  workflow_dispatch:
+    pull_request:
+    workflow_dispatch:
 
 concurrency:
-  group: git-secrets-scan-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+    group: git-secrets-scan-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  scan:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    scan:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v5
 
-      - name: Install git-secrets
-        run: |
-          git clone --depth 1 --branch 1.3.0 https://github.com/awslabs/git-secrets.git
-          cd git-secrets
-          sudo make install
+            - name: Install git-secrets
+              run: |
+                  git clone --depth 1 --branch 1.3.0 https://github.com/awslabs/git-secrets.git
+                  cd git-secrets
+                  sudo make install
 
-      - name: Configure git-secrets
-        run: git secrets --register-aws
+            - name: Configure git-secrets
+              run: git secrets --register-aws
 
-      - name: Run git-secrets
-        run: git secrets --scan
+            - name: Run git-secrets
+              run: git secrets --scan


### PR DESCRIPTION
Adds a git-secrets-scan workflow that installs and executes [git-secrets](https://github.com/awslabs/git-secrets) on pushes to `main` and release branches. This helps to ensure that passwords, secrets, and other sensitive information does not get committed.