### PR TITLE
cleanup: rename `RetryStrategy` and `ConnectionRetryStrategy` for consistency with other Valkey GLIDE clients.

### DIFF
--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -62,8 +62,8 @@ pub struct ConnectionConfig {
     pub connection_timeout: u32,
     pub has_read_from: bool,
     pub read_from: ReadFrom,
-    pub has_connection_retry_strategy: bool,
-    pub connection_retry_strategy: ConnectionRetryStrategy,
+    pub has_reconnect_strategy: bool,
+    pub reconnect_strategy: ConnectionRetryStrategy,
     pub has_authentication_info: bool,
     pub authentication_info: AuthenticationInfo,
     pub database_id: u32,
@@ -240,8 +240,8 @@ pub(crate) unsafe fn create_connection_request(
             .has_connection_timeout
             .then_some(config.connection_timeout),
         connection_retry_strategy: config
-            .has_connection_retry_strategy
-            .then_some(config.connection_retry_strategy),
+            .has_reconnect_strategy
+            .then_some(config.reconnect_strategy),
         lazy_connect: config.lazy_connect,
         refresh_topology_from_initial_nodes: config.refresh_topology_from_initial_nodes,
         pubsub_subscriptions: Some(unsafe { convert_pubsub_config(&config.pubsub_config) }),
@@ -252,7 +252,8 @@ pub(crate) unsafe fn create_connection_request(
                 config.root_certs_len,
             )
         },
-        pubsub_reconciliation_interval_ms: config.has_pubsub_reconciliation_interval_ms
+        pubsub_reconciliation_interval_ms: config
+            .has_pubsub_reconciliation_interval_ms
             .then_some(config.pubsub_reconciliation_interval_ms),
         read_only: config.read_only,
 

--- a/sources/Valkey.Glide/Abstract/ConfigurationOptions.cs
+++ b/sources/Valkey.Glide/Abstract/ConfigurationOptions.cs
@@ -91,7 +91,7 @@ public sealed class ConfigurationOptions : ICloneable
     #region Private fields
     private bool? _ssl;
     private Proxy? _proxy;
-    private RetryStrategy? _reconnectRetryPolicy;
+    private BackoffStrategy? _reconnectRetryPolicy;
     #endregion
 
     #region Internal fields
@@ -238,7 +238,7 @@ public sealed class ConfigurationOptions : ICloneable
     /// <summary>
     /// The retry policy to be used for connection reconnects.
     /// </summary>
-    public RetryStrategy? ReconnectRetryPolicy
+    public BackoffStrategy? ReconnectRetryPolicy
     {
         get => _reconnectRetryPolicy;
         set => _reconnectRetryPolicy = value;

--- a/sources/Valkey.Glide/Abstract/ConnectionMultiplexer.cs
+++ b/sources/Valkey.Glide/Abstract/ConnectionMultiplexer.cs
@@ -236,7 +236,7 @@ public sealed class ConnectionMultiplexer : IConnectionMultiplexer, IDisposable,
         {
             _ = configuration.DefaultDatabase.HasValue ? standalone.DataBaseId = (uint)configuration.DefaultDatabase.Value : 0;
         }
-        _ = configuration.ReconnectRetryPolicy.HasValue ? config.ConnectionRetryStrategy = configuration.ReconnectRetryPolicy.Value : new();
+        _ = configuration.ReconnectRetryPolicy.HasValue ? config.ReconnectStrategy = configuration.ReconnectRetryPolicy.Value : new();
         _ = configuration.ReadFrom.HasValue ? config.ReadFrom = configuration.ReadFrom.Value : new();
 
         return config;

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -25,7 +25,7 @@ public abstract class ConnectionConfiguration
         public TimeSpan? RequestTimeout;
         public TimeSpan? ConnectionTimeout;
         public ReadFrom? ReadFrom;
-        public RetryStrategy? RetryStrategy;
+        public BackoffStrategy? ReconnectStrategy;
         public AuthenticationInfo? AuthenticationInfo;
         public uint DatabaseId;
         public Protocol? Protocol;
@@ -45,7 +45,7 @@ public abstract class ConnectionConfiguration
                 (uint?)RequestTimeout?.TotalMilliseconds,
                 (uint?)ConnectionTimeout?.TotalMilliseconds,
                 ReadFrom,
-                RetryStrategy,
+                ReconnectStrategy,
                 AuthenticationInfo,
                 DatabaseId,
                 Protocol,
@@ -72,7 +72,7 @@ public abstract class ConnectionConfiguration
     /// <param name="exponentBase"><inheritdoc cref="ExponentBase" path="/summary" /></param>
     /// <param name="jitterPercent"><inheritdoc cref="JitterPercent" path="/summary" /></param>
     [StructLayout(LayoutKind.Sequential)]
-    public struct RetryStrategy(uint numberOfRetries, uint factor, uint exponentBase, uint? jitterPercent = null)
+    public struct BackoffStrategy(uint numberOfRetries, uint factor, uint exponentBase, uint? jitterPercent = null)
     {
         /// <summary>
         /// Number of retry attempts that the client should perform when disconnected from the server,
@@ -202,7 +202,7 @@ public abstract class ConnectionConfiguration
     /// <summary>
     /// Configuration for a standalone client. <br />
     /// Use <see cref="StandaloneClientConfigurationBuilder" /> or
-    /// <see cref="StandaloneClientConfiguration(List{ValueTuple{string?, ushort?}}, bool?, TimeSpan?, TimeSpan?, ReadFrom?, RetryStrategy?, string?, string?, uint?, Protocol?, string?, bool)" /> to create an instance.
+    /// <see cref="StandaloneClientConfiguration(List{ValueTuple{string?, ushort?}}, bool?, TimeSpan?, TimeSpan?, ReadFrom?, BackoffStrategy?, string?, string?, uint?, Protocol?, string?, bool)" /> to create an instance.
     /// </summary>
     public sealed class StandaloneClientConfiguration : BaseClientConfiguration
     {
@@ -216,7 +216,7 @@ public abstract class ConnectionConfiguration
         /// <param name="requestTimeout"><inheritdoc cref="ClientConfigurationBuilder{T}.RequestTimeout" path="/summary" /></param>
         /// <param name="connectionTimeout"><inheritdoc cref="ClientConfigurationBuilder{T}.ConnectionTimeout" path="/summary" /></param>
         /// <param name="readFrom"><inheritdoc cref="ClientConfigurationBuilder{T}.ReadFrom" path="/summary" /></param>
-        /// <param name="retryStrategy"><inheritdoc cref="ClientConfigurationBuilder{T}.ConnectionRetryStrategy" path="/summary" /></param>
+        /// <param name="retryStrategy"><inheritdoc cref="ClientConfigurationBuilder{T}.ReconnectStrategy" path="/summary" /></param>
         /// <param name="username">The username for authentication.</param>
         /// <param name="password">The password for authentication.</param>
         /// <param name="databaseId"><inheritdoc cref="ClientConfigurationBuilder{T}.DataBaseId" path="/summary" /></param>
@@ -229,7 +229,7 @@ public abstract class ConnectionConfiguration
             TimeSpan? requestTimeout = null,
             TimeSpan? connectionTimeout = null,
             ReadFrom? readFrom = null,
-            RetryStrategy? retryStrategy = null,
+            BackoffStrategy? retryStrategy = null,
             string? username = null,
             string? password = null,
             uint? databaseId = null,
@@ -244,7 +244,7 @@ public abstract class ConnectionConfiguration
             _ = requestTimeout.HasValue ? builder.RequestTimeout = requestTimeout.Value : new();
             _ = connectionTimeout.HasValue ? builder.ConnectionTimeout = connectionTimeout.Value : new();
             _ = readFrom.HasValue ? builder.ReadFrom = readFrom.Value : new();
-            _ = retryStrategy.HasValue ? builder.ConnectionRetryStrategy = retryStrategy.Value : new();
+            _ = retryStrategy.HasValue ? builder.ReconnectStrategy = retryStrategy.Value : new();
             _ = (username ?? password) is not null ? builder.WithAuthentication(username, password!) : new();
             _ = databaseId.HasValue ? builder.DataBaseId = databaseId.Value : new();
             _ = protocol.HasValue ? builder.ProtocolVersion = protocol.Value : new();
@@ -269,7 +269,7 @@ public abstract class ConnectionConfiguration
         /// <param name="requestTimeout"><inheritdoc cref="ClientConfigurationBuilder{T}.RequestTimeout" path="/summary" /></param>
         /// <param name="connectionTimeout"><inheritdoc cref="ClientConfigurationBuilder{T}.ConnectionTimeout" path="/summary" /></param>
         /// <param name="readFrom"><inheritdoc cref="ClientConfigurationBuilder{T}.ReadFrom" path="/summary" /></param>
-        /// <param name="retryStrategy"><inheritdoc cref="ClientConfigurationBuilder{T}.ConnectionRetryStrategy" path="/summary" /></param>
+        /// <param name="retryStrategy"><inheritdoc cref="ClientConfigurationBuilder{T}.ReconnectStrategy" path="/summary" /></param>
         /// <param name="username">The username for authentication.</param>
         /// <param name="password">The password for authentication.</param>
         /// <param name="databaseId"><inheritdoc cref="ClientConfigurationBuilder{T}.DataBaseId" path="/summary" /></param>
@@ -282,7 +282,7 @@ public abstract class ConnectionConfiguration
             TimeSpan? requestTimeout = null,
             TimeSpan? connectionTimeout = null,
             ReadFrom? readFrom = null,
-            RetryStrategy? retryStrategy = null,
+            BackoffStrategy? retryStrategy = null,
             string? username = null,
             string? password = null,
             uint? databaseId = null,
@@ -297,7 +297,7 @@ public abstract class ConnectionConfiguration
             _ = requestTimeout.HasValue ? builder.RequestTimeout = requestTimeout.Value : new();
             _ = connectionTimeout.HasValue ? builder.ConnectionTimeout = connectionTimeout.Value : new();
             _ = readFrom.HasValue ? builder.ReadFrom = readFrom.Value : new();
-            _ = retryStrategy.HasValue ? builder.ConnectionRetryStrategy = retryStrategy.Value : new();
+            _ = retryStrategy.HasValue ? builder.ReconnectStrategy = retryStrategy.Value : new();
             _ = (username ?? password) is not null ? builder.WithAuthentication(username, password!) : new();
             _ = databaseId.HasValue ? builder.DataBaseId = databaseId.Value : new();
             _ = protocol.HasValue ? builder.ProtocolVersion = protocol.Value : new();
@@ -707,28 +707,28 @@ public abstract class ConnectionConfiguration
         }
 
         #endregion
-        #region Connection Retry Strategy
+        #region Reconnect Strategy
 
         /// <summary>
         /// Strategy used to determine how and when to reconnect, in case of connection failures.<br />
-        /// See also <seealso cref="RetryStrategy" />
+        /// See also <seealso cref="BackoffStrategy" />
         /// </summary>
-        public RetryStrategy ConnectionRetryStrategy
+        public BackoffStrategy ReconnectStrategy
         {
-            set => Config.RetryStrategy = value;
+            set => Config.ReconnectStrategy = value;
         }
 
-        /// <inheritdoc cref="ConnectionRetryStrategy" />
-        public T WithConnectionRetryStrategy(RetryStrategy connectionRetryStrategy)
+        /// <inheritdoc cref="ReconnectStrategy" />
+        public T WithReconnectStrategy(BackoffStrategy connectionRetryStrategy)
         {
-            ConnectionRetryStrategy = connectionRetryStrategy;
+            ReconnectStrategy = connectionRetryStrategy;
             return (T)this;
         }
 
-        /// <inheritdoc cref="ConnectionRetryStrategy" />
-        /// <inheritdoc cref="RetryStrategy(uint, uint, uint, uint?)" />
-        public T WithConnectionRetryStrategy(uint numberOfRetries, uint factor, uint exponentBase, uint? jitterPercent = null)
-            => WithConnectionRetryStrategy(new RetryStrategy(numberOfRetries, factor, exponentBase, jitterPercent));
+        /// <inheritdoc cref="ReconnectStrategy" />
+        /// <inheritdoc cref="BackoffStrategy(uint, uint, uint, uint?)" />
+        public T WithReconnectStrategy(uint numberOfRetries, uint factor, uint exponentBase, uint? jitterPercent = null)
+            => WithReconnectStrategy(new BackoffStrategy(numberOfRetries, factor, exponentBase, jitterPercent));
 
         #endregion
         #region DataBase ID

--- a/sources/Valkey.Glide/GlideClient.cs
+++ b/sources/Valkey.Glide/GlideClient.cs
@@ -34,7 +34,7 @@ public partial class GlideClient : BaseClient, IGenericCommands, IServerManageme
     ///     <b>TLS</b>: If <see cref="ClientConfigurationBuilder{T}.UseTls" /> is set to <see langword="true" />, the client will establish a secure connection using <c>TLS</c>.
     ///   </item>
     ///   <item>
-    ///     <b>Reconnection Strategy</b>: The <see cref="RetryStrategy" /> settings define how the client will attempt to reconnect in case of disconnections.
+    ///     <b>Reconnection Strategy</b>: The <see cref="BackoffStrategy" /> settings define how the client will attempt to reconnect in case of disconnections.
     ///   </item>
     /// </list>
     /// <example>
@@ -48,7 +48,7 @@ public partial class GlideClient : BaseClient, IGenericCommands, IServerManageme
     ///     .WithDataBaseId(1)
     ///     .WithAuthentication("user1", "passwordA")
     ///     .WithTls()
-    ///     .WithConnectionRetryStrategy(5, 100, 2)
+    ///     .WithReconnectStrategy(5, 100, 2)
     ///     .Build();
     /// await using GlideClient client = await GlideClient.CreateClient(config);
     /// </code>

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -207,7 +207,7 @@ internal partial class FFI
             uint? requestTimeout,
             uint? connectionTimeout,
             ReadFrom? readFrom,
-            RetryStrategy? retryStrategy,
+            BackoffStrategy? reconnectStrategy,
             AuthenticationInfo? authenticationInfo,
             uint databaseId,
             ConnectionConfiguration.Protocol? protocol,
@@ -232,8 +232,8 @@ internal partial class FFI
                 ConnectionTimeout = connectionTimeout ?? default,
                 HasReadFrom = readFrom.HasValue,
                 ReadFrom = readFrom ?? default,
-                HasConnectionRetryStrategy = retryStrategy.HasValue,
-                ConnectionRetryStrategy = retryStrategy ?? default,
+                HasReconnectStrategy = reconnectStrategy.HasValue,
+                ReconnectStrategy = reconnectStrategy ?? default,
                 HasAuthenticationInfo = authenticationInfo.HasValue,
                 AuthenticationInfo = authenticationInfo ?? default,
                 DatabaseId = databaseId,
@@ -1091,8 +1091,8 @@ internal partial class FFI
         public ReadFrom ReadFrom;
 
         [MarshalAs(UnmanagedType.U1)]
-        public bool HasConnectionRetryStrategy;
-        public RetryStrategy ConnectionRetryStrategy;
+        public bool HasReconnectStrategy;
+        public BackoffStrategy ReconnectStrategy;
 
         [MarshalAs(UnmanagedType.U1)]
         public bool HasAuthenticationInfo;

--- a/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
@@ -56,7 +56,7 @@ public class StandaloneClientTests(TestConfiguration config)
         await using var client3 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithConnectionTimeout(TimeSpan.FromSeconds(2)).Build());
         await using var client4 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithRequestTimeout(TimeSpan.FromSeconds(2)).Build());
         await using var client5 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithDatabaseId(4).Build());
