### PR TITLE
Add missing blank lines between member declarations

### DIFF
--- a/sources/Valkey.Glide/BaseClient.cs
+++ b/sources/Valkey.Glide/BaseClient.cs
@@ -591,8 +591,10 @@ public abstract partial class BaseClient : IDisposable, IAsyncDisposable
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate void SuccessAction(ulong index, IntPtr ptr);
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate void FailureAction(ulong index, IntPtr strPtr, RequestErrorType err);
+
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate void PubSubAction(
         uint pushKind,

--- a/sources/Valkey.Glide/Commands/Constants/Constants.cs
+++ b/sources/Valkey.Glide/Commands/Constants/Constants.cs
@@ -95,6 +95,7 @@ public static class Constants
     public const string ByKeyword = "BY";
     public const string GetKeyword = "GET";
     public const string StoreKeyword = "STORE";
+
     /// <summary>
     /// Keyword for hash field expiration commands.
     /// </summary>

--- a/sources/Valkey.Glide/Commands/IGenericBaseCommands.cs
+++ b/sources/Valkey.Glide/Commands/IGenericBaseCommands.cs
@@ -539,6 +539,7 @@ public interface IGenericBaseCommands
     /// </example>
     /// </remarks>
     Task<bool> KeyCopyAsync(ValkeyKey sourceKey, ValkeyKey destinationKey, int destinationDatabase, bool replace = false, CommandFlags flags = CommandFlags.None);
+
     /// <summary>
     /// Returns a random key from the database.
     /// </summary>

--- a/sources/Valkey.Glide/Commands/IServerManagementClusterCommands.cs
+++ b/sources/Valkey.Glide/Commands/IServerManagementClusterCommands.cs
@@ -551,6 +551,7 @@ public interface IServerManagementClusterCommands
     /// </example>
     /// </remarks>
     Task<ClusterValue<string>> LolwutAsync(Route route, CommandFlags flags = CommandFlags.None);
+
     /// <summary>
     /// Changes the currently selected database.
     /// </summary>

--- a/sources/Valkey.Glide/Commands/Options/BitFieldOptions.cs
+++ b/sources/Valkey.Glide/Commands/Options/BitFieldOptions.cs
@@ -102,10 +102,12 @@ public static class BitFieldOptions
         /// Wrap around on overflow (modulo arithmetic).
         /// </summary>
         Wrap,
+
         /// <summary>
         /// Saturate at min/max values on overflow.
         /// </summary>
         Sat,
+
         /// <summary>
         /// Return null on overflow.
         /// </summary>

--- a/sources/Valkey.Glide/Commands/Options/InfoOptions.cs
+++ b/sources/Valkey.Glide/Commands/Options/InfoOptions.cs
@@ -13,66 +13,82 @@ public class InfoOptions
         /// SERVER: General information about the server.
         /// </summary>
         SERVER,
+
         /// <summary>
         /// CLIENTS: Client connections section.
         /// </summary>
         CLIENTS,
+
         /// <summary>
         /// MEMORY: Memory consumption related information.
         /// </summary>
         MEMORY,
+
         /// <summary>
         /// PERSISTENCE: RDB and AOF related information.
         /// </summary>
         PERSISTENCE,
+
         /// <summary>
         /// STATS: General statistics.
         /// </summary>
         STATS,
+
         /// <summary>
         /// REPLICATION: Master/replica replication information.
         /// </summary>
         REPLICATION,
+
         /// <summary>
         /// CPU: CPU consumption statistics.
         /// </summary>
         CPU,
+
         /// <summary>
         /// COMMANDSTATS: Valkey command statistics.
         /// </summary>
         COMMANDSTATS,
+
         /// <summary>
         /// LATENCYSTATS: Valkey command latency percentile distribution statistics.
         /// </summary>
         LATENCYSTATS,
+
         /// <summary>
         /// SENTINEL: Valkey Sentinel section (only applicable to Sentinel instances).
         /// </summary>
         SENTINEL,
+
         /// <summary>
         /// CLUSTER: Valkey Cluster section.
         /// </summary>
         CLUSTER,
+
         /// <summary>
         /// MODULES: Modules section.
         /// </summary>
         MODULES,
+
         /// <summary>
         /// KEYSPACE: Database related statistics.
         /// </summary>
         KEYSPACE,
+
         /// <summary>
         /// ERRORSTATS: Valkey error statistics.
         /// </summary>
         ERRORSTATS,
+
         /// <summary>
         /// ALL: Return all sections (excluding module generated ones).
         /// </summary>
         ALL,
+
         /// <summary>
         /// DEFAULT: Return only the default set of sections.
         /// </summary>
         DEFAULT,
+
         /// <summary>
         /// EVERYTHING: Includes all and modules.
         /// </summary>

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -80,16 +80,20 @@ public abstract class ConnectionConfiguration
         /// time between retries will remain constant until a reconnect attempt is successful.
         /// </summary>
         public uint NumberOfRetries = numberOfRetries;
+
         /// <summary>
         /// The multiplier that will be applied to the waiting time between each retry.
         /// </summary>
         public uint Factor = factor;
+
         /// <summary>
         /// The exponent base configured for the strategy.
         /// </summary>
         public uint ExponentBase = exponentBase;
+
         [MarshalAs(UnmanagedType.U1)]
         internal bool HasJitterPercent = jitterPercent is not null;
+
         /// <summary>
         /// The Jitter precent configured for the strategy.
         /// </summary>

--- a/sources/Valkey.Glide/GlideString.cs
+++ b/sources/Valkey.Glide/GlideString.cs
@@ -176,6 +176,7 @@ public sealed class GlideString : IComparable<GlideString>
 
     /// <inheritdoc cref="GlideString(byte[])" />
     public static GlideString Of(byte[] bytes) => new(bytes);
+
     /// <inheritdoc cref="GlideString(string)" />
     public static GlideString Of(string @string) => new(@string);
 
@@ -184,6 +185,7 @@ public sealed class GlideString : IComparable<GlideString>
     /// </summary>
     /// <returns>A <see langword="byte[]" /> of that <see cref="GlideString" />.</returns>
     public ReadOnlySpan<byte> GetBytes() => Bytes;
+
     /// <summary>
     /// Get a length of a <see langword="byte[]" /> stored in this <see cref="GlideString" />.
     /// </summary>
@@ -256,11 +258,13 @@ public sealed class GlideString : IComparable<GlideString>
 
     /// <inheritdoc cref="GetString()" />
     public static implicit operator string?(GlideString? gs) => gs?.ToString();
+
     /// <inheritdoc cref="GetBytes()" />
     public static implicit operator byte[]?(GlideString? gs) => gs?.Bytes;
 
     /// <inheritdoc cref="GlideString(string)" />
     public static implicit operator GlideString(string @string) => new(@string);
+
     /// <inheritdoc cref="GlideString(byte[])" />
     public static implicit operator GlideString(byte[] bytes) => new(bytes);
 

--- a/sources/Valkey.Glide/Internals/Cmd.cs
+++ b/sources/Valkey.Glide/Internals/Cmd.cs
@@ -13,6 +13,7 @@ internal interface ICmd
     /// Convert to an FFI-ready struct.
     /// </summary>
     Cmd ToFfi();
+
     /// <summary>
     /// Get untyped converted (used for batch).
     /// </summary>

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -587,6 +587,7 @@ internal partial class FFI
     {
         public nuint CmdCount;
         public IntPtr Cmds;
+
         [MarshalAs(UnmanagedType.U1)]
         public bool IsAtomic;
     }
@@ -596,8 +597,10 @@ internal partial class FFI
     {
         [MarshalAs(UnmanagedType.U1)]
         public bool RetryServerError;
+
         [MarshalAs(UnmanagedType.U1)]
         public bool RetryConnectionError;
+
         [MarshalAs(UnmanagedType.U1)]
         public bool HasTimeout;
         public uint Timeout;
@@ -609,6 +612,7 @@ internal partial class FFI
     {
         /// Invalid request type
         InvalidRequest = 0,
+
         /// An unknown command, where all arguments are defined by the user.
         CustomCommand = 1,
 
@@ -1057,9 +1061,11 @@ internal partial class FFI
     {
         public RouteType Type;
         public int SlotId;
+
         [MarshalAs(UnmanagedType.LPStr)]
         public string? SlotKey;
         public SlotType SlotType;
+
         [MarshalAs(UnmanagedType.LPStr)]
         public string? Host;
         public int Port;
@@ -1272,26 +1278,37 @@ internal partial class FFI
     {
         /// <summary>Disconnection notification sent from the library when connection is closed.</summary>
         PushDisconnection = 0,
+
         /// <summary>Other/unknown push notification type.</summary>
         PushOther = 1,
+
         /// <summary>Cache invalidation notification received when a key is changed/deleted.</summary>
         PushInvalidate = 2,
+
         /// <summary>Regular channel message received via SUBSCRIBE.</summary>
         PushMessage = 3,
+
         /// <summary>Pattern-based message received via PSUBSCRIBE.</summary>
         PushPMessage = 4,
+
         /// <summary>Sharded channel message received via SSUBSCRIBE.</summary>
         PushSMessage = 5,
+
         /// <summary>Unsubscribe confirmation.</summary>
         PushUnsubscribe = 6,
+
         /// <summary>Pattern unsubscribe confirmation.</summary>
         PushPUnsubscribe = 7,
+
         /// <summary>Sharded unsubscribe confirmation.</summary>
         PushSUnsubscribe = 8,
+
         /// <summary>Subscribe confirmation.</summary>
         PushSubscribe = 9,
+
         /// <summary>Pattern subscribe confirmation.</summary>
         PushPSubscribe = 10,
+
         /// <summary>Sharded subscribe confirmation.</summary>
         PushSSubscribe = 11,
     }

--- a/sources/Valkey.Glide/Pipeline/BaseBatch.GenericCommands.cs
+++ b/sources/Valkey.Glide/Pipeline/BaseBatch.GenericCommands.cs
@@ -94,6 +94,7 @@ public abstract partial class BaseBatch<T>
 
     /// <inheritdoc cref="IBatchGenericCommands.KeyCopy(ValkeyKey, ValkeyKey, int, bool)" />
     public T KeyCopy(ValkeyKey sourceKey, ValkeyKey destinationKey, int destinationDatabase, bool replace = false) => AddCmd(KeyCopyAsync(sourceKey, destinationKey, destinationDatabase, replace));
+
     /// <inheritdoc cref="IBatchGenericCommands.KeyRandom()" />
     public T KeyRandom() => AddCmd(KeyRandomAsync());
 

--- a/sources/Valkey.Glide/Pipeline/IBatchGenericCommands.cs
+++ b/sources/Valkey.Glide/Pipeline/IBatchGenericCommands.cs
@@ -118,6 +118,7 @@ internal interface IBatchGenericCommands
     /// <inheritdoc cref="IGenericBaseCommands.KeyCopyAsync(ValkeyKey, ValkeyKey, int, bool, CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
     /// <returns>Command Response - <inheritdoc cref="IGenericBaseCommands.KeyCopyAsync(ValkeyKey, ValkeyKey, int, bool, CommandFlags)" /></returns>
     IBatch KeyCopy(ValkeyKey sourceKey, ValkeyKey destinationKey, int destinationDatabase, bool replace = false);
+
     /// <inheritdoc cref="IGenericBaseCommands.KeyRandomAsync(CommandFlags)" path="/*[not(self::remarks) and not(self::returns)]" />
     /// <returns>Command Response - <inheritdoc cref="IGenericBaseCommands.KeyRandomAsync(CommandFlags)" /></returns>
     IBatch KeyRandom();

--- a/sources/Valkey.Glide/Route.cs
+++ b/sources/Valkey.Glide/Route.cs
@@ -52,8 +52,10 @@ public abstract class Route
 
     /// <inheritdoc cref="RandomRoute"/>
     public static readonly RandomRoute Random = new();
+
     /// <inheritdoc cref="AllNodesRoute"/>
     public static readonly AllNodesRoute AllNodes = new();
+
     /// <inheritdoc cref="AllPrimariesRoute"/>
     public static readonly AllPrimariesRoute AllPrimaries = new();
 

--- a/sources/Valkey.Glide/abstract_APITypes/ValkeyValue.cs
+++ b/sources/Valkey.Glide/abstract_APITypes/ValkeyValue.cs
@@ -47,6 +47,7 @@ public readonly struct ValkeyValue : IEquatable<ValkeyValue>, IComparable<Valkey
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1085:Use auto-implemented property.", Justification = "Intentional field ref")]
     internal object? DirectObject => _objectOrSentinel;
+
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Roslynator", "RCS1085:Use auto-implemented property.", Justification = "Intentional field ref")]
     internal long DirectOverlappedBits64 => _overlappedBits64;
 

--- a/tests/Valkey.Glide.IntegrationTests/StreamCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/StreamCommandTests.cs
@@ -13,6 +13,7 @@ public class StreamCommandTests
         Assert.False(messageId.IsNull);
         Assert.Contains("-", messageId.ToString());
     }
+
     [Theory(DisableDiscoveryEnumeration = true)]
     [MemberData(nameof(TestConfiguration.TestClients), MemberType = typeof(TestConfiguration))]
     public async Task StreamAddAsync_SingleFieldValue(BaseClient client)


### PR DESCRIPTION
### Summary

Add missing blank lines between consecutive member declarations that each have their own XML doc comments (`/// <summary>`) or attributes (e.g., `[MarshalAs]`, `[Fact]`). This is a whitespace-only change to improve readability and consistency across the codebase — no functional changes.

### Issue Link

:white_check_mark: None — this is a standalone style cleanup.

### Features and Behaviour Changes

:white_check_mark: None — whitespace-only changes with no impact on functionality or public API.

### Implementation

Every `.cs` file in the repository was reviewed for instances where consecutive member declarations (fields, properties, methods, enum values, delegates) with doc comments or attributes were missing a separating blank line. Blank lines were added where missing to match the predominant style used throughout the codebase.

16 files were fixed across `sources/` and `tests/`:

- Struct fields: `ConnectionConfiguration.cs`, `FFI.structs.cs`, `ValkeyValue.cs`
- Delegate declarations: `BaseClient.cs`
- Interface members: `Cmd.cs`, `IGenericBaseCommands.cs`, `IBatchGenericCommands.cs`, `IServerManagementClusterCommands.cs`
- Operator/method members: `GlideString.cs`
- Batch methods: `BaseBatch.GenericCommands.cs`
- Static fields: `Route.cs`
- Constants: `Constants.cs`
- Enum values: `InfoOptions.cs`, `BitFieldOptions.cs`
- Test methods: `StreamCommandTests.cs`

### Limitations

:white_check_mark: None.

### Testing

No new tests required — this is a whitespace-only change. Build, lint, and format checks all pass:

- `dotnet build --framework net8.0` — 0 warnings, 0 errors
- `dotnet build --configuration Lint --framework net8.0` — 0 warnings, 0 errors
- `dotnet format --verify-no-changes` — clean

### Related Issues

:white_check_mark: None.

### Checklist

- ~~[ ] This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- ~~[ ] Tests are added or updated and all checks pass.~~
- ~~[ ] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.