### PR TITLE
cleanup: Remove unnecessary ignore expression values with `await`

### DIFF
--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -127,10 +127,10 @@ public static class MainClass
             switch (action)
             {
                 case ChosenAction.GET_EXISTING:
-                    await client.Get(GenerateKeySet());
+                    _ = await client.Get(GenerateKeySet());
                     break;
                 case ChosenAction.GET_NON_EXISTING:
-                    await client.Get(GenerateKeyGet());
+                    _ = await client.Get(GenerateKeyGet());
                     break;
                 case ChosenAction.SET:
                     await client.Set(GenerateKeySet(), data);

--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -127,10 +127,10 @@ public static class MainClass
             switch (action)
             {
                 case ChosenAction.GET_EXISTING:
-                    _ = await client.Get(GenerateKeySet());
+                    await client.Get(GenerateKeySet());
                     break;
                 case ChosenAction.GET_NON_EXISTING:
-                    _ = await client.Get(GenerateKeyGet());
+                    await client.Get(GenerateKeyGet());
                     break;
                 case ChosenAction.SET:
                     await client.Set(GenerateKeySet(), data);

--- a/sources/Valkey.Glide/Abstract/ValkeyServer.cs
+++ b/sources/Valkey.Glide/Abstract/ValkeyServer.cs
@@ -108,19 +108,19 @@ internal class ValkeyServer(Database conn, EndPoint endpoint) : IServer
     public async Task ConfigResetStatisticsAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await _conn.Command(Request.ConfigResetStatisticsAsync(), MakeRoute());
+        await _conn.Command(Request.ConfigResetStatisticsAsync(), MakeRoute());
     }
 
     public async Task ConfigRewriteAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await _conn.Command(Request.ConfigRewriteAsync(), MakeRoute());
+        await _conn.Command(Request.ConfigRewriteAsync(), MakeRoute());
     }
 
     public async Task ConfigSetAsync(ValkeyValue setting, ValkeyValue value, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await _conn.Command(Request.ConfigSetAsync(setting, value), MakeRoute());
+        await _conn.Command(Request.ConfigSetAsync(setting, value), MakeRoute());
     }
 
     public async Task<long> DatabaseSizeAsync(int database = -1, CommandFlags flags = CommandFlags.None)
@@ -132,13 +132,13 @@ internal class ValkeyServer(Database conn, EndPoint endpoint) : IServer
     public async Task FlushAllDatabasesAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await _conn.Command(Request.FlushAllDatabasesAsync(), MakeRoute());
+        await _conn.Command(Request.FlushAllDatabasesAsync(), MakeRoute());
     }
 
     public async Task FlushDatabaseAsync(int database = -1, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await _conn.Command(Request.FlushDatabaseAsync(database), MakeRoute());
+        await _conn.Command(Request.FlushDatabaseAsync(database), MakeRoute());
     }
 
     public async Task<DateTime> LastSaveAsync(CommandFlags flags = CommandFlags.None)
@@ -233,8 +233,6 @@ internal class ValkeyServer(Database conn, EndPoint endpoint) : IServer
     public async Task ScriptFlushAsync(CommandFlags flags = CommandFlags.None)
     {
         Utils.Requires<NotImplementedException>(flags == CommandFlags.None, "Command flags are not supported by GLIDE");
-
-        // Call SCRIPT FLUSH (default is SYNC mode)
-        _ = await _conn.Command(Request.ScriptFlushAsync(), MakeRoute());
+        await _conn.Command(Request.ScriptFlushAsync(), MakeRoute());
     }
 }

--- a/sources/Valkey.Glide/BaseClient.GenericCommands.cs
+++ b/sources/Valkey.Glide/BaseClient.GenericCommands.cs
@@ -101,13 +101,13 @@ public abstract partial class BaseClient : IGenericBaseCommands
     public async Task KeyRestoreAsync(ValkeyKey key, byte[] value, TimeSpan? expiry = null, RestoreOptions? restoreOptions = null, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.KeyRestoreAsync(key, value, expiry, restoreOptions));
+        await Command(Request.KeyRestoreAsync(key, value, expiry, restoreOptions));
     }
 
     public async Task KeyRestoreDateTimeAsync(ValkeyKey key, byte[] value, DateTime? expiry = null, RestoreOptions? restoreOptions = null, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.KeyRestoreDateTimeAsync(key, value, expiry, restoreOptions));