-        await using var client6 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithConnectionRetryStrategy(1, 2, 3).Build());
+        await using var client6 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithReconnectStrategy(1, 2, 3).Build());
         await using var client7 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithAuthentication("default", "").Build());
         await using var client8 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithProtocolVersion(ConnectionConfiguration.Protocol.RESP2).Build());
         await using var client9 = await GlideClient.CreateClient(TestConfiguration.DefaultClientConfig().WithReadFrom(new ConnectionConfiguration.ReadFrom(ConnectionConfiguration.ReadFromStrategy.Primary)).Build());

--- a/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
@@ -528,19 +528,19 @@ public class ConnectionConfigurationTests
     #region Connection Retry Strategy Tests
 
     [Fact]
-    public void WithConnectionRetryStrategy_Standalone_NotSpecified()
+    public void WithReconnectStrategy_Standalone_NotSpecified()
     {
         var config = new StandaloneClientConfigurationBuilder().Build();
-        Assert.Null(config.Request.RetryStrategy);
+        Assert.Null(config.Request.ReconnectStrategy);
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Standalone_RetryStrategy_NoJitter()
+    public void WithReconnectStrategy_Standalone_BackoffStrategy_NoJitter()
     {
         var builder = new StandaloneClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(new RetryStrategy(NumberOfRetries, Factor, ExponentBase));
+            .WithReconnectStrategy(new BackoffStrategy(NumberOfRetries, Factor, ExponentBase));
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);
@@ -548,12 +548,12 @@ public class ConnectionConfigurationTests
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Standalone_RetryStrategy_WithJitter()
+    public void WithReconnectStrategy_Standalone_BackoffStrategy_WithJitter()
     {
         var builder = new StandaloneClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(new RetryStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent));
+            .WithReconnectStrategy(new BackoffStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent));
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);
@@ -561,12 +561,12 @@ public class ConnectionConfigurationTests
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Standalone_UintParams_NoJitter()
+    public void WithReconnectStrategy_Standalone_UintParams_NoJitter()
     {
         var builder = new StandaloneClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(NumberOfRetries, Factor, ExponentBase);
+            .WithReconnectStrategy(NumberOfRetries, Factor, ExponentBase);
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);
@@ -574,12 +574,12 @@ public class ConnectionConfigurationTests
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Standalone_UintParams_WithJitter()
+    public void WithReconnectStrategy_Standalone_UintParams_WithJitter()
     {
         var builder = new StandaloneClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent);
