### PR TITLE
fix(cd): Only remove Valkey.Glide project reference in CD patch step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -256,7 +256,7 @@ jobs:
               working-directory: tests/Valkey.Glide.IntegrationTests
               shell: bash
               run: |
-                  dotnet remove reference $(dotnet list reference | tail -n +3)
+                  dotnet remove reference ../../sources/Valkey.Glide/Valkey.Glide.csproj
                   dotnet add package Valkey.Glide --version $RELEASE_VERSION
                   git diff
 


### PR DESCRIPTION
### Summary

Fix the CD workflow's integration test patching step to only remove the `Valkey.Glide` project reference instead of all project references. The previous approach (`dotnet remove reference $(dotnet list reference | tail -n +3)`) also removed the `Valkey.Glide.TestUtils` reference, causing compilation failures when integration tests reference test utility classes like `StandaloneServer` and `ClusterServer`.

### Issue Link

:white_circle: None (discovered during release candidate testing).

### Features and Behaviour Changes

The CD patch step now explicitly removes only `../../sources/Valkey.Glide/Valkey.Glide.csproj` instead of dynamically removing all listed references. This preserves the `TestUtils` project reference that integration tests depend on for server lifecycle management.

### Implementation

One-line change in `.github/workflows/cd.yml`:

```diff
- dotnet remove reference $(dotnet list reference | tail -n +3)
+ dotnet remove reference ../../sources/Valkey.Glide/Valkey.Glide.csproj
```

### Limitations

:white_circle: None.

### Testing

Verify the CD workflow runs successfully with the patched reference removal.

### Related Issues

:white_circle: None.

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] ~~Create merge commit if merging release branch into `main`~~, squash otherwise.