+        await Command(Request.KeyRestoreDateTimeAsync(key, value, expiry, restoreOptions));
     }
 
     public async Task<bool> KeyTouchAsync(ValkeyKey key, CommandFlags flags = CommandFlags.None)

--- a/sources/Valkey.Glide/BaseClient.HashCommands.cs
+++ b/sources/Valkey.Glide/BaseClient.HashCommands.cs
@@ -29,7 +29,7 @@ public abstract partial class BaseClient : IHashCommands
     public async Task HashSetAsync(ValkeyKey key, HashEntry[] hashFields, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.HashSetAsync(key, hashFields));
+        await Command(Request.HashSetAsync(key, hashFields));
     }
 
     public async Task<bool> HashSetAsync(ValkeyKey key, ValkeyValue hashField, ValkeyValue value, When when = When.Always, CommandFlags flags = CommandFlags.None)

--- a/sources/Valkey.Glide/BaseClient.ListCommands.cs
+++ b/sources/Valkey.Glide/BaseClient.ListCommands.cs
@@ -82,7 +82,7 @@ public abstract partial class BaseClient : IListCommands
     public async Task ListTrimAsync(ValkeyKey key, long start, long stop, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ListTrimAsync(key, start, stop));
+        await Command(Request.ListTrimAsync(key, start, stop));
     }
 
     public async Task<ValkeyValue[]> ListRangeAsync(ValkeyKey key, long start = 0, long stop = -1, CommandFlags flags = CommandFlags.None)
@@ -142,7 +142,7 @@ public abstract partial class BaseClient : IListCommands
     public async Task ListSetByIndexAsync(ValkeyKey key, long index, ValkeyValue value, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ListSetByIndexAsync(key, index, value));
+        await Command(Request.ListSetByIndexAsync(key, index, value));
     }
 
     // Blocking list operations (Blocking Commands aren't supported in SER so this is according to our own implementation)

--- a/sources/Valkey.Glide/Commands/IListCommands.cs
+++ b/sources/Valkey.Glide/Commands/IListCommands.cs
@@ -326,7 +326,7 @@ public interface IListCommands
     /// <remarks>
     /// <example>
     /// <code>
-    /// _ = await client.ListTrimAsync(key, start, stop);
+    /// await client.ListTrimAsync(key, start, stop);
     /// </code>
     /// </example>
     /// </remarks>
@@ -519,7 +519,7 @@ public interface IListCommands
     // block the entire multiplexer, preventing other operations from executing.
     // These are GLIDE-only features:
     // - BLMOVE (blocking list move)
-    // - BLMPOP (blocking list multi-pop)  
+    // - BLMPOP (blocking list multi-pop)
     // - BLPOP (blocking left pop)
     // - BRPOP (blocking right pop)
 

--- a/sources/Valkey.Glide/GlideClient.cs
+++ b/sources/Valkey.Glide/GlideClient.cs
@@ -100,19 +100,19 @@ public partial class GlideClient : BaseClient, IGenericCommands, IServerManageme
     public async Task ConfigResetStatisticsAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigResetStatisticsAsync());
+        await Command(Request.ConfigResetStatisticsAsync());
     }
 
     public async Task ConfigRewriteAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigRewriteAsync());
+        await Command(Request.ConfigRewriteAsync());
     }
 
     public async Task ConfigSetAsync(ValkeyValue setting, ValkeyValue value, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigSetAsync(setting, value));
+        await Command(Request.ConfigSetAsync(setting, value));
     }
 
     public async Task<long> DatabaseSizeAsync(int database = -1, CommandFlags flags = CommandFlags.None)
@@ -124,13 +124,13 @@ public partial class GlideClient : BaseClient, IGenericCommands, IServerManageme
     public async Task FlushAllDatabasesAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.FlushAllDatabasesAsync());
+        await Command(Request.FlushAllDatabasesAsync());
     }
 
     public async Task FlushDatabaseAsync(int database = -1, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.FlushDatabaseAsync(database));
+        await Command(Request.FlushDatabaseAsync(database));
     }
 
     public async Task<DateTime> LastSaveAsync(CommandFlags flags = CommandFlags.None)