+            .WithReconnectStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent);
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);
@@ -587,19 +587,19 @@ public class ConnectionConfigurationTests
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Cluster_NotSpecified()
+    public void WithReconnectStrategy_Cluster_NotSpecified()
     {
         var config = new ClusterClientConfigurationBuilder().Build();
-        Assert.Null(config.Request.RetryStrategy);
+        Assert.Null(config.Request.ReconnectStrategy);
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Cluster_RetryStrategy_NoJitter()
+    public void WithReconnectStrategy_Cluster_BackoffStrategy_NoJitter()
     {
         var builder = new ClusterClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(new RetryStrategy(NumberOfRetries, Factor, ExponentBase));
+            .WithReconnectStrategy(new BackoffStrategy(NumberOfRetries, Factor, ExponentBase));
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);
@@ -607,12 +607,12 @@ public class ConnectionConfigurationTests
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Cluster_RetryStrategy_WithJitter()
+    public void WithReconnectStrategy_Cluster_BackoffStrategy_WithJitter()
     {
         var builder = new ClusterClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(new RetryStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent));
+            .WithReconnectStrategy(new BackoffStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent));
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);
@@ -620,12 +620,12 @@ public class ConnectionConfigurationTests
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Cluster_UintParams_NoJitter()
+    public void WithReconnectStrategy_Cluster_UintParams_NoJitter()
     {
         var builder = new ClusterClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(NumberOfRetries, Factor, ExponentBase);
+            .WithReconnectStrategy(NumberOfRetries, Factor, ExponentBase);
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);
@@ -633,12 +633,12 @@ public class ConnectionConfigurationTests
     }
 
     [Fact]
