### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,59 @@
+<!--
+Thanks for contributing to Valkey GLIDE!
+
+Please make sure you are aware of our [contributing guidelines](https://github.com/valkey-io/valkey-glide-csharp/blob/main/CONTRIBUTING.md).
+-->
+
+### Summary
+
+<!--
+Add a summary describing the changes.
+-->
+
+### Issue Link
+
+This pull request is linked to issue: [REPLACE ME]
+
+### Features and Behaviour Changes
+
+<!--
+Outline the feature support and behaviour changes included in this pull request.
+-->
+
+### Implementation
+
+<!--
+Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention.
+-->
+
+### Limitations
+
+<!--
+Describe any features or use cases that are not implemented or are only partially supported.
+-->
+
+### Testing
+
+<!--
+Describe what tests have been conducted and any relevant test results.
+-->
+
+### Related Issues
+
+<!--
+List related issues and pull request such closed pull requests and open issues.
+-->
+
+### Checklist
+
+<!--
+Before submitting the PR make sure the following are checked.
+Not applicable items should be crossed out, not removed.
+-->
+
+- [ ] This Pull Request is related to one issue.
+- [ ] Commit message has a detailed description of what changed and why.
+- [ ] Tests are added or updated and all checks pass.
+- [ ] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
+- [ ] Destination branch is correct - `main` or release
+- [ ] Create merge commit if merging release branch into `main`, squash otherwise.


### PR DESCRIPTION
## Summary

Adds a pull request template to improve their consistency and completeness.

## Changes

Added template at `.github/pull_request_template.md`. 

Content is modelled on the [template](https://github.com/valkey-io/valkey-glide/blob/main/.github/pull_request_template.md) for the primary Valkey GLIDE repository, and includes sections for "Summary", "Issue Link", "Features and Behaviour Changes", "Implementation", "Limitations", "Testing", "Related Issues", and "Checklist".

## Test Strategy

⚪ None required

## Related Issues

- https://github.com/valkey-io/valkey-glide/pull/5171