@@ -205,13 +205,13 @@ public partial class GlideClient : BaseClient, IGenericCommands, IServerManageme
     public async Task WatchAsync(ValkeyKey[] keys, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.Watch(keys));
+        await Command(Request.Watch(keys));
     }
 
     public async Task UnwatchAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.Unwatch());
+        await Command(Request.Unwatch());
     }
 
     protected override async Task<Version> GetServerVersionAsync()

--- a/sources/Valkey.Glide/GlideClusterClient.cs
+++ b/sources/Valkey.Glide/GlideClusterClient.cs
@@ -137,37 +137,37 @@ public sealed partial class GlideClusterClient : BaseClient, IGenericClusterComm
     public async Task ConfigResetStatisticsAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigResetStatisticsAsync(), AllPrimaries);
+        await Command(Request.ConfigResetStatisticsAsync(), AllPrimaries);
     }
 
     public async Task ConfigResetStatisticsAsync(Route route, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigResetStatisticsAsync(), route);
+        await Command(Request.ConfigResetStatisticsAsync(), route);
     }
 
     public async Task ConfigRewriteAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigRewriteAsync(), Route.Random);
+        await Command(Request.ConfigRewriteAsync(), Route.Random);
     }
 
     public async Task ConfigRewriteAsync(Route route, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigRewriteAsync(), route);
+        await Command(Request.ConfigRewriteAsync(), route);
     }
 
     public async Task ConfigSetAsync(ValkeyValue setting, ValkeyValue value, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigSetAsync(setting, value), AllPrimaries);
+        await Command(Request.ConfigSetAsync(setting, value), AllPrimaries);
     }
 
     public async Task ConfigSetAsync(ValkeyValue setting, ValkeyValue value, Route route, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.ConfigSetAsync(setting, value), route);
+        await Command(Request.ConfigSetAsync(setting, value), route);
     }
 
     public async Task<Dictionary<string, long>> DatabaseSizeAsync(int database = -1, CommandFlags flags = CommandFlags.None)
@@ -195,27 +195,27 @@ public sealed partial class GlideClusterClient : BaseClient, IGenericClusterComm
     public async Task FlushAllDatabasesAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.FlushAllDatabasesAsync(), AllPrimaries);
+        await Command(Request.FlushAllDatabasesAsync(), AllPrimaries);
     }
 
     public async Task FlushAllDatabasesAsync(Route route, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.FlushAllDatabasesAsync(), route);
+        await Command(Request.FlushAllDatabasesAsync(), route);
     }
 
     public async Task FlushDatabaseAsync(int database = -1, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
         Utils.Requires<ArgumentException>(database == -1, "Different databases for this command are not supported by GLIDE");
-        _ = await Command(Request.FlushDatabaseAsync(database), AllPrimaries);
+        await Command(Request.FlushDatabaseAsync(database), AllPrimaries);
     }
 
     public async Task FlushDatabaseAsync(Route route, int database = -1, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
         Utils.Requires<ArgumentException>(database == -1, "Different databases for this command are not supported by GLIDE");
-        _ = await Command(Request.FlushDatabaseAsync(database), route);
+        await Command(Request.FlushDatabaseAsync(database), route);
     }
 
     public async Task<Dictionary<string, DateTime>> LastSaveAsync(CommandFlags flags = CommandFlags.None)
@@ -308,19 +308,19 @@ public sealed partial class GlideClusterClient : BaseClient, IGenericClusterComm
     public async Task WatchAsync(ValkeyKey[] keys, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.Watch(keys));
+        await Command(Request.Watch(keys));
     }
 
     public async Task UnwatchAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.Unwatch(), AllPrimaries);
+        await Command(Request.Unwatch(), AllPrimaries);
     }
 
     public async Task UnwatchAsync(Route route, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        _ = await Command(Request.Unwatch(), route);
+        await Command(Request.Unwatch(), route);
     }
 
     protected override async Task<Version> GetServerVersionAsync()

--- a/tests/Valkey.Glide.IntegrationTests/BatchTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/BatchTests.cs
@@ -95,7 +95,7 @@ public class BatchTests(TestConfiguration config)
 
         Assert.True(transaction.Execute());
         Assert.True((await t1).IsNull);