-    public void WithConnectionRetryStrategy_Cluster_UintParams_WithJitter()
+    public void WithReconnectStrategy_Cluster_UintParams_WithJitter()
     {
         var builder = new ClusterClientConfigurationBuilder()
-            .WithConnectionRetryStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent);
+            .WithReconnectStrategy(NumberOfRetries, Factor, ExponentBase, JitterPercent);
 
-        var strategy = builder.Build().Request.RetryStrategy!.Value;
+        var strategy = builder.Build().Request.ReconnectStrategy!.Value;
         Assert.Equal(NumberOfRetries, strategy.NumberOfRetries);
         Assert.Equal(Factor, strategy.Factor);
         Assert.Equal(ExponentBase, strategy.ExponentBase);


### PR DESCRIPTION
### Summary

Rename the connection retry strategy APIs across the C# client to align with the other Valkey GLIDE clients:

- From "retry strategy" to "backoff strategy"
- From "connection retry strategy" to "reconnect strategy".

### Cross-Client Naming Comparison

| Client | Backoff Type Name | Config Field / Method |
| --- | --- | --- |
| Java | `BackoffStrategy` | `reconnectStrategy` |
| Python | `BackoffStrategy` | `reconnect_strategy` |
| Go | `BackoffStrategy` | `WithReconnectStrategy()` |
| Node.js | `BackoffStrategy` | `connectionBackoff` |
| PHP | `BackoffStrategy` | ⚪️ N/A |
| C# (before) | `RetryStrategy` | `ConnectionRetryStrategy` / `WithConnectionRetryStrategy()` |
| C# (after) | `BackoffStrategy` | `ReconnectStrategy` / `WithReconnectStrategy()` |

