### PR TITLE
feat: Use valkey-bundle docker images for modules related test (9.0+)

### DIFF
--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -78,9 +78,8 @@ runs:
           with:
               target: ${{ inputs.target }}
 
-        # Always build from source first. This provides valkey-server and
-        # valkey-cli on the host for TLS tests (cluster_manager.py), benchmarks,
-        # and — on the Docker path — the CLI needed to form the cluster.
+        # Always build from source first. This installs 'valkey-cli', which is
+        # needed by 'start-valkey-docker' to start servers in Docker.
         - name: Install server from source
           if: "${{ inputs.server-version }}"
           uses: ./.github/workflows/install-server

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -78,13 +78,27 @@ runs:
           with:
               target: ${{ inputs.target }}
 
-        - name: Install server
+        # Always build from source first. This provides valkey-server and
+        # valkey-cli on the host for TLS tests (cluster_manager.py), benchmarks,
+        # and — on the Docker path — the CLI needed to form the cluster.
+        - name: Install server from source
           if: "${{ inputs.server-version }}"
           uses: ./.github/workflows/install-server
           with:
               os: ${{ inputs.os }}
               target: ${{ inputs.target }}
               server-version: ${{ inputs.server-version }}
+
+        # For valkey 9.0 on ubuntu, also start Docker containers with the
+        # valkey-bundle image (includes modules: Search, JSON, Bloom, LDAP) on
+        # dedicated ports. Regular tests use the source-built server; module
+        # tests connect to these Docker containers via modules-standalone-endpoint
+        # and modules-cluster-endpoints env vars.
+        - name: Start module servers via Docker (valkey 9.0, ubuntu)
+          if: "${{ inputs.server-version == '9.0' && inputs.os == 'ubuntu' }}"
+          uses: ./.github/workflows/start-valkey-docker
+          with:
+              engine-version: ${{ inputs.server-version }}
 
         - name: Install zig
           if: ${{ contains(inputs.target, 'linux-gnu') }}

