### PR TITLE
Add logging for insecure TLS client creation

### DIFF
--- a/sources/Valkey.Glide/BaseClient.cs
+++ b/sources/Valkey.Glide/BaseClient.cs
@@ -157,6 +157,16 @@ public abstract partial class BaseClient : IDisposable, IAsyncDisposable
         nint pubsubCallbackPointer = Marshal.GetFunctionPointerForDelegate(client._pubsubCallbackDelegate);
 
         using FFI.ConnectionConfig request = config.Request.ToFfi();
+
+        // Log warnining if using insecure TLS.
+        if (config.Request.TlsMode == TlsMode.InsecureTls)
+        {
+            var msg = "SECURITY WARNING: Insecure TLS connection established. "
+                + "Certificate verification is disabled. "
+                + "This is strongly discouraged in production environments.";
+            Logger.Log(Level.Warn, typeof(T).Name, msg);
+        }
+
         Message message = client.MessageContainer.GetMessageForCall();
         CreateClientFfi(request.ToPtr(), successCallbackPointer, failureCallbackPointer, pubsubCallbackPointer);
         client.ClientPointer = await message; // This will throw an error thru failure callback if any


### PR DESCRIPTION
### Summary

Add a security warning log when a client is created with insecure TLS (`TlsMode.InsecureTls`).

This is in addition to the existing warning when a configuration is set to use insecure TLS:

- #227

### Issue Link

- #226

### Features and Behaviour Changes

When `TlsMode.InsecureTls` is configured, a `Warn`-level log message is now emitted during client creation in `BaseClient.CreateClient<T>`:

> SECURITY WARNING: Insecure TLS connection established. Certificate verification is disabled. This is strongly discouraged in production environments.

### Implementation

Updated `BaseClient.CreateClient<T>`.

### Limitations

⚪️ None

### Testing

✅ All existing tests pass.

### Related Issues

⚪️ None

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~Tests are added or updated and all checks pass.~
- [x] ~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.