-        _ = await Assert.ThrowsAsync<RequestException>(async () => await t3);
+        await Assert.ThrowsAsync<RequestException>(async () => await t3);
     }
 
     [Theory(DisableDiscoveryEnumeration = true)]
@@ -145,7 +145,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t1);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t1);
         }
 
         Assert.True(c1.WasSatisfied);
@@ -223,7 +223,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -257,7 +257,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -291,7 +291,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -313,7 +313,7 @@ public class BatchTests(TestConfiguration config)
 
         Assert.False(transaction.Execute());
         Assert.False(c.WasSatisfied);
-        _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
     }
 
     [Theory(DisableDiscoveryEnumeration = true)]
@@ -342,7 +342,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -376,7 +376,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -410,7 +410,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -444,7 +444,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -474,7 +474,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -504,7 +504,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -541,7 +541,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -578,7 +578,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -615,7 +615,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -652,7 +652,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -689,7 +689,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -726,7 +726,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -763,7 +763,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -800,7 +800,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -837,7 +837,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -875,7 +875,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -909,7 +909,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -944,7 +944,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -978,7 +978,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 
@@ -1012,7 +1012,7 @@ public class BatchTests(TestConfiguration config)
         }
         else
         {
-            _ = await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await t2);
         }
     }
 #pragma warning restore xUnit1042 // https://xunit.net/xunit.analyzers/rules/xUnit1042

--- a/tests/Valkey.Glide.IntegrationTests/ClusterClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClusterClientTests.cs
@@ -87,9 +87,9 @@ public class ClusterClientTests(TestConfiguration config)
     [MemberData(nameof(Config.TestClusterClients), MemberType = typeof(TestConfiguration))]
     public async Task CustomCommandWithMultiNodeRoute(GlideClusterClient client)
     {
-        _ = await client.StringSetAsync("abc", "abc");
-        _ = await client.StringSetAsync("klm", "klm");
-        _ = await client.StringSetAsync("xyz", "xyz");
+        await client.StringSetAsync("abc", "abc");
+        await client.StringSetAsync("klm", "klm");
+        await client.StringSetAsync("xyz", "xyz");
 
         long res = (long)(await client.CustomCommand(["dbsize"], AllPrimaries)).SingleValue!;
         Assert.True(res >= 3);
@@ -98,7 +98,7 @@ public class ClusterClientTests(TestConfiguration config)
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(Config.TestClusterClients), MemberType = typeof(TestConfiguration))]
     public async Task RetryStrategyIsNotSupportedForTransactions(GlideClusterClient client)
-        => _ = await Assert.ThrowsAsync<RequestException>(async () => _ = await client.Exec(new(true), true, new(retryStrategy: new())));
+        => await Assert.ThrowsAsync<RequestException>(async () => await client.Exec(new(true), true, new(retryStrategy: new())));
 
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(ClusterClientWithAtomic))]

--- a/tests/Valkey.Glide.IntegrationTests/DebugSleepTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/DebugSleepTests.cs
@@ -38,7 +38,7 @@ public class DebugSleepTests
         BaseBatchOptions options = isCluster ? new ClusterBatchOptions(timeout: 100) : new BatchOptions(timeout: 100);
 
         // Expect a timeout exception on short timeout
