### PR TITLE
CD: Fix 2 minor issues in the CD workflow

### DIFF
--- a/.github/json_matrices/os-matrix.json
+++ b/.github/json_matrices/os-matrix.json
@@ -35,7 +35,7 @@
     {
         "OS": "macos",
         "NAMED_OS": "darwin",
-        "RUNNER": "macos-13",
+        "RUNNER": "macos-15-intel",
         "ARCH": "x64",
         "TARGET": "x86_64-apple-darwin",
         "tags": ["ci", "cd"]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -261,6 +261,8 @@ jobs:
                   git diff
 
             - name: Install server
+              # WSL2 is not available on windows-11-arm runners (no Hyper-V), so we cannot run Valkey server there.
+              if: ${{ !(matrix.host.OS == 'windows' && matrix.host.ARCH == 'arm64') }}
               uses: ./.github/workflows/install-server
               with:
                   os: ${{ matrix.host.OS }}
@@ -268,6 +270,8 @@ jobs:
                   server-version: 8.1
 
             - name: Run command tests
+              # WSL2 is not available on windows-11-arm runners (no Hyper-V), so we cannot run Valkey server there.
+              if: ${{ !(matrix.host.OS == 'windows' && matrix.host.ARCH == 'arm64') }}
               working-directory: tests/Valkey.Glide.IntegrationTests
               run: dotnet test --framework net8.0 --logger "console;verbosity=detailed" --logger "html;LogFileName=TestReport.html" --results-directory . --filter "FullyQualifiedName~CommandTests"
 

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -65,8 +65,9 @@ runs:
         # In Windows runners, the Valkey servers run within WSL.
         # These can be accessed via the WSL bash shell.
         # See <https://github.com/Vampire/setup-wsl> for more details.
+        # WSL2 is not available on windows-11-arm runners (no Hyper-V), so skip for aarch64.
         - name: Install software dependencies for Windows
-          if: "${{ inputs.os == 'windows' }}"
+          if: "${{ inputs.os == 'windows' && !contains(inputs.target, 'aarch64') }}"
           uses: Vampire/setup-wsl@v7
           with:
               distribution: Ubuntu-22.04

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -67,7 +67,7 @@ runs:
         # See <https://github.com/Vampire/setup-wsl> for more details.
         - name: Install software dependencies for Windows
           if: "${{ inputs.os == 'windows' }}"
-          uses: Vampire/setup-wsl@v6
+          uses: Vampire/setup-wsl@v7
           with:
               distribution: Ubuntu-22.04
               additional-packages: python3 build-essential git pkg-config libssl-dev


### PR DESCRIPTION
### Summary

Fix three issues preventing the CD workflow from running:
1. The macOS x64 runner `macos-13` has been deprecated by GitHub Actions — updated to `macos-15-intel`.
2. The `Vampire/setup-wsl` action at v6 is no longer compatible — updated to v7.
3. WSL2 cannot run on `windows-11-arm` GitHub-hosted runners (no Hyper-V / nested virtualization support) — skip WSL installation and server-dependent steps for ARM Windows.

### Issue Link

N/A — Fixes CD workflow failures caused by deprecated GitHub Actions runners, outdated actions, and unsupported WSL on ARM Windows.

### Features and Behaviour Changes

No feature or behaviour changes. This is a CI/CD infrastructure fix only. The Windows ARM native binary (`libglide_rs.dll`) is still built and included in the NuGet package; only the post-publish integration test is skipped for that platform.

### Implementation

- **`.github/json_matrices/os-matrix.json`**: Changed the macOS x64 runner from `macos-13` to `macos-15-intel`, aligning with the existing macOS arm64 entry which already uses `macos-15`.
- **`.github/workflows/install-shared-dependencies/action.yml`**:
  - Bumped `Vampire/setup-wsl` from `v6` to `v7`.
  - Added condition to skip the WSL installation step when target is `aarch64` (ARM Windows), since WSL2 requires Hyper-V which is not available on `windows-11-arm` runners.
- **`.github/workflows/cd.yml`**: Added conditions to skip `Install server` and `Run command tests` steps for Windows ARM (`matrix.host.OS == 'windows' && matrix.host.ARCH == 'arm64'`), since the Valkey server can only run under WSL on Windows.

### Limitations

- The Windows ARM binary is not integration-tested in the CD pipeline. This will remain the case until either GitHub enables nested virtualization on `windows-11-arm` runners or Valkey supports running natively on Windows. We might explore other options to test Valkey-GLIDE on Windows without involving WSL in the future.

### Testing

- CD workflow should now complete successfully on all platforms.
- Windows ARM: binary build succeeds; server install and integration tests are skipped.
- Windows x64, Linux, macOS: fully built and tested (unchanged behavior).

### Related Issues

None.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- ~~Tests are added or updated and all checks pass.~~ (No test changes — CI/CD config only)
- ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~ (Not applicable — CI/CD config only)
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
