### PR TITLE
fix: memory leaks for commands and pubsub

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -703,7 +703,10 @@ pub unsafe extern "C-unwind" fn batch(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn free_response(ptr: *mut ResponseValue) {
     unsafe {
-        Box::leak(Box::from_raw(ptr)).free_memory();
+        // Take ownership of ptr in the Box.
+        let boxed = Box::from_raw(ptr);
+        boxed.free_memory(); // This releases the contents of ResponseValue, but not the memory used by ResponseValue itself. This must be done explicitly.
+        // boxed is dropped here, releasing the memory used directly by ResponseValue itself.
     }
 }
 
@@ -861,12 +864,12 @@ pub unsafe extern "C" fn free_script_hash_buffer(buffer: *mut ScriptHashBuffer) 
 /// # Returns
 ///
 /// A null pointer on success, or a pointer to a C string error message on failure.
-/// The caller is responsible for freeing the error message using `free_drop_script_error`.
+/// The caller is responsible for freeing the error message using `free_string`.
 ///
 /// # Safety
 ///
 /// * `hash` must be a valid pointer to a UTF-8 string.
-/// * The returned error pointer (if not null) must be freed using `free_drop_script_error`.
+/// * The returned error pointer (if not null) must be freed using `free_string`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn drop_script(hash: *mut u8, len: usize) -> *mut c_char {
     if hash.is_null() {

--- a/sources/Valkey.Glide/Abstract/ConnectionMultiplexer.cs
+++ b/sources/Valkey.Glide/Abstract/ConnectionMultiplexer.cs
@@ -178,6 +178,7 @@ public sealed class ConnectionMultiplexer : IConnectionMultiplexer, IDisposable,
     public void Dispose()
     {
         GC.SuppressFinalize(this);
+        RemoveAllSubscriptions();
         lock (_lock)
         {
             if (_db is null)

--- a/sources/Valkey.Glide/Client/BaseClient.cs
+++ b/sources/Valkey.Glide/Client/BaseClient.cs
@@ -430,45 +430,6 @@ public abstract partial class BaseClient : IBaseClient
             _ => false
         };
 
-    private static PubSubMessage MarshalPubSubMessage(
-        PushKind pushKind,
-        IntPtr messagePtr,
-        ulong messageLen,
-        IntPtr channelPtr,
-        ulong channelLen,
-        IntPtr patternPtr,
-        ulong patternLen)
-    {
-        // Marshal the raw byte pointers to byte arrays
-        byte[] messageBytes = new byte[messageLen];
-        Marshal.Copy(messagePtr, messageBytes, 0, (int)messageLen);
-
-        byte[] channelBytes = new byte[channelLen];
-        Marshal.Copy(channelPtr, channelBytes, 0, (int)channelLen);
-
-        byte[]? patternBytes = null;
-        if (patternPtr != IntPtr.Zero && patternLen > 0)
-        {
-            patternBytes = new byte[patternLen];
-            Marshal.Copy(patternPtr, patternBytes, 0, (int)patternLen);
-        }
-
-        // Convert to strings (assuming UTF-8 encoding)
-        string message = System.Text.Encoding.UTF8.GetString(messageBytes);
-        string channel = System.Text.Encoding.UTF8.GetString(channelBytes);
-        string? pattern = patternBytes != null ? System.Text.Encoding.UTF8.GetString(patternBytes) : null;
-
-        // Create the appropriate PubSubMessage based on whether pattern is present
-        if (pushKind == PushKind.PushMessage)
-            return PubSubMessage.FromChannel(message, channel);
-        else if (pushKind == PushKind.PushPMessage)
-            return PubSubMessage.FromPattern(message, channel, pattern!);
-        else if (pushKind == PushKind.PushSMessage)
-            return PubSubMessage.FromShardedChannel(message, channel);
-        else
-            throw new ArgumentOutOfRangeException(nameof(pushKind), $"Unsupported PushKind: {pushKind}");
-    }
-
     /// <summary>
     /// Closes the connection to the client.
     /// </summary>

--- a/sources/Valkey.Glide/Internals/FFI.methods.cs
+++ b/sources/Valkey.Glide/Internals/FFI.methods.cs
@@ -145,9 +145,6 @@ internal partial class FFI
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_script_hash_buffer")]
     public static extern void FreeScriptHashBuffer(IntPtr hashBuffer);
 
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_drop_script_error")]
-    public static extern void FreeDropScriptError(IntPtr errorBuffer);
-
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "script_invoke")]
     public static extern void ScriptInvokeFfi(
         IntPtr client,


### PR DESCRIPTION
### Summary

Fix native memory leak in free_response, fix managed memory leak from undisposed PubSub subscriptions in ConnectionMultiplexer, and clean up dead/duplicate code in the FFI layer.

### Issue Link

This pull request is linked to issue: #298 

### Features and Behaviour Changes

No feature or API changes. These are internal fixes to memory management.

### Implementation

* Fix critical native memory leak in free_response. Box::leak(Box::from_raw(ptr)).free_memory() reclaimed the heap-allocated ResponseValue via Box::from_raw, but immediately leaked it again with Box::leak. While free_memory() correctly freed nested contents (strings, arrays, maps), the top-level ResponseValue Box (~24 bytes) was never
deallocated. This leaked on every single command response. Fixed by letting the Box drop naturally after free_memory() completes. free_memory(&self) only reads Copy-type fields (typ, val, size) to
reconstruct and drop inner allocations, so it's safe to drop the Box after the call returns.

* Fix managed memory leak in ConnectionMultiplexer.Dispose(). Dispose() was not calling RemoveAllSubscriptions(), leaving Subscription objects alive in the _subscriptions dictionary. Each Subscription holds delegate references (_handlers) and ChannelMessageQueue objects, which keep handler targets rooted. Added RemoveAllSubscriptions() before _db.Dispose() so subscriptions are cleaned up while the underlying client is still alive. The call is placed outside _lock since RemoveAllSubscriptions() has its own internal lock on _subscriptions.

* Remove duplicate MarshalPubSubMessage from BaseClient and unused FreeDropScriptError method declaration.


### Limitations

N/A

### Testing

Long-running test to confirm the memory leaks are solved.

### Related Issues

#298 

### Checklist

- [ x] This Pull Request is related to one issue.
- [ x] Commit message has a detailed description of what changed and why.
- [ x] Tests are added or updated and all checks pass.
- [ x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [ x] Destination branch is correct - `main` or release
- [ x] Create merge commit if merging release branch into `main`, squash otherwise.