-        _ = await Assert.ThrowsAsync<TimeoutException>(() => isCluster
+        await Assert.ThrowsAsync<TimeoutException>(() => isCluster
                 ? ((GlideClusterClient)client).Exec((ClusterBatch)batch, true, (ClusterBatchOptions)options)
                 : ((GlideClient)client).Exec((Batch)batch, true, (BatchOptions)options));
 

--- a/tests/Valkey.Glide.IntegrationTests/HashCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/HashCommandTests.cs
@@ -96,7 +96,7 @@ public class HashCommandTests(TestConfiguration config)
     {
         string key = Guid.NewGuid().ToString();
 
-        _ = await client.HashSetAsync(key, "field1", "value1");
+        await client.HashSetAsync(key, "field1", "value1");
 
         Assert.True(await client.HashExistsAsync(key, "field1"));
         Assert.False(await client.HashExistsAsync(key, "nonexistent"));
@@ -127,8 +127,8 @@ public class HashCommandTests(TestConfiguration config)
     {
         string key = Guid.NewGuid().ToString();
 
-        _ = await client.HashSetAsync(key, "field1", "value1");
-        _ = await client.HashSetAsync(key, "field2", "value-with-longer-content");
+        await client.HashSetAsync(key, "field1", "value1");
+        await client.HashSetAsync(key, "field2", "value-with-longer-content");
 
         Assert.Equal(6, await client.HashStringLengthAsync(key, "field1"));
         Assert.Equal(25, await client.HashStringLengthAsync(key, "field2"));

--- a/tests/Valkey.Glide.IntegrationTests/SetCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/SetCommandTests.cs
@@ -74,8 +74,8 @@ public class SetCommandTests(TestConfiguration config)
         Assert.Equal(0, await client.SetIntersectionLengthAsync([key1, key2]));
 
         // Set up test data
-        _ = await client.SetAddAsync(key1, ["a", "b", "c", "d"]);
-        _ = await client.SetAddAsync(key2, ["b", "c", "e", "f"]);
+        await client.SetAddAsync(key1, ["a", "b", "c", "d"]);
+        await client.SetAddAsync(key2, ["b", "c", "e", "f"]);
 
         // Test intersection of two sets
         Assert.Equal(2, await client.SetIntersectionLengthAsync([key1, key2])); // "b", "c"
@@ -119,8 +119,8 @@ public class SetCommandTests(TestConfiguration config)
         string key1 = "{prefix}-" + Guid.NewGuid().ToString();
         string key2 = "{prefix}-" + Guid.NewGuid().ToString();
 
-        _ = await client.SetAddAsync(key1, ["a", "b"]);
-        _ = await client.SetAddAsync(key2, ["b", "c"]);
+        await client.SetAddAsync(key1, ["a", "b"]);
+        await client.SetAddAsync(key2, ["b", "c"]);
 
         ValkeyValue[] result = await client.SetUnionAsync(key1, key2);
         Assert.Equal(3, result.Length); // a, b, c
@@ -133,8 +133,8 @@ public class SetCommandTests(TestConfiguration config)
         string key1 = "{prefix}-" + Guid.NewGuid().ToString();
         string key2 = "{prefix}-" + Guid.NewGuid().ToString();
 
-        _ = await client.SetAddAsync(key1, ["a", "b", "c"]);
-        _ = await client.SetAddAsync(key2, ["b", "c", "d"]);
+        await client.SetAddAsync(key1, ["a", "b", "c"]);
+        await client.SetAddAsync(key2, ["b", "c", "d"]);
 
         ValkeyValue[] result = await client.SetIntersectAsync(key1, key2);
         Assert.Equal(2, result.Length); // b, c
@@ -147,8 +147,8 @@ public class SetCommandTests(TestConfiguration config)
         string key1 = "{prefix}-" + Guid.NewGuid().ToString();
         string key2 = "{prefix}-" + Guid.NewGuid().ToString();
 
-        _ = await client.SetAddAsync(key1, ["a", "b", "c"]);
-        _ = await client.SetAddAsync(key2, ["b", "c", "d"]);
+        await client.SetAddAsync(key1, ["a", "b", "c"]);
+        await client.SetAddAsync(key2, ["b", "c", "d"]);
 
         ValkeyValue[] result = await client.SetDifferenceAsync(key1, key2);
         ValkeyValue singleResult = Assert.Single(result); // a
@@ -163,8 +163,8 @@ public class SetCommandTests(TestConfiguration config)
         string key2 = "{prefix}-" + Guid.NewGuid().ToString();
         string destKey = "{prefix}-" + Guid.NewGuid().ToString();
 
-        _ = await client.SetAddAsync(key1, ["a", "b"]);
-        _ = await client.SetAddAsync(key2, ["b", "c"]);
+        await client.SetAddAsync(key1, ["a", "b"]);
+        await client.SetAddAsync(key2, ["b", "c"]);
 
         long count = await client.SetUnionStoreAsync(destKey, key1, key2);
         Assert.Equal(3, count); // a, b, c
@@ -179,8 +179,8 @@ public class SetCommandTests(TestConfiguration config)
         string key2 = "{prefix}-" + Guid.NewGuid().ToString();
         string destKey = "{prefix}-" + Guid.NewGuid().ToString();
 
-        _ = await client.SetAddAsync(key1, ["a", "b", "c"]);
-        _ = await client.SetAddAsync(key2, ["b", "c", "d"]);
+        await client.SetAddAsync(key1, ["a", "b", "c"]);
+        await client.SetAddAsync(key2, ["b", "c", "d"]);
 
         long count = await client.SetIntersectStoreAsync(destKey, key1, key2);
         Assert.Equal(2, count); // b, c
@@ -195,8 +195,8 @@ public class SetCommandTests(TestConfiguration config)
         string key2 = "{prefix}-" + Guid.NewGuid().ToString();
         string destKey = "{prefix}-" + Guid.NewGuid().ToString();
 
-        _ = await client.SetAddAsync(key1, ["a", "b", "c"]);
-        _ = await client.SetAddAsync(key2, ["b", "c", "d"]);
+        await client.SetAddAsync(key1, ["a", "b", "c"]);
+        await client.SetAddAsync(key2, ["b", "c", "d"]);
 
         long count = await client.SetDifferenceStoreAsync(destKey, key1, key2);
         Assert.Equal(1, count); // a
@@ -268,8 +268,8 @@ public class SetCommandTests(TestConfiguration config)
         Assert.False(await client.SetMoveAsync(sourceKey, destKey, "member1"));
 
         // Set up test data
-        _ = await client.SetAddAsync(sourceKey, ["member1", "member2", "member3"]);
-        _ = await client.SetAddAsync(destKey, ["member4", "member5"]);
+        await client.SetAddAsync(sourceKey, ["member1", "member2", "member3"]);
+        await client.SetAddAsync(destKey, ["member4", "member5"]);
 
         // Test successful move
         Assert.True(await client.SetMoveAsync(sourceKey, destKey, "member1"));
@@ -284,7 +284,7 @@ public class SetCommandTests(TestConfiguration config)
         Assert.False(await client.SetMoveAsync(sourceKey, destKey, "nonexistent"));
 
         // Test move when member already exists in destination
-        _ = await client.SetAddAsync(sourceKey, "member4"); // Add member4 to source
+        await client.SetAddAsync(sourceKey, "member4"); // Add member4 to source
         Assert.True(await client.SetMoveAsync(sourceKey, destKey, "member4")); // Should still return true
         Assert.Equal(2, await client.SetLengthAsync(sourceKey)); // member4 removed from source
         Assert.Equal(3, await client.SetLengthAsync(destKey)); // destination size unchanged (member4 already existed)

--- a/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
@@ -92,8 +92,8 @@ public class StandaloneClientTests(TestConfiguration config)
         );
 
         string key3 = Guid.NewGuid().ToString();
-        _ = await client.CustomCommand(["xadd", key3, "0-1", "str-1-id-1-field-1", "str-1-id-1-value-1", "str-1-id-1-field-2", "str-1-id-1-value-2"]);
-        _ = await client.CustomCommand(["xadd", key3, "0-2", "str-1-id-2-field-1", "str-1-id-2-value-1", "str-1-id-2-field-2", "str-1-id-2-value-2"]);
+        await client.CustomCommand(["xadd", key3, "0-1", "str-1-id-1-field-1", "str-1-id-1-value-1", "str-1-id-1-field-2", "str-1-id-1-value-2"]);
+        await client.CustomCommand(["xadd", key3, "0-2", "str-1-id-2-field-1", "str-1-id-2-value-1", "str-1-id-2-field-2", "str-1-id-2-value-2"]);
         _ = Assert.IsType<Dictionary<gs, object?>>((await client.CustomCommand(["xread", "streams", key3, "stream", "0-1", "0-2"]))!);
         _ = Assert.IsType<Dictionary<gs, object?>>((await client.CustomCommand(["xinfo", "stream", key3, "full"]))!);
     }
@@ -208,7 +208,7 @@ public class StandaloneClientTests(TestConfiguration config)
 
         // Switching to a valid database causes issue to tests running in parallel. So instead, we test
         // that using an invalid value to ensure different values can still be sent through.
-        await Assert.ThrowsAsync<RequestException>(async () => _ = await client.SelectAsync(-1));
+        await Assert.ThrowsAsync<RequestException>(async () => await client.SelectAsync(-1));
     }
 
     [Theory(DisableDiscoveryEnumeration = true)]