--- a/.github/workflows/start-valkey-docker/action.yml
+++ b/.github/workflows/start-valkey-docker/action.yml
@@ -1,0 +1,135 @@
+name: Start Valkey Servers via Docker
+description: >
+    Start standalone and cluster Valkey servers with modules (Search, JSON,
+    Bloom, LDAP) using Docker containers on dedicated ports. These run
+    alongside the source-built servers (on default ports) used by regular
+    tests. Module-specific tests read the env vars written here to connect.
+    Assumes valkey-cli is already on the host (installed by install-server).
+
+inputs:
+    engine-version:
+        description: >
+            Valkey engine version (e.g. 9.0, 8.1). The Docker image is
+            pinned to 9.1-rc1 regardless - see the TODO in the image step.
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Determine Docker image
+          id: docker-image
+          shell: bash
+          env:
+              ENGINE_VERSION: ${{ inputs.engine-version }}
+          run: |
+              # TEMPORARY: Pin to 9.1-rc1 until stable per-version valkey-bundle tags exist.
+              # TODO: switch to valkey/valkey-bundle:${ENGINE_VERSION} once stable tags are published.
+              IMAGE="valkey/valkey-bundle:9.1-rc1"
+              echo "image=$IMAGE" >> $GITHUB_OUTPUT
+              echo "Using Docker image: $IMAGE"
+
+        - name: Pull Docker image
+          shell: bash
+          env:
+              IMAGE: ${{ steps.docker-image.outputs.image }}
+          run: |
+              echo "Pulling $IMAGE..."
+              docker pull "$IMAGE"
+
+        - name: Start standalone Valkey server with modules (Docker)
+          shell: bash
+          env:
+              IMAGE: ${{ steps.docker-image.outputs.image }}
+          run: |
+              echo "=== Starting standalone Valkey server with modules on port 6389 ==="
+
+              docker run -d --name valkey-modules-standalone --network host \
+                "$IMAGE" valkey-server \
+                --port 6389 \
+                --enable-debug-command yes \
+                --protected-mode no \
+                --save ""
+
+              # Wait for ready
+              READY=false
+              for i in $(seq 1 30); do
+                if valkey-cli -p 6389 PING 2>/dev/null | grep -q PONG; then
+                  echo "Standalone server with modules ready on port 6389"
+                  READY=true
+                  break
+                fi
+                sleep 0.5
+              done
+
+              if [ "$READY" != "true" ]; then
+                echo "ERROR: Standalone module server on port 6389 failed to start"
+                docker logs valkey-modules-standalone 2>&1 || true
+                exit 1
+              fi
+
+              echo "modules-standalone-endpoint=127.0.0.1:6389" >> $GITHUB_ENV
+
+        - name: Start Valkey cluster with modules (Docker)
+          shell: bash
+          env:
+              IMAGE: ${{ steps.docker-image.outputs.image }}
+              ENGINE_VERSION: ${{ inputs.engine-version }}
+          run: |
+              echo "=== Starting Valkey cluster with modules on ports 8001-8006 ==="
+
+              MAJOR=$(echo "$ENGINE_VERSION" | cut -d. -f1)
+              EXTRA_ARGS=""
+              if [ "$MAJOR" -ge 9 ]; then
+                EXTRA_ARGS="--cluster-databases 16"
+              fi
+
+              for port in 8001 8002 8003 8004 8005 8006; do
+                docker run -d --name "valkey-modules-cluster-${port}" --network host \
+                  "$IMAGE" valkey-server \
+                  --port "$port" \
+                  --cluster-enabled yes \
+                  --cluster-config-file "nodes-${port}.conf" \
+                  --cluster-node-timeout 5000 \
+                  --appendonly no \
+                  --protected-mode no \
+                  --enable-debug-command yes \
+                  --save "" \
+                  $EXTRA_ARGS
+              done
+
+              # Wait for all nodes
+              for port in 8001 8002 8003 8004 8005 8006; do
+                READY=false
+                for i in $(seq 1 30); do
+                  if valkey-cli -p $port PING 2>/dev/null | grep -q PONG; then
+                    echo "  Cluster node $port: ready"
+                    READY=true
+                    break
+                  fi
+                  sleep 0.5
+                done
+                if [ "$READY" != "true" ]; then
+                  echo "ERROR: Cluster module node on port $port failed to start"
+                  docker logs "valkey-modules-cluster-${port}" 2>&1 || true
+                  exit 1
+                fi
+              done
+
+              # Form the cluster (3 primaries, 3 replicas)
+              valkey-cli --cluster create \
+                127.0.0.1:8001 127.0.0.1:8002 127.0.0.1:8003 \
+                127.0.0.1:8004 127.0.0.1:8005 127.0.0.1:8006 \
+                --cluster-replicas 1 \
+                --cluster-yes
+
+              echo "modules-cluster-endpoints=127.0.0.1:8001,127.0.0.1:8002,127.0.0.1:8003,127.0.0.1:8004,127.0.0.1:8005,127.0.0.1:8006" >> $GITHUB_ENV
+              echo "Cluster with modules ready on ports 8001-8006"
+
+        - name: Verify module servers
+          shell: bash
+          run: |
+              echo "=== Module server verification ==="
+              echo "Standalone with modules (6389): $(valkey-cli -p 6389 PING)"
+              for port in 8001 8002 8003 8004 8005 8006; do
+                echo "Cluster with modules node $port: $(valkey-cli -p $port PING)"
+              done

--- a/.github/workflows/start-valkey-docker/action.yml
+++ b/.github/workflows/start-valkey-docker/action.yml
@@ -6,6 +6,9 @@ description: >
     tests. Module-specific tests read the env vars written here to connect.
     Assumes valkey-cli is already on the host (installed by install-server).
 
+    NOTE: This action requires Linux. It uses --network host (not supported
+    on macOS/Windows Docker) and assumes a Linux-based CI runner.
+
 inputs:
     engine-version:
         description: >