### Issue Link

⚪️ None

### Features and Behaviour Changes

No functional or behavioural changes. This is a pure rename/refactoring:

| Layer | Old Name | New Name |
| --- | --- | --- |
| C# struct type | `RetryStrategy` | `BackoffStrategy` |
| C# builder property | `ConnectionRetryStrategy` | `ReconnectStrategy` |
| C# builder methods | `WithConnectionRetryStrategy(...)` | `WithReconnectStrategy(...)` |
| C# internal record field | `ConnectionConfig.RetryStrategy` | `ConnectionConfig.ReconnectStrategy` |
| C# FFI struct field | `HasConnectionRetryStrategy` | `HasReconnectStrategy` |
| C# FFI struct field | `ConnectionRetryStrategy` | `ReconnectStrategy` |
| C# FFI constructor param | `retryStrategy` | `reconnectStrategy` |
| Rust FFI struct fields | `has_connection_retry_strategy` | `has_reconnect_strategy` |
| Rust FFI struct fields | `connection_retry_strategy` | `reconnect_strategy` |

The property `ReconnectRetryPolicy` is intentionally unchanged to preserve [StackExchange.Redis](https://github.com/stackexchange/stackexchange.redis) API compatibility. The glide-core mapping target (`connection_retry_strategy`) is also unchanged.

### Implementation

- Performed renames described above.
- Updated XML doc comments, code examples, and region names.
- Updated unit test method names to reflect the new naming.

### Limitations

⚪️ None

### Testing

⚪️ No new tests needed.

### Related Issues

⚪️ None

### Checklist

- [x] ~This Pull Request is related to one issue.~
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] ~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~
z- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