@@ -233,7 +233,7 @@ public class StandaloneClientTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
         string key2 = Guid.NewGuid().ToString();
 
-        _ = await client.StringSetAsync(key, "val");
+        await client.StringSetAsync(key, "val");
         Assert.True(await client.KeyCopyAsync(key, key2, 1));
         Assert.True(await client.KeyMoveAsync(key, 2));
     }

--- a/tests/Valkey.Glide.IntegrationTests/StringCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/StringCommandTests.cs
@@ -41,8 +41,8 @@ public class StringCommandTests(TestConfiguration config)
         string value2 = Guid.NewGuid().ToString();
 
         // Set key1 and key2, leave key3 unset
-        _ = await client.StringSetAsync(key1, value1);
-        _ = await client.StringSetAsync(key2, value2);
+        await client.StringSetAsync(key1, value1);
+        await client.StringSetAsync(key2, value2);
 
         ValkeyKey[] keys = [key1, key2, key3];
         ValkeyValue[] values = await client.StringGetAsync(keys);
@@ -152,8 +152,8 @@ public class StringCommandTests(TestConfiguration config)
         string newValue2 = "new2";
 
         // Set initial values
-        _ = await client.StringSetAsync(key1, initialValue1);
-        _ = await client.StringSetAsync(key2, initialValue2);
+        await client.StringSetAsync(key1, initialValue1);
+        await client.StringSetAsync(key2, initialValue2);
 
         // Overwrite with StringSetAsync
         KeyValuePair<ValkeyKey, ValkeyValue>[] values = [
@@ -180,7 +180,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
         string value = "Hello World";
 
-        _ = await client.StringSetAsync(key, value);
+        await client.StringSetAsync(key, value);
         long length = await client.StringLengthAsync(key);
         Assert.Equal(value.Length, length);
     }