@@ -23,7 +26,7 @@ runs:
               ENGINE_VERSION: ${{ inputs.engine-version }}
           run: |
               # TEMPORARY: Pin to 9.1-rc1 until stable per-version valkey-bundle tags exist.
-              # TODO: switch to valkey/valkey-bundle:${ENGINE_VERSION} once stable tags are published.
+              # TODO #346: switch to valkey/valkey-bundle:${ENGINE_VERSION} once stable tags are published.
               IMAGE="valkey/valkey-bundle:9.1-rc1"
               echo "image=$IMAGE" >> $GITHUB_OUTPUT
               echo "Using Docker image: $IMAGE"
@@ -40,12 +43,13 @@ runs:
           shell: bash
           env:
               IMAGE: ${{ steps.docker-image.outputs.image }}
+              MODULES_STANDALONE_PORT: "6389"
           run: |
-              echo "=== Starting standalone Valkey server with modules on port 6389 ==="
+              echo "=== Starting standalone Valkey server with modules on port $MODULES_STANDALONE_PORT ==="
 
               docker run -d --name valkey-modules-standalone --network host \
                 "$IMAGE" valkey-server \
-                --port 6389 \
+                --port "$MODULES_STANDALONE_PORT" \
                 --enable-debug-command yes \
                 --protected-mode no \
                 --save ""
@@ -53,8 +57,8 @@ runs:
               # Wait for ready
               READY=false
               for i in $(seq 1 30); do
-                if valkey-cli -p 6389 PING 2>/dev/null | grep -q PONG; then
-                  echo "Standalone server with modules ready on port 6389"
+                if valkey-cli -p "$MODULES_STANDALONE_PORT" PING 2>/dev/null | grep -q PONG; then
+                  echo "Standalone server with modules ready on port $MODULES_STANDALONE_PORT"
                   READY=true
                   break
                 fi
@@ -62,28 +66,29 @@ runs:
               done
 
               if [ "$READY" != "true" ]; then
-                echo "ERROR: Standalone module server on port 6389 failed to start"
+                echo "ERROR: Standalone module server on port $MODULES_STANDALONE_PORT failed to start"
                 docker logs valkey-modules-standalone 2>&1 || true
                 exit 1
               fi
 
-              echo "modules-standalone-endpoint=127.0.0.1:6389" >> $GITHUB_ENV
+              echo "modules-standalone-endpoint=127.0.0.1:${MODULES_STANDALONE_PORT}" >> $GITHUB_ENV
 
         - name: Start Valkey cluster with modules (Docker)
           shell: bash
           env:
               IMAGE: ${{ steps.docker-image.outputs.image }}
               ENGINE_VERSION: ${{ inputs.engine-version }}
+              MODULES_CLUSTER_PORTS: "8001 8002 8003 8004 8005 8006"
           run: |
-              echo "=== Starting Valkey cluster with modules on ports 8001-8006 ==="
+              echo "=== Starting Valkey cluster with modules on ports $MODULES_CLUSTER_PORTS ==="
 
               MAJOR=$(echo "$ENGINE_VERSION" | cut -d. -f1)
-              EXTRA_ARGS=""
+              EXTRA_ARGS=()
               if [ "$MAJOR" -ge 9 ]; then
-                EXTRA_ARGS="--cluster-databases 16"
+                EXTRA_ARGS+=(--cluster-databases 16)
               fi
 
-              for port in 8001 8002 8003 8004 8005 8006; do
+              for port in $MODULES_CLUSTER_PORTS; do
                 docker run -d --name "valkey-modules-cluster-${port}" --network host \
                   "$IMAGE" valkey-server \
                   --port "$port" \
@@ -94,14 +99,14 @@ runs:
                   --protected-mode no \
                   --enable-debug-command yes \
                   --save "" \
-                  $EXTRA_ARGS
+                  "${EXTRA_ARGS[@]}"
               done
 
               # Wait for all nodes
-              for port in 8001 8002 8003 8004 8005 8006; do
+              for port in $MODULES_CLUSTER_PORTS; do
                 READY=false
                 for i in $(seq 1 30); do
