### PR TITLE
cleanup: rename `WithDataBaseId` to `WithDatabaseId`

### DIFF
--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -708,7 +708,7 @@ public abstract class ConnectionConfiguration
             set => Config.DatabaseId = value;
         }
         /// <inheritdoc cref="DataBaseId" />
-        public T WithDataBaseId(uint dataBaseId)
+        public T WithDatabaseId(uint dataBaseId)
         {
             DataBaseId = dataBaseId;
             return (T)this;

--- a/tests/Valkey.Glide.IntegrationTests/ClusterClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClusterClientTests.cs
@@ -517,7 +517,7 @@ public class ClusterClientTests(TestConfiguration config)
         );
 
         var config = TestConfiguration.DefaultClusterClientConfig()
-            .WithDataBaseId(1)
+            .WithDatabaseId(1)
             .Build();
 
         await using var client = await GlideClusterClient.CreateClient(config);

--- a/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
@@ -55,7 +55,7 @@ public class StandaloneClientTests(TestConfiguration config)
         await using var client2 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithTls(false).Build());
         await using var client3 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithConnectionTimeout(TimeSpan.FromSeconds(2)).Build());
         await using var client4 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithRequestTimeout(TimeSpan.FromSeconds(2)).Build());
-        await using var client5 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithDataBaseId(4).Build());
+        await using var client5 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithDatabaseId(4).Build());
         await using var client6 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithConnectionRetryStrategy(1, 2, 3).Build());
         await using var client7 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithAuthentication("default", "").Build());
         await using var client8 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithProtocolVersion(ConnectionConfiguration.Protocol.RESP2).Build());


### PR DESCRIPTION
### Summary
Renames `WithDataBaseId` to `WithDatabaseId` to follow standard naming conventions.

### Issue Link

⚪ None

### Features and Behaviour Changes

No behaviour changes.


### Implementation

Updated the method name in `ConnectionConfiguration` and updated all call sites.

**Note**: `WithDataBaseId`/`WithDatabaseId` is not needed for [StackExchange.Redis](https://github.com/stackexchange/stackexchange.redis) compatibility. 

### Testing

Existing integration tests cover the renamed method. Build, format, and lint all pass.

Related Issues

⚪ None

### Checklist

- [x] ~This Pull Request is related to one issue.~
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] ~CHANGELOG.md, README.md, DEVELOPER.md, and other documentation files are updated.~
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.