@@ -201,7 +201,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
         string value = "Hello World";
 
-        _ = await client.StringSetAsync(key, value);
+        await client.StringSetAsync(key, value);
         ValkeyValue result = await client.StringGetRangeAsync(key, 0, 4);
         Assert.Equal("Hello", result.ToString());
     }
@@ -222,7 +222,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
         string initialValue = "Hello World";
 
-        _ = await client.StringSetAsync(key, initialValue);
+        await client.StringSetAsync(key, initialValue);
         ValkeyValue newLength = await client.StringSetRangeAsync(key, 6, "Valkey");
         Assert.Equal(12, (long)newLength);
 
@@ -251,7 +251,7 @@ public class StringCommandTests(TestConfiguration config)
         string appendValue = " World";
 
         // Set initial value
-        _ = await client.StringSetAsync(key, initialValue);
+        await client.StringSetAsync(key, initialValue);
 
         // Append to the key
         long newLength = await client.StringAppendAsync(key, appendValue);
@@ -291,7 +291,7 @@ public class StringCommandTests(TestConfiguration config)
         string appendValue = "";
 
         // Set initial value
-        _ = await client.StringSetAsync(key, initialValue);
+        await client.StringSetAsync(key, initialValue);
 
         // Append empty string
         long newLength = await client.StringAppendAsync(key, appendValue);
@@ -313,10 +313,10 @@ public class StringCommandTests(TestConfiguration config)
         string appendValue = " 世界";
 
         // Set initial value
-        _ = await client.StringSetAsync(key, initialValue);
+        await client.StringSetAsync(key, initialValue);
 
         // Append Unicode string
-        _ = await client.StringAppendAsync(key, appendValue);
+        await client.StringAppendAsync(key, appendValue);
 
         // Verify the value was appended correctly
         ValkeyValue value = await client.StringGetAsync(key);
@@ -352,7 +352,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10");
+        await client.StringSetAsync(key, "10");
 
         // Decrement by 1
         long result = await client.StringDecrementAsync(key);
@@ -385,7 +385,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10");
+        await client.StringSetAsync(key, "10");
 
         // Decrement by 5
         long result = await client.StringDecrementAsync(key, 5);
@@ -418,7 +418,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10");
+        await client.StringSetAsync(key, "10");
 
         // Decrement by -5 (effectively incrementing by 5)
         long result = await client.StringDecrementAsync(key, -5);
