### PR TITLE
(cleanup): rename `InvokeScript` to `ScriptInvoke` for consistency

### DIFF
--- a/sources/Valkey.Glide/BaseClient.ScriptingCommands.cs
+++ b/sources/Valkey.Glide/BaseClient.ScriptingCommands.cs
@@ -14,7 +14,7 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
     // ===== Script Execution =====
 
     /// <inheritdoc/>
-    public async Task<ValkeyResult> InvokeScriptAsync(
+    public async Task<ValkeyResult> ScriptInvokeAsync(
         Script script,
         CommandFlags flags = CommandFlags.None,
         CancellationToken cancellationToken = default)
@@ -25,11 +25,11 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
         }
 
         GuardClauses.ThrowIfCommandFlags(flags);
-        return await InvokeScriptInternalAsync(script.Hash, null, null, null);
+        return await ScriptInvokeInternalAsync(script.Hash, null, null, null);
     }
 
     /// <inheritdoc/>
-    public async Task<ValkeyResult> InvokeScriptAsync(
+    public async Task<ValkeyResult> ScriptInvokeAsync(
         Script script,
         ScriptOptions options,
         CommandFlags flags = CommandFlags.None,
@@ -46,10 +46,10 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
         }
 
         GuardClauses.ThrowIfCommandFlags(flags);
-        return await InvokeScriptInternalAsync(script.Hash, options.Keys, options.Args, null);
+        return await ScriptInvokeInternalAsync(script.Hash, options.Keys, options.Args, null);
     }
 
