### PR TITLE
fix(abstract): Add missing IBitmapCommands, IGeospatialCommands, and IStreamCommands to IDatabaseAsync

### DIFF
--- a/sources/Valkey.Glide/Abstract/IDatabaseAsync.cs
+++ b/sources/Valkey.Glide/Abstract/IDatabaseAsync.cs
@@ -9,7 +9,21 @@ namespace Valkey.Glide;
 /// See also <see cref="GlideClient" /> and <see cref="GlideClusterClient" />.
 /// </summary>
 // TODO #263: Move GLIDE-only command interfaces out of IDatabaseAsync inheritance.
-public partial interface IDatabaseAsync : IConnectionManagementCommands, IGenericCommands, IGenericBaseCommands, IHashCommands, IHyperLogLogCommands, IListCommands, IScriptingAndFunctionBaseCommands, IServerManagementCommands, ISetCommands, ISortedSetCommands, IStringCommands
+public partial interface IDatabaseAsync :
+    IBitmapCommands,
+    IConnectionManagementCommands,
+    IGenericCommands,
+    IGenericBaseCommands,
+    IGeospatialCommands,
+    IHashCommands,
+    IHyperLogLogCommands,
+    IListCommands,
+    IScriptingAndFunctionBaseCommands,
+    IServerManagementCommands,
+    ISetCommands,
+    ISortedSetCommands,
+    IStreamCommands,
+    IStringCommands
 {
     /// <summary>
     /// Execute an arbitrary command against the server; this is primarily intended for executing modules,


### PR DESCRIPTION
### Summary

Add missing `IBitmapCommands`, `IGeospatialCommands`, and `IStreamCommands` to the `IDatabaseAsync` inheritance list. Without these, callers programming against `IDatabaseAsync` or `IDatabase` could not access the no-flags overloads from these interfaces.

### Issue Link

:white_circle: None — discovered during API surface review.

### Features and Behaviour Changes

- `IDatabaseAsync` now inherits from `IBitmapCommands`, `IGeospatialCommands`, and `IStreamCommands`, matching the pattern already established by all other command interfaces (`IHashCommands`, `IListCommands`, `ISetCommands`, etc.).
- Callers using `IDatabaseAsync` or `IDatabase` can now call the simpler no-flags overloads for bitmap, geospatial, and stream commands (e.g., `StringGetBitAsync(key, offset)` instead of being forced to use `StringGetBitAsync(key, offset, CommandFlags.None)`).

### Implementation

- Single-line change to the `IDatabaseAsync` interface declaration in `sources/Valkey.Glide/Abstract/IDatabaseAsync.cs`. The inheritance list was also reformatted to one interface per line for readability.
- No new code, no behavioral changes — the concrete `Database` class already implemented all three interfaces through its `BaseClient` inheritance chain. This change only affects the interface contract visible to callers.

### Limitations

:white_circle: None.

### Testing

No new tests required. Build and lint both pass. The concrete implementation is unchanged — only the interface declaration was updated.

### Related Issues

- TODO #263 (referenced in `IDatabaseAsync.cs`) tracks broader cleanup of the GLIDE-only command interface inheritance.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.