### PR TITLE
(cleanup): Remove outdated comment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,8 +203,6 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Don't use generated matrix for dotnet until net6.0 compatibility issues resolved on amazon linux
-                # dotnet: ${{ fromJson(needs.get-containers.outputs.version-matrix-output) }}
                 dotnet: ["8.0"]
                 server: ${{ fromJson(needs.get-containers.outputs.server-matrix-output) }}
                 host: ${{ fromJson(needs.get-containers.outputs.host-matrix-output) }}


### PR DESCRIPTION
## Summary

Remove outdated comment in `tests.yml`: .NET 6.0 is no longer supported.

## Changes

Removed the following outdated comment from `tests.yml`:

> \# Don't use generated matrix for dotnet until net6.0 compatibility issues resolved on amazon linux
\# dotnet: ${{ fromJson(needs.get-containers.outputs.version-matrix-output) }}

## Test Strategy

⚪ None - No code changes

## Related Issues

⚪ None - trivial cleanup