-    private async Task<ValkeyResult> InvokeScriptInternalAsync(
+    private async Task<ValkeyResult> ScriptInvokeInternalAsync(
         string hash,
         string[]? keys,
         string[]? args,
@@ -80,7 +80,7 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
 
             // Call FFI
             Message message = MessageContainer.GetMessageForCall();
-            FFI.InvokeScriptFfi(
+            FFI.ScriptInvokeFfi(
                 ClientPointer,
                 (ulong)message.Index,
                 hashPtr,
@@ -361,7 +361,7 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
     {
         GuardClauses.ThrowIfCommandFlags(flags);
 
-        // Use the optimized InvokeScript path via Script object
+        // Use the optimized ScriptInvoke path via Script object
         // Script constructor will validate the script parameter
         using Script scriptObj = new(script);
 
@@ -369,8 +369,8 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
         string[]? keyStrings = keys?.Select(k => k.ToString()).ToArray();
         string[]? valueStrings = values?.Select(v => v.ToString()).ToArray();
 
-        // Use InvokeScriptInternalAsync for automatic EVALSHA→EVAL optimization
-        return await InvokeScriptInternalAsync(scriptObj.Hash, keyStrings, valueStrings, null);
+        // Use ScriptInvokeInternalAsync for automatic EVALSHA→EVAL optimization
+        return await ScriptInvokeInternalAsync(scriptObj.Hash, keyStrings, valueStrings, null);
     }
 
     /// <inheritdoc/>
@@ -386,8 +386,8 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
         string[]? keyStrings = keys?.Select(k => k.ToString()).ToArray();
         string[]? valueStrings = values?.Select(v => v.ToString()).ToArray();
 
-        // Use InvokeScriptInternalAsync (will use EVALSHA directly, no fallback since we don't have source)
-        return await InvokeScriptInternalAsync(hashString, keyStrings, valueStrings, null);
+        // Use ScriptInvokeInternalAsync (will use EVALSHA directly, no fallback since we don't have source)
+        return await ScriptInvokeInternalAsync(hashString, keyStrings, valueStrings, null);
     }
 
     /// <inheritdoc/>
@@ -413,10 +413,10 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
         string[]? keyStrings = keys.Length > 0 ? [.. keys.Select(k => k.ToString())] : null;
         string[]? valueStrings = args.Length > 0 ? [.. args.Select(v => v.ToString())] : null;
 
-        // Create a Script object from the executable script and use InvokeScript
+        // Create a Script object from the executable script and use ScriptInvoke
         // This will automatically load the script if needed (EVALSHA with fallback to EVAL)
         using Script scriptObj = new(executableScript);
-        return await InvokeScriptInternalAsync(scriptObj.Hash, keyStrings, valueStrings, null);
+        return await ScriptInvokeInternalAsync(scriptObj.Hash, keyStrings, valueStrings, null);
     }
 
     /// <inheritdoc/>
@@ -441,9 +441,9 @@ public abstract partial class BaseClient : IScriptingAndFunctionBaseCommands
         // The hash in LoadedLuaScript is the hash of the script that was actually loaded on the server
         string hashString = BitConverter.ToString(script.Hash).Replace("-", "").ToLowerInvariant();
 
-        // Use InvokeScriptInternalAsync with the hash from LoadedLuaScript
+        // Use ScriptInvokeInternalAsync with the hash from LoadedLuaScript
         // The script was already loaded on the server, so EVALSHA will work
-        return await InvokeScriptInternalAsync(hashString, keyStrings, valueStrings, null);
+        return await ScriptInvokeInternalAsync(hashString, keyStrings, valueStrings, null);
     }
 
     // ===== Synchronous Wrappers =====

--- a/sources/Valkey.Glide/Commands/IScriptingAndFunctionBaseCommands.cs
+++ b/sources/Valkey.Glide/Commands/IScriptingAndFunctionBaseCommands.cs
@@ -20,11 +20,11 @@ public interface IScriptingAndFunctionBaseCommands
     /// <example>
     /// <code>
     /// using var script = new Script("return 'Hello, World!'");
-    /// ValkeyResult result = await client.InvokeScriptAsync(script);
+    /// ValkeyResult result = await client.ScriptInvokeAsync(script);
     /// </code>
     /// </example>
     /// </remarks>
-    Task<ValkeyResult> InvokeScriptAsync(
+    Task<ValkeyResult> ScriptInvokeAsync(
         Script script,
         CommandFlags flags = CommandFlags.None,
         CancellationToken cancellationToken = default);
@@ -42,11 +42,11 @@ public interface IScriptingAndFunctionBaseCommands
     /// <code>
     /// using var script = new Script("return KEYS[1] .. ARGV[1]");
     /// var options = new ScriptOptions().WithKeys("mykey").WithArgs("myvalue");
-    /// ValkeyResult result = await client.InvokeScriptAsync(script, options);
+    /// ValkeyResult result = await client.ScriptInvokeAsync(script, options);
     /// </code>
     /// </example>
     /// </remarks>
-    Task<ValkeyResult> InvokeScriptAsync(
+    Task<ValkeyResult> ScriptInvokeAsync(
         Script script,
         ScriptOptions options,
         CommandFlags flags = CommandFlags.None,

--- a/sources/Valkey.Glide/Commands/IScriptingAndFunctionClusterCommands.cs
+++ b/sources/Valkey.Glide/Commands/IScriptingAndFunctionClusterCommands.cs
@@ -22,7 +22,7 @@ public interface IScriptingAndFunctionClusterCommands : IScriptingAndFunctionBas
     /// <code>
     /// using var script = new Script("return 'Hello'");
     /// var options = new ClusterScriptOptions().WithRoute(Route.AllPrimaries);
-    /// ClusterValue&lt;ValkeyResult&gt; result = await client.InvokeScriptAsync(script, options);
+    /// ClusterValue&lt;ValkeyResult&gt; result = await client.ScriptInvokeAsync(script, options);
     /// if (result.HasMultiData)
     /// {
     ///     foreach (var (node, value) in result.MultiValue)
@@ -32,7 +32,7 @@ public interface IScriptingAndFunctionClusterCommands : IScriptingAndFunctionBas
     /// </code>
     /// </example>
     /// </remarks>
-    Task<ClusterValue<ValkeyResult>> InvokeScriptAsync(
+    Task<ClusterValue<ValkeyResult>> ScriptInvokeAsync(
         Script script,
         ClusterScriptOptions options,
         CommandFlags flags = CommandFlags.None,

--- a/sources/Valkey.Glide/GlideClusterClient.ScriptingCommands.cs
+++ b/sources/Valkey.Glide/GlideClusterClient.ScriptingCommands.cs
@@ -10,7 +10,7 @@ public sealed partial class GlideClusterClient : IScriptingAndFunctionClusterCom
     // ===== Script Execution with Routing =====
 
     /// <inheritdoc/>
-    public async Task<ClusterValue<ValkeyResult>> InvokeScriptAsync(
+    public async Task<ClusterValue<ValkeyResult>> ScriptInvokeAsync(
         Script script,
         ClusterScriptOptions options,
         CommandFlags flags = CommandFlags.None,

--- a/sources/Valkey.Glide/Internals/FFI.methods.cs
+++ b/sources/Valkey.Glide/Internals/FFI.methods.cs
@@ -69,7 +69,7 @@ internal partial class FFI
 
     [LibraryImport("libglide_rs", EntryPoint = "invoke_script")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial void InvokeScriptFfi(
+    public static partial void ScriptInvokeFfi(
         IntPtr client,
         ulong index,
         IntPtr hash,
@@ -144,8 +144,8 @@ internal partial class FFI
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_drop_script_error")]
     public static extern void FreeDropScriptError(IntPtr errorBuffer);
 
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "invoke_script")]
-    public static extern void InvokeScriptFfi(
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "script_invoke")]
+    public static extern void ScriptInvokeFfi(
         IntPtr client,
         ulong index,
         IntPtr hash,

--- a/tests/Valkey.Glide.IntegrationTests/ScriptingCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ScriptingCommandTests.cs
@@ -9,11 +9,11 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_SimpleScript_ReturnsExpectedResult(BaseClient client)
+    public async Task ScriptInvokeAsync_SimpleScript_ReturnsExpectedResult(BaseClient client)
     {
         // Test simple script execution
         using var script = new Script("return 'Hello, World!'");
-        ValkeyResult result = await client.InvokeScriptAsync(script);
+        ValkeyResult result = await client.ScriptInvokeAsync(script);
 
         Assert.NotNull(result);
         Assert.Equal("Hello, World!", result.ToString());
@@ -21,7 +21,7 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_WithKeysAndArgs_ReturnsExpectedResult(BaseClient client)
+    public async Task ScriptInvokeAsync_WithKeysAndArgs_ReturnsExpectedResult(BaseClient client)
     {
         // Test script with keys and arguments
         using var script = new Script("return KEYS[1] .. ':' .. ARGV[1]");
@@ -29,7 +29,7 @@ public class ScriptingCommandTests(TestConfiguration config)
             .WithKeys("mykey")
             .WithArgs("myvalue");
 
-        ValkeyResult result = await client.InvokeScriptAsync(script, options);
+        ValkeyResult result = await client.ScriptInvokeAsync(script, options);
 
         Assert.NotNull(result);
         Assert.Equal("mykey:myvalue", result.ToString());
@@ -37,14 +37,14 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_NOSCRIPTFallback_AutomaticallyUsesEVAL(BaseClient client)
+    public async Task ScriptInvokeAsync_NOSCRIPTFallback_AutomaticallyUsesEVAL(BaseClient client)
     {
         // Flush scripts to ensure NOSCRIPT error
         await client.ScriptFlushAsync();
 
         // This should trigger NOSCRIPT and automatically fallback to EVAL
         using var script = new Script("return 'fallback test'");
-        ValkeyResult result = await client.InvokeScriptAsync(script);
+        ValkeyResult result = await client.ScriptInvokeAsync(script);
 
         Assert.NotNull(result);
         Assert.Equal("fallback test", result.ToString());
@@ -52,13 +52,13 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_ScriptError_ThrowsException(BaseClient client)
+    public async Task ScriptInvokeAsync_ScriptError_ThrowsException(BaseClient client)
     {
         // Test script execution error
         using var script = new Script("return redis.call('INVALID_COMMAND')");
 
         await Assert.ThrowsAsync<Errors.RequestException>(async () =>
-            await client.InvokeScriptAsync(script));
+            await client.ScriptInvokeAsync(script));
     }
 
     [Theory(DisableDiscoveryEnumeration = true)]
@@ -67,7 +67,7 @@ public class ScriptingCommandTests(TestConfiguration config)
     {
         // Load a script and verify it exists
         using var script = new Script("return 'exists test'");
-        await client.InvokeScriptAsync(script);
+        await client.ScriptInvokeAsync(script);
 
         bool[] exists = await client.ScriptExistsAsync([script.Hash]);
 
@@ -102,7 +102,7 @@ public class ScriptingCommandTests(TestConfiguration config)
         using var script2 = new Script("return 'script2'");
 
         // Execute only script1
-        await client.InvokeScriptAsync(script1);
+        await client.ScriptInvokeAsync(script1);
 
         bool[] exists = await client.ScriptExistsAsync([script1.Hash, script2.Hash]);
 
@@ -117,7 +117,7 @@ public class ScriptingCommandTests(TestConfiguration config)
     {
         // Load a script
         using var script = new Script("return 'flush test'");
-        await client.InvokeScriptAsync(script);
+        await client.ScriptInvokeAsync(script);
 
         // Verify it exists
         bool[] existsBefore = await client.ScriptExistsAsync([script.Hash]);
@@ -138,7 +138,7 @@ public class ScriptingCommandTests(TestConfiguration config)
     {
         // Load a script
         using var script = new Script("return 'async flush test'");
-        await client.InvokeScriptAsync(script);
+        await client.ScriptInvokeAsync(script);
 
         // Flush with ASYNC mode
         string result = await client.ScriptFlushAsync(FlushMode.Async);
@@ -158,7 +158,7 @@ public class ScriptingCommandTests(TestConfiguration config)
     {
         // Load a script
         using var script = new Script("return 'default flush test'");
-        await client.InvokeScriptAsync(script);
+        await client.ScriptInvokeAsync(script);
 
         // Flush with default mode (SYNC)
         string result = await client.ScriptFlushAsync();
@@ -178,7 +178,7 @@ public class ScriptingCommandTests(TestConfiguration config)
         // Load a script
         string scriptCode = "return 'show test'";
         using var script = new Script(scriptCode);
-        await client.InvokeScriptAsync(script);
+        await client.ScriptInvokeAsync(script);
 
         // Get the source code
         string? source = await client.ScriptShowAsync(script.Hash);
@@ -216,7 +216,7 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_MultipleKeys_WorksCorrectly(BaseClient client)
+    public async Task ScriptInvokeAsync_MultipleKeys_WorksCorrectly(BaseClient client)
     {
         // Test script with multiple keys
         // Use hash tags to ensure keys hash to same slot in cluster mode
@@ -224,7 +224,7 @@ public class ScriptingCommandTests(TestConfiguration config)
         var options = new ScriptOptions()
             .WithKeys("{key}1", "{key}2", "{key}3");
 
-        ValkeyResult result = await client.InvokeScriptAsync(script, options);
+        ValkeyResult result = await client.ScriptInvokeAsync(script, options);
 
         Assert.NotNull(result);
         Assert.Equal(3, (long)result);
@@ -232,14 +232,14 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_MultipleArgs_WorksCorrectly(BaseClient client)
+    public async Task ScriptInvokeAsync_MultipleArgs_WorksCorrectly(BaseClient client)
     {
         // Test script with multiple arguments
         using var script = new Script("return #ARGV");
         var options = new ScriptOptions()
             .WithArgs("arg1", "arg2", "arg3", "arg4");
 
-        ValkeyResult result = await client.InvokeScriptAsync(script, options);
+        ValkeyResult result = await client.ScriptInvokeAsync(script, options);
 
         Assert.NotNull(result);
         Assert.Equal(4, (long)result);
@@ -247,11 +247,11 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_ReturnsInteger_ConvertsCorrectly(BaseClient client)
+    public async Task ScriptInvokeAsync_ReturnsInteger_ConvertsCorrectly(BaseClient client)
     {
         // Test script returning integer
         using var script = new Script("return 42");
-        ValkeyResult result = await client.InvokeScriptAsync(script);
+        ValkeyResult result = await client.ScriptInvokeAsync(script);
 
         Assert.NotNull(result);
         Assert.Equal(42, (long)result);
@@ -259,11 +259,11 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_ReturnsArray_ConvertsCorrectly(BaseClient client)
+    public async Task ScriptInvokeAsync_ReturnsArray_ConvertsCorrectly(BaseClient client)
     {
         // Test script returning array
         using var script = new Script("return {'a', 'b', 'c'}");
-        ValkeyResult result = await client.InvokeScriptAsync(script);
+        ValkeyResult result = await client.ScriptInvokeAsync(script);
 
         Assert.NotNull(result);
         string?[]? arr = (string?[]?)result;
@@ -276,11 +276,11 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_ReturnsNil_HandlesCorrectly(BaseClient client)
+    public async Task ScriptInvokeAsync_ReturnsNil_HandlesCorrectly(BaseClient client)
     {
         // Test script returning nil
         using var script = new Script("return nil");
-        ValkeyResult result = await client.InvokeScriptAsync(script);
+        ValkeyResult result = await client.ScriptInvokeAsync(script);
 
         Assert.NotNull(result);
         Assert.True(result.IsNull);
@@ -288,7 +288,7 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_AccessesRedisData_WorksCorrectly(BaseClient client)
+    public async Task ScriptInvokeAsync_AccessesRedisData_WorksCorrectly(BaseClient client)
     {
         // Set up test data
         string key = Guid.NewGuid().ToString();
@@ -299,7 +299,7 @@ public class ScriptingCommandTests(TestConfiguration config)
         using var script = new Script("return redis.call('GET', KEYS[1])");
         var options = new ScriptOptions().WithKeys(key);
 
-        ValkeyResult result = await client.InvokeScriptAsync(script, options);
+        ValkeyResult result = await client.ScriptInvokeAsync(script, options);
 
         Assert.NotNull(result);
         Assert.Equal(value, result.ToString());
@@ -307,7 +307,7 @@ public class ScriptingCommandTests(TestConfiguration config)
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task InvokeScriptAsync_ModifiesRedisData_WorksCorrectly(BaseClient client)
+    public async Task ScriptInvokeAsync_ModifiesRedisData_WorksCorrectly(BaseClient client)
     {
         // Script that sets a value
         string key = Guid.NewGuid().ToString();
@@ -318,7 +318,7 @@ public class ScriptingCommandTests(TestConfiguration config)
             .WithKeys(key)
             .WithArgs(value);
 
-        ValkeyResult result = await client.InvokeScriptAsync(script, options);
+        ValkeyResult result = await client.ScriptInvokeAsync(script, options);
 
         Assert.NotNull(result);
         Assert.Equal("OK", result.ToString());
@@ -1709,7 +1709,7 @@ redis.register_function('{funcName}', function(keys, args) return 'multi-node re
         using var scriptObj = new Script(script);
 
         // Execute once to cache it
-        await client.InvokeScriptAsync(scriptObj);
+        await client.ScriptInvokeAsync(scriptObj);
 
         // Convert hash string to byte array
         byte[] hash = Convert.FromHexString(scriptObj.Hash);
@@ -1821,7 +1821,7 @@ redis.register_function('{funcName}', function(keys, args) return 'multi-node re
             Assert.False(existsBefore);
 
             // Load the script
-            await client.InvokeScriptAsync(scriptObj);
+            await client.ScriptInvokeAsync(scriptObj);
 
             // Script should exist now
             bool existsAfter = await server.ScriptExistsAsync(hash);
@@ -1901,7 +1901,7 @@ redis.register_function('{funcName}', function(keys, args) return 'multi-node re
             // Load a script
             string script = "return 'flush test'";
             using var scriptObj = new Script(script);
-            await client.InvokeScriptAsync(scriptObj);
+            await client.ScriptInvokeAsync(scriptObj);
 
             // Verify it exists
             bool existsBefore = await server.ScriptExistsAsync(script);

--- a/tests/Valkey.Glide.IntegrationTests/SharedClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/SharedClientTests.cs
@@ -40,7 +40,7 @@ public class SharedClientTests(TestConfiguration config)
         using var script = new Script("return KEYS[1]");
         var options = new ScriptOptions().WithKeys(LargeString);
 
-        var result = await client.InvokeScriptAsync(script, options);
+        var result = await client.ScriptInvokeAsync(script, options);
 
         Assert.Equal(LargeString, result.ToString());
     }
@@ -52,7 +52,7 @@ public class SharedClientTests(TestConfiguration config)
         using var script = new Script("return ARGV[1]");
         var options = new ScriptOptions().WithArgs(LargeString);
 
-        ValkeyResult result = await client.InvokeScriptAsync(script, options);
+        ValkeyResult result = await client.ScriptInvokeAsync(script, options);
 
         Assert.Equal(LargeString, result.ToString());
     }
@@ -66,7 +66,7 @@ public class SharedClientTests(TestConfiguration config)
             .WithKeys(LargeString)
             .WithArgs(LargeString);
 
-        var result = await client.InvokeScriptAsync(script, options);
+        var result = await client.ScriptInvokeAsync(script, options);
 
         Assert.Equal((string[])[LargeString, LargeString], result.AsStringArray());
     }


### PR DESCRIPTION
## Summary

Rename `InvokeScript` to `ScriptInvoke` for consistency with other `Script*` methods

## Changes

This PR renames the `InvokeScript` method family to `ScriptInvoke` across the codebase to align with the naming convention used by other scripting methods (`ScriptFlush`, `ScriptExists`, `ScriptShow`, etc.).

Files modified:

- `IScriptingAndFunctionBaseCommands.cs`
- `IScriptingAndFunctionClusterCommands.cs`
- `BaseClient.ScriptingCommands.cs`
- `GlideClusterClient.ScriptingCommands.cs`
- `FFI.methods.cs`
- `ScriptingCommandTests.cs`
- `SharedClientTests.cs`

## Test Strategy

✅ Pipeline passes. No additional testing required.

## Further Work

⚪ None

## Related Issues

⚪ None