-                  if valkey-cli -p $port PING 2>/dev/null | grep -q PONG; then
+                  if valkey-cli -p "$port" PING 2>/dev/null | grep -q PONG; then
                     echo "  Cluster node $port: ready"
                     READY=true
                     break
@@ -115,21 +120,23 @@ runs:
                 fi
               done
 
+              # Build comma-separated endpoint list for env var
+              ENDPOINTS=""
+              for port in $MODULES_CLUSTER_PORTS; do
+                [ -n "$ENDPOINTS" ] && ENDPOINTS="${ENDPOINTS},"
+                ENDPOINTS="${ENDPOINTS}127.0.0.1:${port}"
+              done
+
+              # Build node list for cluster create
+              NODES=""
+              for port in $MODULES_CLUSTER_PORTS; do
+                NODES="${NODES} 127.0.0.1:${port}"
+              done
+
               # Form the cluster (3 primaries, 3 replicas)
-              valkey-cli --cluster create \
-                127.0.0.1:8001 127.0.0.1:8002 127.0.0.1:8003 \
-                127.0.0.1:8004 127.0.0.1:8005 127.0.0.1:8006 \
+              valkey-cli --cluster create $NODES \
                 --cluster-replicas 1 \
                 --cluster-yes
 
-              echo "modules-cluster-endpoints=127.0.0.1:8001,127.0.0.1:8002,127.0.0.1:8003,127.0.0.1:8004,127.0.0.1:8005,127.0.0.1:8006" >> $GITHUB_ENV
-              echo "Cluster with modules ready on ports 8001-8006"
-
-        - name: Verify module servers
-          shell: bash
-          run: |
-              echo "=== Module server verification ==="
-              echo "Standalone with modules (6389): $(valkey-cli -p 6389 PING)"
-              for port in 8001 8002 8003 8004 8005 8006; do
-                echo "Cluster with modules node $port: $(valkey-cli -p $port PING)"
-              done
+              echo "modules-cluster-endpoints=${ENDPOINTS}" >> $GITHUB_ENV
+              echo "Cluster with modules ready on ports $MODULES_CLUSTER_PORTS"


### PR DESCRIPTION
### Summary

Add Docker-based valkey-bundle servers on dedicated ports for module tests (Search, JSON, Bloom, LDAP). Regular tests still run against the source-built server.

On the 9.0 / ubuntu matrix, CI now builds from source (like every other combo) AND pulls the `valkey/valkey-bundle` Docker image. The source-built server handles all existing tests. The Docker containers run on separate ports (standalone: 6389, cluster: 8001-8006) with modules loaded, and export `modules-standalone-endpoint` / `modules-cluster-endpoints` env vars for module-specific tests to pick up.

We tried routing everything through Docker first, but the bundle image is pinned to `9.1-rc1` (no stable 9.0 tag yet) and that caused consistent standalone timeouts. Separate ports and separate servers to handle module-related tests should be sufficient and better.

### Issue link

Closes #245

### What changed

- New composite action `.github/workflows/start-valkey-docker/action.yml`. Pulls `valkey/valkey-bundle:9.1-rc1`, starts standalone (port 6389) and cluster (ports 8001-8006) containers with `--network host`, forms the cluster, writes endpoint env vars. Uses the source-built `valkey-cli` already on the host, so no binary extraction needed.
- `install-shared-dependencies` now always builds from source first. For 9.0 on ubuntu it also runs the Docker action afterward.

### Limitations

- `9.1-rc1` pin means module tests hit a pre-release server . TODO in the action to swap once stable tags exist.
- Only 9.0 on ubuntu gets module servers, other combos skip module tests due to limitations with Docker.
- Nothing reads the `modules-*` env vars yet. #225.

### Testing

Ran the 9.0 / ubuntu matrix three times. Regular tests pass on the source-built server. Docker containers start and respond to PING. TLS tests work via `cluster_manager.py` + source-built `valkey-server`. Confirmed ports 6389 and 8001-8006 don't collide with anything in the test suite or `cluster_manager.py`'s random port range.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [ ] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