@@ -436,7 +436,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10");
+        await client.StringSetAsync(key, "10");
 
         // Increment by 1
         long result = await client.StringIncrementAsync(key);
@@ -469,7 +469,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10");
+        await client.StringSetAsync(key, "10");
 
         // Increment by 5
         long result = await client.StringIncrementAsync(key, 5);
@@ -502,7 +502,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10");
+        await client.StringSetAsync(key, "10");
 
         // Increment by -5 (effectively decrementing by 5)
         long result = await client.StringIncrementAsync(key, -5);
@@ -520,7 +520,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10.5");
+        await client.StringSetAsync(key, "10.5");
 
         // Increment by 0.5
         double result = await client.StringIncrementAsync(key, 0.5);
@@ -553,7 +553,7 @@ public class StringCommandTests(TestConfiguration config)
         string key = Guid.NewGuid().ToString();
 
         // Set initial value
-        _ = await client.StringSetAsync(key, "10.5");
+        await client.StringSetAsync(key, "10.5");
 
         // Increment by -0.5 (effectively decrementing by 0.5)
         double result = await client.StringIncrementAsync(key, -0.5);
@@ -870,7 +870,7 @@ public class StringCommandTests(TestConfiguration config)
         string key2 = $"{{{baseKey}}}:key2";
 
         // Set up strings with predictable matches based on actual Redis behavior
-        // "abcdef" and "aXcYeF" 
+        // "abcdef" and "aXcYeF"
         // Expected LCS: "ace" (note: 'f' != 'F' due to case sensitivity)
         // Expected matches: "e" at (4,4), "c" at (2,2), "a" at (0,0) - all length 1
         await client.StringSetAsync(key1, "abcdef");
@@ -892,7 +892,7 @@ public class StringCommandTests(TestConfiguration config)
         Assert.Equal(0, sortedMatches[0].SecondStringIndex);
         Assert.Equal(1, sortedMatches[0].Length);
 
-        // Match 2: "c" at position (2,2) with length 1  
+        // Match 2: "c" at position (2,2) with length 1
         Assert.Equal(2, sortedMatches[1].FirstStringIndex);
         Assert.Equal(2, sortedMatches[1].SecondStringIndex);
         Assert.Equal(1, sortedMatches[1].Length);
@@ -915,7 +915,7 @@ public class StringCommandTests(TestConfiguration config)
         string key2 = $"{{{baseKey}}}:key2";
 
         // Set up strings based on actual Redis behavior
-        // "abcdefghijk" and "aXXdefXXijk" 
+        // "abcdefghijk" and "aXXdefXXijk"
         // Expected LCS: "adefijk" with length 7
         // Expected matches: "ijk" at (8,8) length=3, "def" at (3,3) length=3, "a" at (0,0) length=1
         await client.StringSetAsync(key1, "abcdefghijk");
@@ -937,7 +937,7 @@ public class StringCommandTests(TestConfiguration config)
 
         // Validate match counts based on filtering
         Assert.Equal(3, resultAll.Matches.Length); // All matches: "a"(1), "def"(3), "ijk"(3)
-        Assert.Equal(2, resultFiltered.Matches.Length); // Only "def"(3) and "ijk"(3) 
+        Assert.Equal(2, resultFiltered.Matches.Length); // Only "def"(3) and "ijk"(3)
         Assert.Empty(resultHighFilter.Matches); // No matches >= 4
 
         // Validate exact match details for unfiltered result (sorted by position)


### PR DESCRIPTION
## Summary

Minor cleanup. Remove unnecessary ignored expression value when awaiting a method that returns `Task`.

## Changes

Remove unnecessary ignored expression value when awaiting method that returns `Task`:

```csharp
// Before
_ = await Command(Request.FlushDatabaseAsync(database))

// After
await Command(Request.FlushDatabaseAsync(database))
```

When an async method returns `Task` (`Task<void>`), `_ = await` is equivalent to `await`. Simply using `await` (a) is cleaner/more readable, and (b) clearly communicates that the method does not return a value. 

## Test Strategy

✅ Pipeline passes. No other verification needed for trivial cleanup.

## Further Work

⚪ None

## Related Issues

⚪ None
