### PR TITLE
feat(core): add ttl based client-side cache configuration and metrics API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-### 1.0.0
-
-- Add client-side caching support with TTL-based expiration, LRU/LFU eviction policies, and cache metrics (#330)
+## 1.0.0
 
 ### Changes
+
+- Add client-side caching support with TTL-based expiration, LRU/LFU eviction policies, and cache metrics (#330)
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0
+## 1.1.0
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 1.0.0
+
+- Add client-side caching support with TTL-based expiration, LRU/LFU eviction policies, and cache metrics (#330)
+
+### Changes
+
 ## 0.10.0
 
 ### Changes

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -53,8 +53,8 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "Unicode-3.0",
     "ISC",
+    "Unicode-3.0",
     "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -53,8 +53,8 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "ISC",
     "Unicode-3.0",
+    "ISC",
     "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -80,9 +80,7 @@ pub enum EvictionPolicy {
 pub struct ClientSideCacheConfig {
     pub cache_id: *const c_char,
     pub max_cache_kb: u64,
-    pub has_entry_ttl_ms: bool,
     pub entry_ttl_ms: u64,
-    pub has_eviction_policy: bool,
     pub eviction_policy: EvictionPolicy,
     pub enable_metrics: bool,
 }
@@ -330,13 +328,11 @@ pub(crate) unsafe fn create_connection_request(
             Some(glide_core::client::ClientSideCache {
                 cache_id: unsafe { ptr_to_str(csc.cache_id) },
                 max_cache_kb: csc.max_cache_kb,
-                entry_ttl_ms: if csc.has_entry_ttl_ms { csc.entry_ttl_ms } else { 0 },
-                eviction_policy: csc
-                    .has_eviction_policy
-                    .then_some(match csc.eviction_policy {
-                        EvictionPolicy::Lru => CoreEvictionPolicy::Lru,
-                        EvictionPolicy::Lfu => CoreEvictionPolicy::Lfu,
-                    }),
+                entry_ttl_ms: csc.entry_ttl_ms,
+                eviction_policy: Some(match csc.eviction_policy {
+                    EvictionPolicy::Lru => CoreEvictionPolicy::Lru,
+                    EvictionPolicy::Lfu => CoreEvictionPolicy::Lfu,
+                }),
                 enable_metrics: csc.enable_metrics,
             })
         } else {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -81,6 +81,7 @@ pub struct ClientSideCacheConfig {
     pub cache_id: *const c_char,
     pub max_cache_kb: u64,
     pub entry_ttl_ms: u64,
+    pub has_eviction_policy: bool,
     pub eviction_policy: EvictionPolicy,
     pub enable_metrics: bool,
 }
@@ -329,10 +330,14 @@ pub(crate) unsafe fn create_connection_request(
                 cache_id: unsafe { ptr_to_str(csc.cache_id) },
                 max_cache_kb: csc.max_cache_kb,
                 entry_ttl_ms: csc.entry_ttl_ms,
-                eviction_policy: Some(match csc.eviction_policy {
-                    EvictionPolicy::Lru => CoreEvictionPolicy::Lru,
-                    EvictionPolicy::Lfu => CoreEvictionPolicy::Lfu,
-                }),
+                eviction_policy: if csc.has_eviction_policy {
+                    Some(match csc.eviction_policy {
+                        EvictionPolicy::Lru => CoreEvictionPolicy::Lru,
+                        EvictionPolicy::Lfu => CoreEvictionPolicy::Lfu,
+                    })
+                } else {
+                    None
+                },
                 enable_metrics: csc.enable_metrics,
             })
         } else {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -80,8 +80,8 @@ pub enum EvictionPolicy {
 pub struct ClientSideCacheConfig {
     pub cache_id: *const c_char,
     pub max_cache_kb: u64,
-    pub has_entry_ttl_seconds: bool,
-    pub entry_ttl_seconds: u64,
+    pub has_entry_ttl_ms: bool,
+    pub entry_ttl_ms: u64,
     pub has_eviction_policy: bool,
     pub eviction_policy: EvictionPolicy,
     pub enable_metrics: bool,
@@ -330,7 +330,7 @@ pub(crate) unsafe fn create_connection_request(
             Some(glide_core::client::ClientSideCache {
                 cache_id: unsafe { ptr_to_str(csc.cache_id) },
                 max_cache_kb: csc.max_cache_kb,
-                entry_ttl_seconds: csc.has_entry_ttl_seconds.then_some(csc.entry_ttl_seconds),
+                entry_ttl_ms: if csc.has_entry_ttl_ms { csc.entry_ttl_ms } else { 0 },
                 eviction_policy: csc
                     .has_eviction_policy
                     .then_some(match csc.eviction_policy {

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -66,6 +66,27 @@ pub enum CompressionBackend {
     Lz4 = 1,
 }
 
+/// A mirror of [`EvictionPolicy`] adopted for FFI.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub enum EvictionPolicy {
+    LRU = 0,
+    LFU = 1,
+}
+
+/// A mirror of [`ClientSideCache`] adopted for FFI.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ClientSideCacheConfig {
+    pub cache_id: *const c_char,
+    pub max_cache_kb: u64,
+    pub has_entry_ttl_seconds: bool,
+    pub entry_ttl_seconds: u64,
+    pub has_eviction_policy: bool,
+    pub eviction_policy: EvictionPolicy,
+    pub enable_metrics: bool,
+}
+
 /// A mirror of [`ConnectionRequest`] adopted for FFI.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -106,6 +127,8 @@ pub struct ConnectionConfig {
     pub has_compression_config: bool,
     pub compression_config: CompressionConfig,
     pub read_only: bool,
+    pub has_client_side_cache_config: bool,
+    pub client_side_cache_config: ClientSideCacheConfig,
     /*
     TODO below
     pub periodic_checks: Option<PeriodicCheck>,
@@ -299,6 +322,24 @@ pub(crate) unsafe fn create_connection_request(
             },
         ),
         read_only: config.read_only,
+
+        // Client-side cache configuration
+        client_side_cache: if config.has_client_side_cache_config {
+            use redis::cache::EvictionPolicy as CoreEvictionPolicy;
+            let csc = config.client_side_cache_config;
+            Some(glide_core::client::ClientSideCache {
+                cache_id: unsafe { ptr_to_str(csc.cache_id) },
+                max_cache_kb: csc.max_cache_kb,
+                entry_ttl_seconds: csc.has_entry_ttl_seconds.then_some(csc.entry_ttl_seconds),
+                eviction_policy: csc.has_eviction_policy.then_some(match csc.eviction_policy {
+                    EvictionPolicy::LRU => CoreEvictionPolicy::Lru,
+                    EvictionPolicy::LFU => CoreEvictionPolicy::Lfu,
+                }),
+                enable_metrics: csc.enable_metrics,
+            })
+        } else {
+            None
+        },
 
         // Unimplemented configuration options.
         client_cert: Vec::new(),

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -74,7 +74,7 @@ pub enum EvictionPolicy {
     Lfu = 1,
 }
 
-/// A mirror of [`ClientSideCache`] adopted for FFI.
+/// A mirror of [`glide_core::client::ClientSideCache`] adopted for FFI.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct ClientSideCacheConfig {
@@ -345,7 +345,6 @@ pub(crate) unsafe fn create_connection_request(
         tcp_nodelay: false,
         periodic_checks: None,
         inflight_requests_limit: None,
-        client_side_cache: None,
         node_discovery_mode: glide_core::client::NodeDiscoveryMode::default(),
     }
 }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -70,8 +70,8 @@ pub enum CompressionBackend {
 #[repr(u32)]
 #[derive(Debug, Clone, Copy)]
 pub enum EvictionPolicy {
-    LRU = 0,
-    LFU = 1,
+    Lru = 0,
+    Lfu = 1,
 }
 
 /// A mirror of [`ClientSideCache`] adopted for FFI.
@@ -331,10 +331,12 @@ pub(crate) unsafe fn create_connection_request(
                 cache_id: unsafe { ptr_to_str(csc.cache_id) },
                 max_cache_kb: csc.max_cache_kb,
                 entry_ttl_seconds: csc.has_entry_ttl_seconds.then_some(csc.entry_ttl_seconds),
-                eviction_policy: csc.has_eviction_policy.then_some(match csc.eviction_policy {
-                    EvictionPolicy::LRU => CoreEvictionPolicy::Lru,
-                    EvictionPolicy::LFU => CoreEvictionPolicy::Lfu,
-                }),
+                eviction_policy: csc
+                    .has_eviction_policy
+                    .then_some(match csc.eviction_policy {
+                        EvictionPolicy::Lru => CoreEvictionPolicy::Lru,
+                        EvictionPolicy::Lfu => CoreEvictionPolicy::Lfu,
+                    }),
                 enable_metrics: csc.enable_metrics,
             })
         } else {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1736,6 +1736,77 @@ fn create_span(command_name: &str) -> *const c_void {
 }
 
 // ========================================================================================
+// Client-Side Cache Metrics
+// ========================================================================================
+
+/// Cache metrics type enum matching the Rust core's cache metric methods.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub enum CacheMetricsType {
+    HitRate = 0,
+    MissRate = 1,
+    EntryCount = 2,
+    Evictions = 3,
+    Expirations = 4,
+    TotalLookups = 5,
+}
+
+/// Get a cache metric from the client.
+///
+/// # Arguments
+/// * `client_ptr` - Pointer to the client
+/// * `callback_index` - Callback index for async response
+/// * `metrics_type` - The type of cache metric to retrieve
+///
+/// # Safety
+/// * `client_ptr` must be a valid pointer to a Client
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn get_cache_metrics(
+    client_ptr: *const c_void,
+    callback_index: usize,
+    metrics_type: CacheMetricsType,
+) {
+    let client = unsafe {
+        Arc::increment_strong_count(client_ptr);
+        Arc::from_raw(client_ptr as *mut Client)
+    };
+    let core = client.core.clone();
+
+    let mut panic_guard = PanicGuard {
+        panicked: true,
+        failure_callback: core.failure_callback,
+        callback_index,
+    };
+
+    let result = match metrics_type {
+        CacheMetricsType::HitRate => core.client.cache_hit_rate(),
+        CacheMetricsType::MissRate => core.client.cache_miss_rate(),
+        CacheMetricsType::EntryCount => core.client.cache_entry_count(),
+        CacheMetricsType::Evictions => core.client.cache_evictions(),
+        CacheMetricsType::Expirations => core.client.cache_expirations(),
+        CacheMetricsType::TotalLookups => core.client.cache_total_lookups(),
+    };
+
+    match result {
+        Ok(value) => {
+            let ptr = Box::into_raw(Box::new(ResponseValue::from_value(value)));
+            unsafe { (core.success_callback)(callback_index, ptr) };
+        }
+        Err(err) => unsafe {
+            report_error(
+                core.failure_callback,
+                callback_index,
+                error_message(&err),
+                error_type(&err),
+            );
+        },
+    };
+
+    panic_guard.panicked = false;
+    drop(panic_guard);
+}
+
+// ========================================================================================
 // Compression Statistics
 // ========================================================================================
 

--- a/sources/Valkey.Glide/Client/BaseClient.ClientSideCacheCommands.cs
+++ b/sources/Valkey.Glide/Client/BaseClient.ClientSideCacheCommands.cs
@@ -26,25 +26,25 @@ public abstract partial class BaseClient
 
     /// <inheritdoc/>
     public Task<double> GetCacheHitRateAsync()
-        => GetCacheMetricAsync(CacheMetricsType.HitRate, v => Convert.ToDouble(v));
+        => GetCacheMetricAsync(CacheMetricsType.HitRate, Convert.ToDouble);
 
     /// <inheritdoc/>
     public Task<double> GetCacheMissRateAsync()
-        => GetCacheMetricAsync(CacheMetricsType.MissRate, v => Convert.ToDouble(v));
+        => GetCacheMetricAsync(CacheMetricsType.MissRate, Convert.ToDouble);
 
     /// <inheritdoc/>
     public Task<long> GetCacheEntryCountAsync()
-        => GetCacheMetricAsync(CacheMetricsType.EntryCount, v => Convert.ToInt64(v));
+        => GetCacheMetricAsync(CacheMetricsType.EntryCount, Convert.ToInt64);
 
     /// <inheritdoc/>
     public Task<long> GetCacheEvictionsAsync()
-        => GetCacheMetricAsync(CacheMetricsType.Evictions, v => Convert.ToInt64(v));
+        => GetCacheMetricAsync(CacheMetricsType.Evictions, Convert.ToInt64);
 
     /// <inheritdoc/>
     public Task<long> GetCacheExpirationsAsync()
-        => GetCacheMetricAsync(CacheMetricsType.Expirations, v => Convert.ToInt64(v));
+        => GetCacheMetricAsync(CacheMetricsType.Expirations, Convert.ToInt64);
 
     /// <inheritdoc/>
     public Task<long> GetCacheTotalLookupsAsync()
-        => GetCacheMetricAsync(CacheMetricsType.TotalLookups, v => Convert.ToInt64(v));
+        => GetCacheMetricAsync(CacheMetricsType.TotalLookups, Convert.ToInt64);
 }

--- a/sources/Valkey.Glide/Client/BaseClient.ClientSideCacheCommands.cs
+++ b/sources/Valkey.Glide/Client/BaseClient.ClientSideCacheCommands.cs
@@ -1,0 +1,113 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+using Valkey.Glide.Internals;
+
+using static Valkey.Glide.Internals.FFI;
+using static Valkey.Glide.Internals.ResponseHandler;
+
+namespace Valkey.Glide;
+
+public abstract partial class BaseClient
+{
+    /// <inheritdoc/>
+    public async Task<double> GetCacheHitRateAsync()
+    {
+        Message message = MessageContainer.GetMessageForCall();
+        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.HitRate);
+        IntPtr response = await message;
+        try
+        {
+            object? value = HandleResponse(response);
+            return value is double d ? d : Convert.ToDouble(value);
+        }
+        finally
+        {
+            FreeResponse(response);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<double> GetCacheMissRateAsync()
+    {
+        Message message = MessageContainer.GetMessageForCall();
+        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.MissRate);
+        IntPtr response = await message;
+        try
+        {
+            object? value = HandleResponse(response);
+            return value is double d ? d : Convert.ToDouble(value);
+        }
+        finally
+        {
+            FreeResponse(response);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<long> GetCacheEntryCountAsync()
+    {
+        Message message = MessageContainer.GetMessageForCall();
+        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.EntryCount);
+        IntPtr response = await message;
+        try
+        {
+            object? value = HandleResponse(response);
+            return value is long l ? l : Convert.ToInt64(value);
+        }
+        finally
+        {
+            FreeResponse(response);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<long> GetCacheEvictionsAsync()
+    {
+        Message message = MessageContainer.GetMessageForCall();
+        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.Evictions);
+        IntPtr response = await message;
+        try
+        {
+            object? value = HandleResponse(response);
+            return value is long l ? l : Convert.ToInt64(value);
+        }
+        finally
+        {
+            FreeResponse(response);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<long> GetCacheExpirationsAsync()
+    {
+        Message message = MessageContainer.GetMessageForCall();
+        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.Expirations);
+        IntPtr response = await message;
+        try
+        {
+            object? value = HandleResponse(response);
+            return value is long l ? l : Convert.ToInt64(value);
+        }
+        finally
+        {
+            FreeResponse(response);
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<long> GetCacheTotalLookupsAsync()
+    {
+        Message message = MessageContainer.GetMessageForCall();
+        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.TotalLookups);
+        IntPtr response = await message;
+        try
+        {
+            object? value = HandleResponse(response);
+            return value is long l ? l : Convert.ToInt64(value);
+        }
+        finally
+        {
+            FreeResponse(response);
+        }
+    }
+}

--- a/sources/Valkey.Glide/Client/BaseClient.ClientSideCacheCommands.cs
+++ b/sources/Valkey.Glide/Client/BaseClient.ClientSideCacheCommands.cs
@@ -9,16 +9,14 @@ namespace Valkey.Glide;
 
 public abstract partial class BaseClient
 {
-    /// <inheritdoc/>
-    public async Task<double> GetCacheHitRateAsync()
+    private async Task<T> GetCacheMetricAsync<T>(CacheMetricsType type, Func<object?, T> convert)
     {
         Message message = MessageContainer.GetMessageForCall();
-        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.HitRate);
+        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)type);
         IntPtr response = await message;
         try
         {
-            object? value = HandleResponse(response);
-            return value is double d ? d : Convert.ToDouble(value);
+            return convert(HandleResponse(response));
         }
         finally
         {
@@ -27,87 +25,26 @@ public abstract partial class BaseClient
     }
 
     /// <inheritdoc/>
-    public async Task<double> GetCacheMissRateAsync()
-    {
-        Message message = MessageContainer.GetMessageForCall();
-        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.MissRate);
-        IntPtr response = await message;
-        try
-        {
-            object? value = HandleResponse(response);
-            return value is double d ? d : Convert.ToDouble(value);
-        }
-        finally
-        {
-            FreeResponse(response);
-        }
-    }
+    public Task<double> GetCacheHitRateAsync()
+        => GetCacheMetricAsync(CacheMetricsType.HitRate, v => Convert.ToDouble(v));
 
     /// <inheritdoc/>
-    public async Task<long> GetCacheEntryCountAsync()
-    {
-        Message message = MessageContainer.GetMessageForCall();
-        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.EntryCount);
-        IntPtr response = await message;
-        try
-        {
-            object? value = HandleResponse(response);
-            return value is long l ? l : Convert.ToInt64(value);
-        }
-        finally
-        {
-            FreeResponse(response);
-        }
-    }
+    public Task<double> GetCacheMissRateAsync()
+        => GetCacheMetricAsync(CacheMetricsType.MissRate, v => Convert.ToDouble(v));
 
     /// <inheritdoc/>
-    public async Task<long> GetCacheEvictionsAsync()
-    {
-        Message message = MessageContainer.GetMessageForCall();
-        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.Evictions);
-        IntPtr response = await message;
-        try
-        {
-            object? value = HandleResponse(response);
-            return value is long l ? l : Convert.ToInt64(value);
-        }
-        finally
-        {
-            FreeResponse(response);
-        }
-    }
+    public Task<long> GetCacheEntryCountAsync()
+        => GetCacheMetricAsync(CacheMetricsType.EntryCount, v => Convert.ToInt64(v));
 
     /// <inheritdoc/>
-    public async Task<long> GetCacheExpirationsAsync()
-    {
-        Message message = MessageContainer.GetMessageForCall();
-        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.Expirations);
-        IntPtr response = await message;
-        try
-        {
-            object? value = HandleResponse(response);
-            return value is long l ? l : Convert.ToInt64(value);
-        }
-        finally
-        {
-            FreeResponse(response);
-        }
-    }
+    public Task<long> GetCacheEvictionsAsync()
+        => GetCacheMetricAsync(CacheMetricsType.Evictions, v => Convert.ToInt64(v));
 
     /// <inheritdoc/>
-    public async Task<long> GetCacheTotalLookupsAsync()
-    {
-        Message message = MessageContainer.GetMessageForCall();
-        GetCacheMetricsFfi(ClientPointer, (ulong)message.Index, (uint)CacheMetricsType.TotalLookups);
-        IntPtr response = await message;
-        try
-        {
-            object? value = HandleResponse(response);
-            return value is long l ? l : Convert.ToInt64(value);
-        }
-        finally
-        {
-            FreeResponse(response);
-        }
-    }
+    public Task<long> GetCacheExpirationsAsync()
+        => GetCacheMetricAsync(CacheMetricsType.Expirations, v => Convert.ToInt64(v));
+
+    /// <inheritdoc/>
+    public Task<long> GetCacheTotalLookupsAsync()
+        => GetCacheMetricAsync(CacheMetricsType.TotalLookups, v => Convert.ToInt64(v));
 }

--- a/sources/Valkey.Glide/Client/IBaseClient.ClientSideCacheCommands.cs
+++ b/sources/Valkey.Glide/Client/IBaseClient.ClientSideCacheCommands.cs
@@ -1,0 +1,110 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide;
+
+/// ATTENTION: Methods should only be added to this interface if they are implemented
+/// by Valkey GLIDE clients but NOT by StackExchange.Redis databases. Methods implemented
+/// by both should be added to the corresponding Commands interface instead.
+
+/// <summary>
+/// Client-side cache commands for Valkey GLIDE clients.
+/// These methods provide access to cache metrics when client-side caching is enabled.
+/// </summary>
+/// <seealso cref="ClientSideCacheConfig"/>
+public partial interface IBaseClient
+{
+    /// <summary>
+    /// Returns the cache hit rate as a value between 0.0 and 1.0.
+    /// A higher hit rate indicates better cache performance.
+    /// </summary>
+    /// <returns>The cache hit rate (0.0 to 1.0).</returns>
+    /// <exception cref="Errors.RequestException">
+    /// Thrown when client-side caching is not enabled or metrics collection is disabled.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// double hitRate = await client.GetCacheHitRateAsync();
+    /// Console.WriteLine($"Cache hit rate: {hitRate:P2}");
+    /// </code>
+    /// </example>
+    Task<double> GetCacheHitRateAsync();
+
+    /// <summary>
+    /// Returns the cache miss rate as a value between 0.0 and 1.0.
+    /// A lower miss rate indicates better cache performance.
+    /// </summary>
+    /// <returns>The cache miss rate (0.0 to 1.0).</returns>
+    /// <exception cref="Errors.RequestException">
+    /// Thrown when client-side caching is not enabled or metrics collection is disabled.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// double missRate = await client.GetCacheMissRateAsync();
+    /// Console.WriteLine($"Cache miss rate: {missRate:P2}");
+    /// </code>
+    /// </example>
+    Task<double> GetCacheMissRateAsync();
+
+    /// <summary>
+    /// Returns the current number of entries in the client-side cache.
+    /// </summary>
+    /// <returns>The number of cache entries.</returns>
+    /// <exception cref="Errors.RequestException">
+    /// Thrown when client-side caching is not enabled.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// long entryCount = await client.GetCacheEntryCountAsync();
+    /// Console.WriteLine($"Cache contains {entryCount} entries");
+    /// </code>
+    /// </example>
+    Task<long> GetCacheEntryCountAsync();
+
+    /// <summary>
+    /// Returns the total number of cache evictions.
+    /// Evictions occur when the cache reaches its maximum size and entries are removed
+    /// based on the configured <see cref="EvictionPolicy"/>.
+    /// </summary>
+    /// <returns>The number of cache evictions.</returns>
+    /// <exception cref="Errors.RequestException">
+    /// Thrown when client-side caching is not enabled or metrics collection is disabled.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// long evictions = await client.GetCacheEvictionsAsync();
+    /// Console.WriteLine($"Cache has evicted {evictions} entries");
+    /// </code>
+    /// </example>
+    Task<long> GetCacheEvictionsAsync();
+
+    /// <summary>
+    /// Returns the total number of cache expirations.
+    /// Expirations occur when entries exceed their TTL (Time-To-Live).
+    /// </summary>
+    /// <returns>The number of cache expirations.</returns>
+    /// <exception cref="Errors.RequestException">
+    /// Thrown when client-side caching is not enabled or metrics collection is disabled.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// long expirations = await client.GetCacheExpirationsAsync();
+    /// Console.WriteLine($"Cache has expired {expirations} entries");
+    /// </code>
+    /// </example>
+    Task<long> GetCacheExpirationsAsync();
+
+    /// <summary>
+    /// Returns the total number of cache lookups (hits + misses).
+    /// </summary>
+    /// <returns>The total number of cache lookups.</returns>
+    /// <exception cref="Errors.RequestException">
+    /// Thrown when client-side caching is not enabled or metrics collection is disabled.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// long totalLookups = await client.GetCacheTotalLookupsAsync();
+    /// Console.WriteLine($"Cache has performed {totalLookups} lookups");
+    /// </code>
+    /// </example>
+    Task<long> GetCacheTotalLookupsAsync();
+}

--- a/sources/Valkey.Glide/Client/IBaseClient.ClientSideCacheCommands.cs
+++ b/sources/Valkey.Glide/Client/IBaseClient.ClientSideCacheCommands.cs
@@ -3,8 +3,7 @@
 namespace Valkey.Glide;
 
 /// ATTENTION: Methods should only be added to this interface if they are implemented
-/// by Valkey GLIDE clients but NOT by StackExchange.Redis databases. Methods implemented
-/// by both should be added to the corresponding Commands interface instead.
+/// by Valkey GLIDE clients but NOT by StackExchange.Redis databases.
 
 /// <summary>
 /// Client-side cache commands for Valkey GLIDE clients.

--- a/sources/Valkey.Glide/ClientSideCacheConfig.cs
+++ b/sources/Valkey.Glide/ClientSideCacheConfig.cs
@@ -56,9 +56,9 @@ public sealed class ClientSideCacheConfig
     /// <summary>
     /// The Time-To-Live for cached entries in milliseconds.
     /// After this duration, entries automatically expire and are removed from the cache.
-    /// If <see langword="null"/>, no expiration is applied.
+    /// A value of <c>0</c> means no expiration is applied.
     /// </summary>
-    public ulong? EntryTtlMs { get; private set; }
+    public ulong EntryTtlMs { get; private set; }
 
     /// <summary>
     /// The policy for evicting entries when the cache reaches its maximum size.
@@ -153,8 +153,7 @@ public sealed class ClientSideCacheConfig
     {
         CacheId = CacheId,
         MaxCacheKb = MaxCacheKb,
-        HasEntryTtlMs = EntryTtlMs.HasValue,
-        EntryTtlMs = EntryTtlMs ?? default,
+        EntryTtlMs = EntryTtlMs,
         HasEvictionPolicy = EvictionPolicy.HasValue,
         EvictionPolicy = EvictionPolicy ?? default,
         EnableMetrics = EnableMetrics,

--- a/sources/Valkey.Glide/ClientSideCacheConfig.cs
+++ b/sources/Valkey.Glide/ClientSideCacheConfig.cs
@@ -54,11 +54,11 @@ public sealed class ClientSideCacheConfig
     public ulong MaxCacheKb { get; }
 
     /// <summary>
-    /// The Time-To-Live for cached entries in seconds.
+    /// The Time-To-Live for cached entries in milliseconds.
     /// After this duration, entries automatically expire and are removed from the cache.
     /// If <see langword="null"/>, no expiration is applied.
     /// </summary>
-    public ulong? EntryTtlSeconds { get; private set; }
+    public ulong? EntryTtlMs { get; private set; }
 
     /// <summary>
     /// The policy for evicting entries when the cache reaches its maximum size.
@@ -79,7 +79,7 @@ public sealed class ClientSideCacheConfig
     /// <example>
     /// <code>
     /// var cache = new ClientSideCacheConfig(1024)          // 1 MB cache
-    ///     .WithEntryTtlSeconds(60)                         // 1 minute TTL
+    ///     .WithEntryTtlMs(60000)                           // 1 minute TTL
     ///     .WithEvictionPolicy(EvictionPolicy.LRU)
     ///     .WithMetrics(true);
     ///
@@ -108,19 +108,19 @@ public sealed class ClientSideCacheConfig
     }
 
     /// <summary>
-    /// Sets the TTL for cache entries in seconds.
+    /// Sets the TTL for cache entries in milliseconds.
     /// </summary>
-    /// <param name="ttlSeconds">Time-To-Live in seconds. Must be positive.</param>
+    /// <param name="ttlMs">Time-To-Live in milliseconds. Must be positive.</param>
     /// <returns>This instance for method chaining.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="ttlSeconds"/> is zero.</exception>
-    public ClientSideCacheConfig WithEntryTtlSeconds(ulong ttlSeconds)
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="ttlMs"/> is zero.</exception>
+    public ClientSideCacheConfig WithEntryTtlMs(ulong ttlMs)
     {
-        if (ttlSeconds == 0)
+        if (ttlMs == 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(ttlSeconds), "ttlSeconds must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(ttlMs), "ttlMs must be positive.");
         }
 
-        EntryTtlSeconds = ttlSeconds;
+        EntryTtlMs = ttlMs;
         return this;
     }
 
@@ -153,8 +153,8 @@ public sealed class ClientSideCacheConfig
     {
         CacheId = CacheId,
         MaxCacheKb = MaxCacheKb,
-        HasEntryTtlSeconds = EntryTtlSeconds.HasValue,
-        EntryTtlSeconds = EntryTtlSeconds ?? default,
+        HasEntryTtlMs = EntryTtlMs.HasValue,
+        EntryTtlMs = EntryTtlMs ?? default,
         HasEvictionPolicy = EvictionPolicy.HasValue,
         EvictionPolicy = EvictionPolicy ?? default,
         EnableMetrics = EnableMetrics,

--- a/sources/Valkey.Glide/ClientSideCacheConfig.cs
+++ b/sources/Valkey.Glide/ClientSideCacheConfig.cs
@@ -12,17 +12,18 @@ namespace Valkey.Glide;
 /// <remarks>
 /// <list type="bullet">
 ///   <item>
-///     Glide currently supports TTL-based caching only. Invalidation-based client-side
-///     caching (where the server notifies clients of key changes) is not currently supported.
+///     Valkey GLIDE supports TTL-based caching only. Invalidation-based client-side
+///     caching (where the server notifies clients of key changes) is not supported.
 ///     This means cached values may become stale if updated on the server before the TTL expires.
 ///   </item>
 ///   <item>
-///     Currently, Glide's client-side cache supports lazy eviction only. Expired entries
+///     Valkey GLIDE client-side cache supports lazy eviction only. Expired entries
 ///     are removed only when accessed after their TTL has expired. There is no proactive
 ///     background cleanup of expired entries.
 ///   </item>
 ///   <item>
-///     Currently, only read commands that retrieve entire values are cached (GET, HGETALL, SMEMBERS).
+///     Only read commands that retrieve entire values are cached
+///     (GET, HGETALL, SMEMBERS).
 ///   </item>
 /// </list>
 /// In order for two clients to share the same cache, they must be created with the same
@@ -36,15 +37,12 @@ namespace Valkey.Glide;
 /// <seealso cref="EvictionPolicy"/>
 public sealed class ClientSideCacheConfig
 {
-    private static readonly object CounterLock = new();
-    private static readonly string UuidPrefix = Guid.NewGuid().ToString("N")[..8];
-    private static ulong s_counter;
-
     /// <summary>
     /// A unique identifier for the cache instance.
     /// Multiple clients can share the same cache by using the same <see cref="ClientSideCacheConfig"/> instance.
     /// </summary>
-    public string CacheId { get; }
+    // Internal for testing.
+    internal string CacheId { get; } = Guid.NewGuid().ToString("N");
 
     /// <summary>
     /// The maximum size of the cache in kilobytes (KB).
@@ -54,17 +52,17 @@ public sealed class ClientSideCacheConfig
     public ulong MaxCacheKb { get; }
 
     /// <summary>
-    /// The Time-To-Live for cached entries in milliseconds.
+    /// The Time-To-Live for cached entries.
     /// After this duration, entries automatically expire and are removed from the cache.
-    /// A value of <c>0</c> means no expiration is applied.
+    /// <see cref="TimeSpan.Zero"/> means no expiration is applied (entries remain until evicted).
     /// </summary>
-    public ulong EntryTtlMs { get; private set; }
+    public TimeSpan EntryTtl { get; }
 
     /// <summary>
     /// The policy for evicting entries when the cache reaches its maximum size.
-    /// If <see langword="null"/>, the default policy of <see cref="Valkey.Glide.EvictionPolicy.LRU"/> will be used.
+    /// Defaults to <see cref="Valkey.Glide.EvictionPolicy.LRU"/>.
     /// </summary>
-    public EvictionPolicy? EvictionPolicy { get; private set; }
+    public EvictionPolicy EvictionPolicy { get; private set; } = EvictionPolicy.LRU;
 
     /// <summary>
     /// Whether collection of cache metrics (hit/miss rates, evictions, etc.) is enabled.
@@ -75,11 +73,11 @@ public sealed class ClientSideCacheConfig
     /// Creates a new <see cref="ClientSideCacheConfig"/> with an auto-generated unique cache ID.
     /// </summary>
     /// <param name="maxCacheKb">Maximum size of the cache in kilobytes (KB). Must be positive.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCacheKb"/> is zero.</exception>
+    /// <param name="entryTtl">Time-To-Live for cached entries. Use <see cref="TimeSpan.Zero"/> to disable expiration.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCacheKb"/> is zero or <paramref name="entryTtl"/> is negative.</exception>
     /// <example>
     /// <code>
-    /// var cache = new ClientSideCacheConfig(1024)          // 1 MB cache
-    ///     .WithEntryTtlMs(60000)                           // 1 minute TTL
+    /// var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
     ///     .WithEvictionPolicy(EvictionPolicy.LRU)
     ///     .WithMetrics(true);
     ///
@@ -89,39 +87,20 @@ public sealed class ClientSideCacheConfig
     ///     .Build();
     /// </code>
     /// </example>
-    public ClientSideCacheConfig(ulong maxCacheKb)
+    public ClientSideCacheConfig(ulong maxCacheKb, TimeSpan entryTtl)
     {
         if (maxCacheKb == 0)
         {
             throw new ArgumentOutOfRangeException(nameof(maxCacheKb), "maxCacheKb must be positive.");
         }
 
-        string cacheId;
-        lock (CounterLock)
+        if (entryTtl < TimeSpan.Zero)
         {
-            cacheId = $"{UuidPrefix}-{s_counter}";
-            s_counter++;
+            throw new ArgumentOutOfRangeException(nameof(entryTtl), "entryTtl must not be negative.");
         }
 
-        CacheId = cacheId;
         MaxCacheKb = maxCacheKb;
-    }
-
-    /// <summary>
-    /// Sets the TTL for cache entries in milliseconds.
-    /// </summary>
-    /// <param name="ttlMs">Time-To-Live in milliseconds. Must be positive.</param>
-    /// <returns>This instance for method chaining.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="ttlMs"/> is zero.</exception>
-    public ClientSideCacheConfig WithEntryTtlMs(ulong ttlMs)
-    {
-        if (ttlMs == 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(ttlMs), "ttlMs must be positive.");
-        }
-
-        EntryTtlMs = ttlMs;
-        return this;
+        EntryTtl = entryTtl;
     }
 
     /// <summary>
@@ -149,13 +128,11 @@ public sealed class ClientSideCacheConfig
     /// <summary>
     /// Converts to the FFI representation for marshalling to Rust core.
     /// </summary>
-    internal Internals.FFI.ClientSideCacheConfig ToFfi() => new()
-    {
-        CacheId = CacheId,
-        MaxCacheKb = MaxCacheKb,
-        EntryTtlMs = EntryTtlMs,
-        HasEvictionPolicy = EvictionPolicy.HasValue,
-        EvictionPolicy = EvictionPolicy ?? default,
-        EnableMetrics = EnableMetrics,
-    };
+    internal Internals.FFI.ClientSideCacheConfig ToFfi() => new(
+        CacheId,
+        MaxCacheKb,
+        (ulong)EntryTtl.TotalMilliseconds,
+        EvictionPolicy,
+        EnableMetrics
+    );
 }

--- a/sources/Valkey.Glide/ClientSideCacheConfig.cs
+++ b/sources/Valkey.Glide/ClientSideCacheConfig.cs
@@ -81,7 +81,7 @@ public sealed class ClientSideCacheConfig
     ///     .WithEvictionPolicy(EvictionPolicy.LRU)
     ///     .WithMetrics(true);
     ///
-    /// var config = new StandaloneClientConfigurationBuilder()
+    /// var config = new ConnectionConfiguration.StandaloneClientConfigurationBuilder()
     ///     .WithAddress("localhost", 6379)
     ///     .WithClientSideCache(cache)
     ///     .Build();

--- a/sources/Valkey.Glide/ClientSideCacheConfig.cs
+++ b/sources/Valkey.Glide/ClientSideCacheConfig.cs
@@ -1,5 +1,7 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+using Valkey.Glide.Internals;
+
 namespace Valkey.Glide;
 
 /// <summary>
@@ -60,9 +62,9 @@ public sealed class ClientSideCacheConfig
 
     /// <summary>
     /// The policy for evicting entries when the cache reaches its maximum size.
-    /// Defaults to <see cref="Valkey.Glide.EvictionPolicy.LRU"/>.
+    /// If <see langword="null"/>, the default policy (LRU) is applied by the Rust core.
     /// </summary>
-    public EvictionPolicy EvictionPolicy { get; private set; } = EvictionPolicy.LRU;
+    public EvictionPolicy? EvictionPolicy { get; private set; }
 
     /// <summary>
     /// Whether collection of cache metrics (hit/miss rates, evictions, etc.) is enabled.
@@ -74,7 +76,8 @@ public sealed class ClientSideCacheConfig
     /// </summary>
     /// <param name="maxCacheKb">Maximum size of the cache in kilobytes (KB). Must be positive.</param>
     /// <param name="entryTtl">Time-To-Live for cached entries. Use <see cref="TimeSpan.Zero"/> to disable expiration.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCacheKb"/> is zero or <paramref name="entryTtl"/> is negative.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCacheKb"/> is zero.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="entryTtl"/> is negative.</exception>
     /// <example>
     /// <code>
     /// var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
@@ -94,10 +97,7 @@ public sealed class ClientSideCacheConfig
             throw new ArgumentOutOfRangeException(nameof(maxCacheKb), "maxCacheKb must be positive.");
         }
 
-        if (entryTtl < TimeSpan.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(entryTtl), "entryTtl must not be negative.");
-        }
+        GuardClauses.ThrowIfTimeSpanNegative(entryTtl);
 
         MaxCacheKb = maxCacheKb;
         EntryTtl = entryTtl;
@@ -131,8 +131,9 @@ public sealed class ClientSideCacheConfig
     internal Internals.FFI.ClientSideCacheConfig ToFfi() => new(
         CacheId,
         MaxCacheKb,
-        (ulong)EntryTtl.TotalMilliseconds,
-        EvictionPolicy,
+        Utils.ToMillisecondsUlong(EntryTtl),
+        EvictionPolicy.HasValue,
+        EvictionPolicy ?? default,
         EnableMetrics
     );
 }

--- a/sources/Valkey.Glide/ClientSideCacheConfig.cs
+++ b/sources/Valkey.Glide/ClientSideCacheConfig.cs
@@ -1,0 +1,162 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide;
+
+/// <summary>
+/// Configuration for client-side caching with TTL-based expiration.
+/// <para />
+/// Configures a local cache that stores read command responses on the client side
+/// to reduce network round-trips and server load. The cache uses Time-To-Live (TTL)
+/// based expiration, where entries are automatically removed after a specified duration.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+///   <item>
+///     Glide currently supports TTL-based caching only. Invalidation-based client-side
+///     caching (where the server notifies clients of key changes) is not currently supported.
+///     This means cached values may become stale if updated on the server before the TTL expires.
+///   </item>
+///   <item>
+///     Currently, Glide's client-side cache supports lazy eviction only. Expired entries
+///     are removed only when accessed after their TTL has expired. There is no proactive
+///     background cleanup of expired entries.
+///   </item>
+///   <item>
+///     Currently, only read commands that retrieve entire values are cached (GET, HGETALL, SMEMBERS).
+///   </item>
+/// </list>
+/// In order for two clients to share the same cache, they must be created with the same
+/// <see cref="ClientSideCacheConfig"/> instance.
+/// <list type="bullet">
+///   <item>Clients with different <see cref="ClientSideCacheConfig"/> instances will have separate caches, even if the configurations are identical.</item>
+///   <item>Clients using different databases cannot share the same cache.</item>
+///   <item>Clients using different ACL users cannot share the same cache.</item>
+/// </list>
+/// </remarks>
+/// <seealso cref="EvictionPolicy"/>
+public sealed class ClientSideCacheConfig
+{
+    private static readonly object CounterLock = new();
+    private static readonly string UuidPrefix = Guid.NewGuid().ToString("N")[..8];
+    private static ulong s_counter;
+
+    /// <summary>
+    /// A unique identifier for the cache instance.
+    /// Multiple clients can share the same cache by using the same <see cref="ClientSideCacheConfig"/> instance.
+    /// </summary>
+    public string CacheId { get; }
+
+    /// <summary>
+    /// The maximum size of the cache in kilobytes (KB).
+    /// This limits the total memory used by cached keys and values.
+    /// When this limit is reached, entries are evicted based on the <see cref="EvictionPolicy"/>.
+    /// </summary>
+    public ulong MaxCacheKb { get; }
+
+    /// <summary>
+    /// The Time-To-Live for cached entries in seconds.
+    /// After this duration, entries automatically expire and are removed from the cache.
+    /// If <see langword="null"/>, no expiration is applied.
+    /// </summary>
+    public ulong? EntryTtlSeconds { get; private set; }
+
+    /// <summary>
+    /// The policy for evicting entries when the cache reaches its maximum size.
+    /// If <see langword="null"/>, the default policy of <see cref="Valkey.Glide.EvictionPolicy.LRU"/> will be used.
+    /// </summary>
+    public EvictionPolicy? EvictionPolicy { get; private set; }
+
+    /// <summary>
+    /// Whether collection of cache metrics (hit/miss rates, evictions, etc.) is enabled.
+    /// </summary>
+    public bool EnableMetrics { get; private set; }
+
+    /// <summary>
+    /// Creates a new <see cref="ClientSideCacheConfig"/> with an auto-generated unique cache ID.
+    /// </summary>
+    /// <param name="maxCacheKb">Maximum size of the cache in kilobytes (KB). Must be positive.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCacheKb"/> is zero.</exception>
+    /// <example>
+    /// <code>
+    /// var cache = new ClientSideCacheConfig(1024)          // 1 MB cache
+    ///     .WithEntryTtlSeconds(60)                         // 1 minute TTL
+    ///     .WithEvictionPolicy(EvictionPolicy.LRU)
+    ///     .WithMetrics(true);
+    ///
+    /// var config = new StandaloneClientConfigurationBuilder()
+    ///     .WithAddress("localhost", 6379)
+    ///     .WithClientSideCache(cache)
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public ClientSideCacheConfig(ulong maxCacheKb)
+    {
+        if (maxCacheKb == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCacheKb), "maxCacheKb must be positive.");
+        }
+
+        string cacheId;
+        lock (CounterLock)
+        {
+            cacheId = $"{UuidPrefix}-{s_counter}";
+            s_counter++;
+        }
+
+        CacheId = cacheId;
+        MaxCacheKb = maxCacheKb;
+    }
+
+    /// <summary>
+    /// Sets the TTL for cache entries in seconds.
+    /// </summary>
+    /// <param name="ttlSeconds">Time-To-Live in seconds. Must be positive.</param>
+    /// <returns>This instance for method chaining.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="ttlSeconds"/> is zero.</exception>
+    public ClientSideCacheConfig WithEntryTtlSeconds(ulong ttlSeconds)
+    {
+        if (ttlSeconds == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ttlSeconds), "ttlSeconds must be positive.");
+        }
+
+        EntryTtlSeconds = ttlSeconds;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the eviction policy for the cache.
+    /// </summary>
+    /// <param name="policy">The eviction policy to use.</param>
+    /// <returns>This instance for method chaining.</returns>
+    public ClientSideCacheConfig WithEvictionPolicy(EvictionPolicy policy)
+    {
+        EvictionPolicy = policy;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables cache metrics collection.
+    /// </summary>
+    /// <param name="enable">Whether to enable metrics.</param>
+    /// <returns>This instance for method chaining.</returns>
+    public ClientSideCacheConfig WithMetrics(bool enable = true)
+    {
+        EnableMetrics = enable;
+        return this;
+    }
+
+    /// <summary>
+    /// Converts to the FFI representation for marshalling to Rust core.
+    /// </summary>
+    internal Internals.FFI.ClientSideCacheConfig ToFfi() => new()
+    {
+        CacheId = CacheId,
+        MaxCacheKb = MaxCacheKb,
+        HasEntryTtlSeconds = EntryTtlSeconds.HasValue,
+        EntryTtlSeconds = EntryTtlSeconds ?? default,
+        HasEvictionPolicy = EvictionPolicy.HasValue,
+        EvictionPolicy = EvictionPolicy ?? default,
+        EnableMetrics = EnableMetrics,
+    };
+}

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -42,6 +42,7 @@ public abstract class ConnectionConfiguration
         public TimeSpan? PubSubReconciliationInterval;
         public CompressionConfig? CompressionConfig;
         public bool ReadOnly;
+        public ClientSideCacheConfig? ClientSideCacheConfig;
 
         internal FFI.ConnectionConfig ToFfi() =>
             new(
@@ -62,7 +63,8 @@ public abstract class ConnectionConfiguration
                 RootCertificates,
                 (uint?)PubSubReconciliationInterval?.TotalMilliseconds,
                 CompressionConfig?.ToFfi(),
-                ReadOnly
+                ReadOnly,
+                ClientSideCacheConfig?.ToFfi()
             );
     }
 
@@ -846,6 +848,30 @@ public abstract class ConnectionConfiguration
         public T WithCompression(CompressionConfig compressionConfig)
         {
             CompressionConfig = compressionConfig;
+            return (T)this;
+        }
+
+        #endregion
+
+        #region Client-Side Cache
+
+        /// <summary>
+        /// Client-side cache configuration for local caching of read command responses.
+        /// When enabled, the client stores responses locally to reduce network round-trips
+        /// and server load. The cache uses TTL-based expiration.
+        /// </summary>
+        /// <seealso cref="ClientSideCacheConfig"/>
+        public ClientSideCacheConfig? ClientSideCacheConfig
+        {
+            get => Config.ClientSideCacheConfig;
+            set => Config.ClientSideCacheConfig = value;
+        }
+
+        /// <inheritdoc cref="ClientSideCacheConfig" />
+        public T WithClientSideCache(ClientSideCacheConfig clientSideCacheConfig)
+        {
+            ArgumentNullException.ThrowIfNull(clientSideCacheConfig);
+            ClientSideCacheConfig = clientSideCacheConfig;
             return (T)this;
         }
 

--- a/sources/Valkey.Glide/Internals/FFI.methods.cs
+++ b/sources/Valkey.Glide/Internals/FFI.methods.cs
@@ -117,6 +117,10 @@ internal partial class FFI
     [LibraryImport("libglide_rs", EntryPoint = "get_statistics")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial Statistics GetStatisticsFfi();
+
+    [LibraryImport("libglide_rs", EntryPoint = "get_cache_metrics")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    public static partial void GetCacheMetricsFfi(IntPtr client, ulong index, uint metricsType);
 #else
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "command")]
     public static extern void CommandFfi(IntPtr client, ulong index, IntPtr cmdInfo, IntPtr routeInfo);
@@ -185,5 +189,8 @@ internal partial class FFI
 
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "get_statistics")]
     public static extern Statistics GetStatisticsFfi();
+
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "get_cache_metrics")]
+    public static extern void GetCacheMetricsFfi(IntPtr client, ulong index, uint metricsType);
 #endif
 }

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -1222,10 +1222,10 @@ internal partial class FFI
 
         /// <summary>Whether an entry TTL was explicitly specified.</summary>
         [MarshalAs(UnmanagedType.U1)]
-        public bool HasEntryTtlSeconds;
+        public bool HasEntryTtlMs;
 
-        /// <summary>Time-To-Live for cached entries in seconds.</summary>
-        public ulong EntryTtlSeconds;
+        /// <summary>Time-To-Live for cached entries in milliseconds.</summary>
+        public ulong EntryTtlMs;
 
         /// <summary>Whether an eviction policy was explicitly specified.</summary>
         [MarshalAs(UnmanagedType.U1)]

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -1215,6 +1215,7 @@ internal partial class FFI
         string cacheId,
         ulong maxCacheKb,
         ulong entryTtlMs,
+        bool hasEvictionPolicy,
         EvictionPolicy evictionPolicy,
         bool enableMetrics)
     {
@@ -1227,6 +1228,10 @@ internal partial class FFI
 
         /// <summary>Time-To-Live for cached entries in milliseconds (0 = no expiration).</summary>
         public readonly ulong EntryTtlMs = entryTtlMs;
+
+        /// <summary>Whether an eviction policy was explicitly specified.</summary>
+        [MarshalAs(UnmanagedType.U1)]
+        public readonly bool HasEvictionPolicy = hasEvictionPolicy;
 
         /// <summary>The eviction policy for the cache.</summary>
         public readonly EvictionPolicy EvictionPolicy = evictionPolicy;

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -1220,11 +1220,7 @@ internal partial class FFI
         /// <summary>Maximum size of the cache in kilobytes.</summary>
         public ulong MaxCacheKb;
 
-        /// <summary>Whether an entry TTL was explicitly specified.</summary>
-        [MarshalAs(UnmanagedType.U1)]
-        public bool HasEntryTtlMs;
-
-        /// <summary>Time-To-Live for cached entries in milliseconds.</summary>
+        /// <summary>Time-To-Live for cached entries in milliseconds (0 = no expiration).</summary>
         public ulong EntryTtlMs;
 
         /// <summary>Whether an eviction policy was explicitly specified.</summary>

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -218,7 +218,8 @@ internal partial class FFI
             List<byte[]> rootCertificates,
             uint? pubSubReconciliationIntervalMs,
             CompressionConfig? compressionConfig,
-            bool readOnly)
+            bool readOnly,
+            ClientSideCacheConfig? clientSideCacheConfig)
         {
             _request = new()
             {
@@ -252,6 +253,8 @@ internal partial class FFI
                 HasCompressionConfig = compressionConfig.HasValue,
                 CompressionConfig = compressionConfig ?? default,
                 ReadOnly = readOnly,
+                HasClientSideCacheConfig = clientSideCacheConfig.HasValue,
+                ClientSideCacheConfig = clientSideCacheConfig ?? default,
             };
         }
 
@@ -1127,6 +1130,10 @@ internal partial class FFI
         [MarshalAs(UnmanagedType.U1)]
         public bool ReadOnly;
 
+        [MarshalAs(UnmanagedType.U1)]
+        public bool HasClientSideCacheConfig;
+        public ClientSideCacheConfig ClientSideCacheConfig;
+
         // TODO more config params, see ffi.rs
     }
 
@@ -1201,6 +1208,35 @@ internal partial class FFI
 
         /// <summary>Maximum allowed size for decompressed data (prevents decompression bombs).</summary>
         public ulong MaxDecompressedSize = maxDecompressedSize ?? default;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    internal struct ClientSideCacheConfig
+    {
+        /// <summary>Unique identifier for the cache instance.</summary>
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string CacheId;
+
+        /// <summary>Maximum size of the cache in kilobytes.</summary>
+        public ulong MaxCacheKb;
+
+        /// <summary>Whether an entry TTL was explicitly specified.</summary>
+        [MarshalAs(UnmanagedType.U1)]
+        public bool HasEntryTtlSeconds;
+
+        /// <summary>Time-To-Live for cached entries in seconds.</summary>
+        public ulong EntryTtlSeconds;
+
+        /// <summary>Whether an eviction policy was explicitly specified.</summary>
+        [MarshalAs(UnmanagedType.U1)]
+        public bool HasEvictionPolicy;
+
+        /// <summary>The eviction policy for the cache.</summary>
+        public EvictionPolicy EvictionPolicy;
+
+        /// <summary>Whether cache metrics collection is enabled.</summary>
+        [MarshalAs(UnmanagedType.U1)]
+        public bool EnableMetrics;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -1514,5 +1550,18 @@ internal partial class FFI
     {
         ElastiCache = 0,
         MemoryDB = 1,
+    }
+
+    /// <summary>
+    /// Cache metrics type enum matching the Rust core's cache metric methods.
+    /// </summary>
+    internal enum CacheMetricsType : uint
+    {
+        HitRate = 0,
+        MissRate = 1,
+        EntryCount = 2,
+        Evictions = 3,
+        Expirations = 4,
+        TotalLookups = 5,
     }
 }

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -1211,28 +1211,29 @@ internal partial class FFI
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
-    internal struct ClientSideCacheConfig
+    internal readonly struct ClientSideCacheConfig(
+        string cacheId,
+        ulong maxCacheKb,
+        ulong entryTtlMs,
+        EvictionPolicy evictionPolicy,
+        bool enableMetrics)
     {
         /// <summary>Unique identifier for the cache instance.</summary>
         [MarshalAs(UnmanagedType.LPStr)]
-        public string CacheId;
+        public readonly string CacheId = cacheId;
 
         /// <summary>Maximum size of the cache in kilobytes.</summary>
-        public ulong MaxCacheKb;
+        public readonly ulong MaxCacheKb = maxCacheKb;
 
         /// <summary>Time-To-Live for cached entries in milliseconds (0 = no expiration).</summary>
-        public ulong EntryTtlMs;
-
-        /// <summary>Whether an eviction policy was explicitly specified.</summary>
-        [MarshalAs(UnmanagedType.U1)]
-        public bool HasEvictionPolicy;
+        public readonly ulong EntryTtlMs = entryTtlMs;
 
         /// <summary>The eviction policy for the cache.</summary>
-        public EvictionPolicy EvictionPolicy;
+        public readonly EvictionPolicy EvictionPolicy = evictionPolicy;
 
         /// <summary>Whether cache metrics collection is enabled.</summary>
         [MarshalAs(UnmanagedType.U1)]
-        public bool EnableMetrics;
+        public readonly bool EnableMetrics = enableMetrics;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/sources/Valkey.Glide/Internals/Utils.cs
+++ b/sources/Valkey.Glide/Internals/Utils.cs
@@ -5,6 +5,13 @@ using System.Net;
 
 internal class Utils
 {
+    /// <summary>
+    /// Converts a <see cref="TimeSpan"/> to milliseconds as a <see cref="ulong"/>,
+    /// using tick-based arithmetic to avoid floating-point precision loss.
+    /// </summary>
+    public static ulong ToMillisecondsUlong(TimeSpan timeSpan)
+        => (ulong)(timeSpan.Ticks / TimeSpan.TicksPerMillisecond);
+
     public static (string host, ushort port) SplitEndpoint(EndPoint ep)
         => ep switch
         {

--- a/sources/Valkey.Glide/abstract_Enums/EvictionPolicy.cs
+++ b/sources/Valkey.Glide/abstract_Enums/EvictionPolicy.cs
@@ -1,0 +1,23 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide;
+
+/// <summary>
+/// Eviction policy for client-side cache entries.
+/// When the cache reaches its maximum size, it must evict existing entries to make room for new ones.
+/// Values must match the corresponding enum in glide-core.
+/// </summary>
+public enum EvictionPolicy : uint
+{
+    /// <summary>
+    /// Least Recently Used — evicts the least recently accessed entry.
+    /// Best for recency-biased workloads like event streams and job queues.
+    /// </summary>
+    LRU = 0,
+
+    /// <summary>
+    /// Least Frequently Used — evicts the least frequently accessed entry.
+    /// Best for frequency-biased workloads like user profiles and product catalogs.
+    /// </summary>
+    LFU = 1,
+}

--- a/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
@@ -1,5 +1,7 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+using Valkey.Glide.TestUtils;
+
 namespace Valkey.Glide.IntegrationTests;
 
 /// <summary>
@@ -35,14 +37,12 @@ public class ClientSideCacheTests
         return await CreateStandaloneClientWithCache(cache);
     }
 
-    public static TheoryData<bool> ClusterModes => [false, true];
-
     #endregion
 
     #region Basic Cache Hit With Metrics
 
     [Theory]
-    [MemberData(nameof(ClusterModes))]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task BasicCacheHitWithMetrics(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
@@ -92,7 +92,7 @@ public class ClientSideCacheTests
     #region Without Metrics
 
     [Theory]
-    [MemberData(nameof(ClusterModes))]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task WithoutMetrics_MetricCallsFail(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
@@ -145,7 +145,7 @@ public class ClientSideCacheTests
     #region Multiple Keys
 
     [Theory]
-    [MemberData(nameof(ClusterModes))]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task MultipleKeys(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
@@ -191,7 +191,7 @@ public class ClientSideCacheTests
     #region TTL Expiration
 
     [Theory]
-    [MemberData(nameof(ClusterModes))]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task TTLExpiration(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1024, TimeSpan.FromSeconds(2))
@@ -235,7 +235,7 @@ public class ClientSideCacheTests
     #region Eviction Policy LRU
 
     [Theory]
-    [MemberData(nameof(ClusterModes))]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task EvictionPolicyLRU(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction
@@ -285,7 +285,7 @@ public class ClientSideCacheTests
     #region Eviction Policy LFU
 
     [Theory]
-    [MemberData(nameof(ClusterModes))]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task EvictionPolicyLFU(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction

--- a/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
@@ -238,14 +238,16 @@ public class ClientSideCacheTests
     [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task EvictionPolicyLRU(bool clusterMode)
     {
-        var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction
+        // Each entry: ~42 byte key + 1000 byte value ≈ ~1 KB with overhead.
+        // 4 KB cache fits 3 entries but not 5.
+        var cache = new ClientSideCacheConfig(4, TimeSpan.FromMinutes(10))
             .WithEvictionPolicy(EvictionPolicy.LRU)
             .WithMetrics(true);
 
         await using var client = await CreateClientWithCache(cache, clusterMode);
 
         string prefix = Guid.NewGuid().ToString();
-        string largeValue = new('x', 250); // ~250 bytes
+        string largeValue = new('x', 1000);
 
         // Set and cache 3 keys
         for (int i = 1; i <= 3; i++)
@@ -263,7 +265,7 @@ public class ClientSideCacheTests
         var retrieved = await client.GetAsync($"{prefix}_lru1");
         Assert.Equal(largeValue, retrieved.ToString());
 
-        // Add 2 more keys — should evict least recently used
+        // Add 2 more keys — should evict key2 and key3 (least recently used)
         for (int i = 4; i <= 5; i++)
         {
             await client.SetAsync($"{prefix}_lru{i}", largeValue);
@@ -271,13 +273,26 @@ public class ClientSideCacheTests
             Assert.Equal(largeValue, value.ToString());
         }
 
-        // Verify evictions occurred
+        // Verify 2 evictions occurred
         long evictions = await client.GetCacheEvictionsAsync();
         Assert.Equal(2, evictions);
 
-        // Hit rate should be > 0
+        // Verify cache is working (hit rate > 0)
         double hitRate = await client.GetCacheHitRateAsync();
         Assert.True(hitRate > 0.0);
+
+        // Check that key1 is still cached
+        retrieved = await client.GetAsync($"{prefix}_lru1");
+        Assert.Equal(largeValue, retrieved.ToString());
+        double newHitRate = await client.GetCacheHitRateAsync();
+        Assert.True(newHitRate > hitRate, "Key1 should still be in cache");
+
+        // Check that key2 and key3 are evicted (miss rate should increase)
+        double oldMissRate = await client.GetCacheMissRateAsync();
+        _ = await client.GetAsync($"{prefix}_lru2");
+        _ = await client.GetAsync($"{prefix}_lru3");
+        double newMissRate = await client.GetCacheMissRateAsync();
+        Assert.True(newMissRate > oldMissRate, "Key2 and Key3 should be evicted from cache");
     }
 
     #endregion
@@ -288,14 +303,16 @@ public class ClientSideCacheTests
     [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task EvictionPolicyLFU(bool clusterMode)
     {
-        var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction
+        // Each entry: ~42 byte key + 1000 byte value ≈ ~1 KB with overhead.
+        // 4 KB cache fits 3 entries but not 4.
+        var cache = new ClientSideCacheConfig(4, TimeSpan.FromMinutes(10))
             .WithEvictionPolicy(EvictionPolicy.LFU)
             .WithMetrics(true);
 
         await using var client = await CreateClientWithCache(cache, clusterMode);
 
         string prefix = Guid.NewGuid().ToString();
-        string largeValue = new('x', 250);
+        string largeValue = new('x', 1000);
 
         // Set key1 and access it multiple times (high frequency)
         await client.SetAsync($"{prefix}_key1", largeValue);
@@ -304,6 +321,7 @@ public class ClientSideCacheTests
             var value = await client.GetAsync($"{prefix}_key1");
             Assert.Equal(largeValue, value.ToString());
         }
+        // key1 frequency: 5
 
         // Set key2 with medium frequency
         await client.SetAsync($"{prefix}_key2", largeValue);
@@ -312,11 +330,17 @@ public class ClientSideCacheTests
             var value = await client.GetAsync($"{prefix}_key2");
             Assert.Equal(largeValue, value.ToString());
         }
+        // key2 frequency: 2
 
         // Set key3 with low frequency
         await client.SetAsync($"{prefix}_key3", largeValue);
         var retrieved = await client.GetAsync($"{prefix}_key3");
         Assert.Equal(largeValue, retrieved.ToString());
+        // key3 frequency: 1
+
+        // Verify cache is working
+        double hitRate = await client.GetCacheHitRateAsync();
+        Assert.True(hitRate > 0.0, "Cache should have some hits");
 
         // Cache should have 3 entries
         long entryCount = await client.GetCacheEntryCountAsync();
@@ -326,17 +350,36 @@ public class ClientSideCacheTests
         await client.SetAsync($"{prefix}_key4", largeValue);
         retrieved = await client.GetAsync($"{prefix}_key4");
         Assert.Equal(largeValue, retrieved.ToString());
+        // key4 frequency: 1
+
+        // Check that cache entry count is still 3
+        entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(3, entryCount);
 
         // Verify 1 eviction occurred
         long evictions = await client.GetCacheEvictionsAsync();
         Assert.Equal(1, evictions);
 
-        // key1 (highest frequency) should still be cached
+        // Check that key1 (highest frequency) is still cached
         double oldHitRate = await client.GetCacheHitRateAsync();
         retrieved = await client.GetAsync($"{prefix}_key1");
         Assert.Equal(largeValue, retrieved.ToString());
         double newHitRate = await client.GetCacheHitRateAsync();
-        Assert.True(newHitRate > oldHitRate);
+        Assert.True(newHitRate > oldHitRate, "key1 (highest frequency) should still be cached");
+
+        // Check that key3 (lowest frequency) was evicted
+        double oldMissRate = await client.GetCacheMissRateAsync();
+        retrieved = await client.GetAsync($"{prefix}_key3");
+        Assert.Equal(largeValue, retrieved.ToString());
+        double newMissRate = await client.GetCacheMissRateAsync();
+        Assert.True(newMissRate > oldMissRate, "key3 (lowest frequency) should have been evicted");
+
+        // key2 (medium frequency) should still be cached
+        oldHitRate = await client.GetCacheHitRateAsync();
+        retrieved = await client.GetAsync($"{prefix}_key2");
+        Assert.Equal(largeValue, retrieved.ToString());
+        newHitRate = await client.GetCacheHitRateAsync();
+        Assert.True(newHitRate > oldHitRate, "key2 (medium frequency) should still be cached");
     }
 
     #endregion

--- a/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
@@ -388,7 +388,7 @@ public class ClientSideCacheTests
         var config = new ClientSideCacheConfig(512);
 
         Assert.Equal(512UL, config.MaxCacheKb);
-        Assert.Null(config.EntryTtlMs);
+        Assert.Equal(0UL, config.EntryTtlMs);
         Assert.Null(config.EvictionPolicy);
         Assert.False(config.EnableMetrics);
     }

--- a/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
@@ -1,0 +1,397 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide.IntegrationTests;
+
+/// <summary>
+/// Integration tests for client-side caching configuration and metrics.
+/// </summary>
+public class ClientSideCacheTests
+{
+    #region Helpers
+
+    private static async Task<GlideClient> CreateStandaloneClientWithCache(ClientSideCacheConfig cache)
+    {
+        var config = TestConfiguration.DefaultClientConfig()
+            .WithClientSideCache(cache)
+            .Build();
+        return await GlideClient.CreateClient(config);
+    }
+
+    private static async Task<GlideClusterClient> CreateClusterClientWithCache(ClientSideCacheConfig cache)
+    {
+        var config = TestConfiguration.DefaultClusterClientConfig()
+            .WithClientSideCache(cache)
+            .Build();
+        return await GlideClusterClient.CreateClient(config);
+    }
+
+    #endregion
+
+    #region Basic Cache Hit With Metrics
+
+    [Fact]
+    public async Task BasicCacheHitWithMetrics_Standalone()
+    {
+        var cache = new ClientSideCacheConfig(1024)
+            .WithEntryTtlSeconds(60)
+            .WithMetrics(true);
+
+        await using var client = await CreateStandaloneClientWithCache(cache);
+
+        // SET a key
+        await client.SetAsync("cache_test_key", "cache_test_value");
+
+        // First GET — cache miss
+        var value = await client.GetAsync("cache_test_key");
+        Assert.Equal("cache_test_value", value.ToString());
+
+        // Entry count should be 1
+        long entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(1, entryCount);
+
+        // Second GET — cache hit
+        value = await client.GetAsync("cache_test_key");
+        Assert.Equal("cache_test_value", value.ToString());
+
+        // Third GET — cache hit
+        value = await client.GetAsync("cache_test_key");
+        Assert.Equal("cache_test_value", value.ToString());
+
+        // Verify metrics: 1 miss + 2 hits = 3 total
+        double hitRate = await client.GetCacheHitRateAsync();
+        Assert.InRange(hitRate, 2.0 / 3.0 - 0.001, 2.0 / 3.0 + 0.001);
+
+        double missRate = await client.GetCacheMissRateAsync();
+        Assert.InRange(missRate, 1.0 / 3.0 - 0.001, 1.0 / 3.0 + 0.001);
+
+        // Rates should sum to 1.0
+        Assert.InRange(hitRate + missRate, 0.9999, 1.0001);
+    }
+
+    [Fact]
+    public async Task BasicCacheHitWithMetrics_Cluster()
+    {
+        var cache = new ClientSideCacheConfig(1024)
+            .WithEntryTtlSeconds(60)
+            .WithMetrics(true);
+
+        await using var client = await CreateClusterClientWithCache(cache);
+
+        await client.SetAsync("cache_test_key", "cache_test_value");
+
+        // First GET — cache miss
+        var value = await client.GetAsync("cache_test_key");
+        Assert.Equal("cache_test_value", value.ToString());
+
+        long entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(1, entryCount);
+
+        // Second GET — cache hit
+        value = await client.GetAsync("cache_test_key");
+        Assert.Equal("cache_test_value", value.ToString());
+
+        // Third GET — cache hit
+        value = await client.GetAsync("cache_test_key");
+        Assert.Equal("cache_test_value", value.ToString());
+
+        double hitRate = await client.GetCacheHitRateAsync();
+        Assert.InRange(hitRate, 2.0 / 3.0 - 0.001, 2.0 / 3.0 + 0.001);
+
+        double missRate = await client.GetCacheMissRateAsync();
+        Assert.InRange(missRate, 1.0 / 3.0 - 0.001, 1.0 / 3.0 + 0.001);
+
+        Assert.InRange(hitRate + missRate, 0.9999, 1.0001);
+    }
+
+    #endregion
+
+    #region Without Metrics
+
+    [Fact]
+    public async Task WithoutMetrics_MetricCallsFail_Standalone()
+    {
+        var cache = new ClientSideCacheConfig(1024)
+            .WithEntryTtlSeconds(60)
+            .WithMetrics(false);
+
+        await using var client = await CreateStandaloneClientWithCache(cache);
+
+        // Cache should work
+        await client.SetAsync("key", "value");
+        var value = await client.GetAsync("key");
+        Assert.Equal("value", value.ToString());
+
+        // Second GET — from cache
+        value = await client.GetAsync("key");
+        Assert.Equal("value", value.ToString());
+
+        // Metrics that require EnableMetrics should fail
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheHitRateAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheMissRateAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheEvictionsAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheExpirationsAsync());
+
+        // Entry count should still work (doesn't require metrics)
+        long entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(1, entryCount);
+    }
+
+    #endregion
+
+    #region No Cache Configured
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(TestConfiguration.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task NoCacheConfigured_AllMetricsFail(BaseClient client)
+    {
+        // Without cache configured, all metric calls should fail
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheHitRateAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheMissRateAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheEntryCountAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheEvictionsAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheExpirationsAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheTotalLookupsAsync());
+    }
+
+    #endregion
+
+    #region Multiple Keys
+
+    [Fact]
+    public async Task MultipleKeys_Standalone()
+    {
+        var cache = new ClientSideCacheConfig(1024)
+            .WithEntryTtlSeconds(60)
+            .WithMetrics(true);
+
+        await using var client = await CreateStandaloneClientWithCache(cache);
+
+        // Set 3 keys
+        for (int i = 1; i <= 3; i++)
+        {
+            await client.SetAsync($"key{i}", $"value{i}");
+        }
+
+        // GET each key twice (miss + hit)
+        for (int i = 1; i <= 3; i++)
+        {
+            // First GET — miss
+            var value = await client.GetAsync($"key{i}");
+            Assert.Equal($"value{i}", value.ToString());
+
+            // Second GET — hit
+            value = await client.GetAsync($"key{i}");
+            Assert.Equal($"value{i}", value.ToString());
+        }
+
+        // Entry count should be 3
+        long entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(3, entryCount);
+
+        // 3 misses + 3 hits = 50% hit rate
+        double hitRate = await client.GetCacheHitRateAsync();
+        Assert.Equal(0.5, hitRate, precision: 3);
+    }
+
+    #endregion
+
+    #region TTL Expiration
+
+    [Fact]
+    public async Task TTLExpiration_Standalone()
+    {
+        var cache = new ClientSideCacheConfig(1024)
+            .WithEntryTtlSeconds(2) // 2 seconds
+            .WithMetrics(true);
+
+        await using var client = await CreateStandaloneClientWithCache(cache);
+
+        await client.SetAsync("ttl_key", "ttl_value");
+
+        // First GET — miss
+        var value = await client.GetAsync("ttl_key");
+        Assert.Equal("ttl_value", value.ToString());
+
+        long entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(1, entryCount);
+
+        // Second GET — from cache
+        value = await client.GetAsync("ttl_key");
+        Assert.Equal("ttl_value", value.ToString());
+
+        // Wait for TTL to expire
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        // GET after expiration — should fetch from server again
+        value = await client.GetAsync("ttl_key");
+        Assert.Equal("ttl_value", value.ToString());
+
+        // Expiration count should be 1
+        long expirations = await client.GetCacheExpirationsAsync();
+        Assert.Equal(1, expirations);
+
+        // Miss rate should be 2 misses out of 3 total = 66.67%
+        double missRate = await client.GetCacheMissRateAsync();
+        Assert.InRange(missRate, 2.0 / 3.0 - 0.001, 2.0 / 3.0 + 0.001);
+    }
+
+    #endregion
+
+    #region Eviction Policy LRU
+
+    [Fact]
+    public async Task EvictionPolicyLRU_Standalone()
+    {
+        var cache = new ClientSideCacheConfig(1) // 1 KB to force eviction
+            .WithEvictionPolicy(EvictionPolicy.LRU)
+            .WithMetrics(true);
+
+        await using var client = await CreateStandaloneClientWithCache(cache);
+
+        string largeValue = new('x', 250); // ~250 bytes
+
+        // Set and cache 3 keys
+        for (int i = 1; i <= 3; i++)
+        {
+            await client.SetAsync($"lru_key{i}", largeValue);
+            var value = await client.GetAsync($"lru_key{i}");
+            Assert.Equal(largeValue, value.ToString());
+        }
+
+        // Cache should have 3 entries
+        long entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(3, entryCount);
+
+        // Access key1 to make it recently used
+        var retrieved = await client.GetAsync("lru_key1");
+        Assert.Equal(largeValue, retrieved.ToString());
+
+        // Add 2 more keys — should evict least recently used
+        for (int i = 4; i <= 5; i++)
+        {
+            await client.SetAsync($"lru_key{i}", largeValue);
+            var value = await client.GetAsync($"lru_key{i}");
+            Assert.Equal(largeValue, value.ToString());
+        }
+
+        // Verify evictions occurred
+        long evictions = await client.GetCacheEvictionsAsync();
+        Assert.Equal(2, evictions);
+
+        // Hit rate should be > 0
+        double hitRate = await client.GetCacheHitRateAsync();
+        Assert.True(hitRate > 0.0);
+    }
+
+    #endregion
+
+    #region Eviction Policy LFU
+
+    [Fact]
+    public async Task EvictionPolicyLFU_Standalone()
+    {
+        var cache = new ClientSideCacheConfig(1) // 1 KB to force eviction
+            .WithEvictionPolicy(EvictionPolicy.LFU)
+            .WithMetrics(true);
+
+        await using var client = await CreateStandaloneClientWithCache(cache);
+
+        string largeValue = new('x', 250);
+
+        // Set key1 and access it multiple times (high frequency)
+        await client.SetAsync("key1", largeValue);
+        for (int i = 0; i < 5; i++)
+        {
+            var value = await client.GetAsync("key1");
+            Assert.Equal(largeValue, value.ToString());
+        }
+
+        // Set key2 with medium frequency
+        await client.SetAsync("key2", largeValue);
+        for (int i = 0; i < 2; i++)
+        {
+            var value = await client.GetAsync("key2");
+            Assert.Equal(largeValue, value.ToString());
+        }
+
+        // Set key3 with low frequency
+        await client.SetAsync("key3", largeValue);
+        var retrieved = await client.GetAsync("key3");
+        Assert.Equal(largeValue, retrieved.ToString());
+
+        // Cache should have 3 entries
+        long entryCount = await client.GetCacheEntryCountAsync();
+        Assert.Equal(3, entryCount);
+
+        // Set key4 — should trigger eviction of key3 (lowest frequency)
+        await client.SetAsync("key4", largeValue);
+        retrieved = await client.GetAsync("key4");
+        Assert.Equal(largeValue, retrieved.ToString());
+
+        // Verify 1 eviction occurred
+        long evictions = await client.GetCacheEvictionsAsync();
+        Assert.Equal(1, evictions);
+
+        // key1 (highest frequency) should still be cached
+        double oldHitRate = await client.GetCacheHitRateAsync();
+        retrieved = await client.GetAsync("key1");
+        Assert.Equal(largeValue, retrieved.ToString());
+        double newHitRate = await client.GetCacheHitRateAsync();
+        Assert.True(newHitRate > oldHitRate);
+    }
+
+    #endregion
+
+    #region Config Validation
+
+    [Fact]
+    public void ClientSideCacheConfig_MaxCacheKbMustBePositive()
+    {
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => new ClientSideCacheConfig(0));
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_EntryTtlSecondsMustBePositive()
+    {
+        var config = new ClientSideCacheConfig(1024);
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => config.WithEntryTtlSeconds(0));
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_FluentBuilderChaining()
+    {
+        var config = new ClientSideCacheConfig(2048)
+            .WithEntryTtlSeconds(120)
+            .WithEvictionPolicy(EvictionPolicy.LFU)
+            .WithMetrics(true);
+
+        Assert.Equal(2048UL, config.MaxCacheKb);
+        Assert.Equal(120UL, config.EntryTtlSeconds);
+        Assert.Equal(EvictionPolicy.LFU, config.EvictionPolicy);
+        Assert.True(config.EnableMetrics);
+        Assert.NotNull(config.CacheId);
+        Assert.NotEmpty(config.CacheId);
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_UniqueCacheIds()
+    {
+        var config1 = new ClientSideCacheConfig(1024);
+        var config2 = new ClientSideCacheConfig(1024);
+
+        Assert.NotEqual(config1.CacheId, config2.CacheId);
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_DefaultValues()
+    {
+        var config = new ClientSideCacheConfig(512);
+
+        Assert.Equal(512UL, config.MaxCacheKb);
+        Assert.Null(config.EntryTtlSeconds);
+        Assert.Null(config.EvictionPolicy);
+        Assert.False(config.EnableMetrics);
+    }
+
+    #endregion
+}

--- a/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
@@ -190,13 +190,14 @@ public class ClientSideCacheTests
 
     #region TTL Expiration
 
-    [Fact]
-    public async Task TTLExpiration_Standalone()
+    [Theory]
+    [MemberData(nameof(ClusterModes))]
+    public async Task TTLExpiration(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1024, TimeSpan.FromSeconds(2))
             .WithMetrics(true);
 
-        await using var client = await CreateStandaloneClientWithCache(cache);
+        await using var client = await CreateClientWithCache(cache, clusterMode);
 
         string key = $"ttl_{Guid.NewGuid()}";
 
@@ -233,14 +234,15 @@ public class ClientSideCacheTests
 
     #region Eviction Policy LRU
 
-    [Fact]
-    public async Task EvictionPolicyLRU_Standalone()
+    [Theory]
+    [MemberData(nameof(ClusterModes))]
+    public async Task EvictionPolicyLRU(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction
             .WithEvictionPolicy(EvictionPolicy.LRU)
             .WithMetrics(true);
 
-        await using var client = await CreateStandaloneClientWithCache(cache);
+        await using var client = await CreateClientWithCache(cache, clusterMode);
 
         string prefix = Guid.NewGuid().ToString();
         string largeValue = new('x', 250); // ~250 bytes
@@ -282,14 +284,15 @@ public class ClientSideCacheTests
 
     #region Eviction Policy LFU
 
-    [Fact]
-    public async Task EvictionPolicyLFU_Standalone()
+    [Theory]
+    [MemberData(nameof(ClusterModes))]
+    public async Task EvictionPolicyLFU(bool clusterMode)
     {
         var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction
             .WithEvictionPolicy(EvictionPolicy.LFU)
             .WithMetrics(true);
 
-        await using var client = await CreateStandaloneClientWithCache(cache);
+        await using var client = await CreateClientWithCache(cache, clusterMode);
 
         string prefix = Guid.NewGuid().ToString();
         string largeValue = new('x', 250);

--- a/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
@@ -33,7 +33,7 @@ public class ClientSideCacheTests
     public async Task BasicCacheHitWithMetrics_Standalone()
     {
         var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlSeconds(60)
+            .WithEntryTtlMs(60000)
             .WithMetrics(true);
 
         await using var client = await CreateStandaloneClientWithCache(cache);
@@ -72,7 +72,7 @@ public class ClientSideCacheTests
     public async Task BasicCacheHitWithMetrics_Cluster()
     {
         var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlSeconds(60)
+            .WithEntryTtlMs(60000)
             .WithMetrics(true);
 
         await using var client = await CreateClusterClientWithCache(cache);
@@ -111,7 +111,7 @@ public class ClientSideCacheTests
     public async Task WithoutMetrics_MetricCallsFail_Standalone()
     {
         var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlSeconds(60)
+            .WithEntryTtlMs(60000)
             .WithMetrics(false);
 
         await using var client = await CreateStandaloneClientWithCache(cache);
@@ -161,7 +161,7 @@ public class ClientSideCacheTests
     public async Task MultipleKeys_Standalone()
     {
         var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlSeconds(60)
+            .WithEntryTtlMs(60000)
             .WithMetrics(true);
 
         await using var client = await CreateStandaloneClientWithCache(cache);
@@ -201,7 +201,7 @@ public class ClientSideCacheTests
     public async Task TTLExpiration_Standalone()
     {
         var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlSeconds(2) // 2 seconds
+            .WithEntryTtlMs(2000) // 2 seconds
             .WithMetrics(true);
 
         await using var client = await CreateStandaloneClientWithCache(cache);
@@ -351,22 +351,22 @@ public class ClientSideCacheTests
     }
 
     [Fact]
-    public void ClientSideCacheConfig_EntryTtlSecondsMustBePositive()
+    public void ClientSideCacheConfig_EntryTtlMsMustBePositive()
     {
         var config = new ClientSideCacheConfig(1024);
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => config.WithEntryTtlSeconds(0));
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => config.WithEntryTtlMs(0));
     }
 
     [Fact]
     public void ClientSideCacheConfig_FluentBuilderChaining()
     {
         var config = new ClientSideCacheConfig(2048)
-            .WithEntryTtlSeconds(120)
+            .WithEntryTtlMs(120000)
             .WithEvictionPolicy(EvictionPolicy.LFU)
             .WithMetrics(true);
 
         Assert.Equal(2048UL, config.MaxCacheKb);
-        Assert.Equal(120UL, config.EntryTtlSeconds);
+        Assert.Equal(120000UL, config.EntryTtlMs);
         Assert.Equal(EvictionPolicy.LFU, config.EvictionPolicy);
         Assert.True(config.EnableMetrics);
         Assert.NotNull(config.CacheId);
@@ -388,7 +388,7 @@ public class ClientSideCacheTests
         var config = new ClientSideCacheConfig(512);
 
         Assert.Equal(512UL, config.MaxCacheKb);
-        Assert.Null(config.EntryTtlSeconds);
+        Assert.Null(config.EntryTtlMs);
         Assert.Null(config.EvictionPolicy);
         Assert.False(config.EnableMetrics);
     }

--- a/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientSideCacheTests.cs
@@ -25,104 +25,90 @@ public class ClientSideCacheTests
         return await GlideClusterClient.CreateClient(config);
     }
 
+    private static async Task<BaseClient> CreateClientWithCache(ClientSideCacheConfig cache, bool clusterMode)
+    {
+        if (clusterMode)
+        {
+            return await CreateClusterClientWithCache(cache);
+        }
+
+        return await CreateStandaloneClientWithCache(cache);
+    }
+
+    public static TheoryData<bool> ClusterModes => [false, true];
+
     #endregion
 
     #region Basic Cache Hit With Metrics
 
-    [Fact]
-    public async Task BasicCacheHitWithMetrics_Standalone()
+    [Theory]
+    [MemberData(nameof(ClusterModes))]
+    public async Task BasicCacheHitWithMetrics(bool clusterMode)
     {
-        var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlMs(60000)
+        var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
             .WithMetrics(true);
 
-        await using var client = await CreateStandaloneClientWithCache(cache);
+        await using var client = await CreateClientWithCache(cache, clusterMode);
+
+        string key = $"cache_test_{Guid.NewGuid()}";
+        string expectedValue = Guid.NewGuid().ToString();
 
         // SET a key
-        await client.SetAsync("cache_test_key", "cache_test_value");
+        await client.SetAsync(key, expectedValue);
 
         // First GET — cache miss
-        var value = await client.GetAsync("cache_test_key");
-        Assert.Equal("cache_test_value", value.ToString());
+        var value = await client.GetAsync(key);
+        Assert.Equal(expectedValue, value.ToString());
 
         // Entry count should be 1
         long entryCount = await client.GetCacheEntryCountAsync();
         Assert.Equal(1, entryCount);
 
         // Second GET — cache hit
-        value = await client.GetAsync("cache_test_key");
-        Assert.Equal("cache_test_value", value.ToString());
+        value = await client.GetAsync(key);
+        Assert.Equal(expectedValue, value.ToString());
 
         // Third GET — cache hit
-        value = await client.GetAsync("cache_test_key");
-        Assert.Equal("cache_test_value", value.ToString());
+        value = await client.GetAsync(key);
+        Assert.Equal(expectedValue, value.ToString());
 
         // Verify metrics: 1 miss + 2 hits = 3 total
         double hitRate = await client.GetCacheHitRateAsync();
-        Assert.InRange(hitRate, 2.0 / 3.0 - 0.001, 2.0 / 3.0 + 0.001);
+        Assert.Equal(2.0 / 3.0, hitRate, precision: 3);
 
         double missRate = await client.GetCacheMissRateAsync();
-        Assert.InRange(missRate, 1.0 / 3.0 - 0.001, 1.0 / 3.0 + 0.001);
+        Assert.Equal(1.0 / 3.0, missRate, precision: 3);
 
         // Rates should sum to 1.0
-        Assert.InRange(hitRate + missRate, 0.9999, 1.0001);
-    }
+        Assert.Equal(1.0, hitRate + missRate, precision: 3);
 
-    [Fact]
-    public async Task BasicCacheHitWithMetrics_Cluster()
-    {
-        var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlMs(60000)
-            .WithMetrics(true);
-
-        await using var client = await CreateClusterClientWithCache(cache);
-
-        await client.SetAsync("cache_test_key", "cache_test_value");
-
-        // First GET — cache miss
-        var value = await client.GetAsync("cache_test_key");
-        Assert.Equal("cache_test_value", value.ToString());
-
-        long entryCount = await client.GetCacheEntryCountAsync();
-        Assert.Equal(1, entryCount);
-
-        // Second GET — cache hit
-        value = await client.GetAsync("cache_test_key");
-        Assert.Equal("cache_test_value", value.ToString());
-
-        // Third GET — cache hit
-        value = await client.GetAsync("cache_test_key");
-        Assert.Equal("cache_test_value", value.ToString());
-
-        double hitRate = await client.GetCacheHitRateAsync();
-        Assert.InRange(hitRate, 2.0 / 3.0 - 0.001, 2.0 / 3.0 + 0.001);
-
-        double missRate = await client.GetCacheMissRateAsync();
-        Assert.InRange(missRate, 1.0 / 3.0 - 0.001, 1.0 / 3.0 + 0.001);
-
-        Assert.InRange(hitRate + missRate, 0.9999, 1.0001);
+        // Total lookups should be 3
+        long totalLookups = await client.GetCacheTotalLookupsAsync();
+        Assert.Equal(3, totalLookups);
     }
 
     #endregion
 
     #region Without Metrics
 
-    [Fact]
-    public async Task WithoutMetrics_MetricCallsFail_Standalone()
+    [Theory]
+    [MemberData(nameof(ClusterModes))]
+    public async Task WithoutMetrics_MetricCallsFail(bool clusterMode)
     {
-        var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlMs(60000)
+        var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
             .WithMetrics(false);
 
-        await using var client = await CreateStandaloneClientWithCache(cache);
+        await using var client = await CreateClientWithCache(cache, clusterMode);
+
+        string key = $"no_metrics_{Guid.NewGuid()}";
 
         // Cache should work
-        await client.SetAsync("key", "value");
-        var value = await client.GetAsync("key");
+        await client.SetAsync(key, "value");
+        var value = await client.GetAsync(key);
         Assert.Equal("value", value.ToString());
 
         // Second GET — from cache
-        value = await client.GetAsync("key");
+        value = await client.GetAsync(key);
         Assert.Equal("value", value.ToString());
 
         // Metrics that require EnableMetrics should fail
@@ -130,6 +116,7 @@ public class ClientSideCacheTests
         _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheMissRateAsync());
         _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheEvictionsAsync());
         _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheExpirationsAsync());
+        _ = await Assert.ThrowsAsync<Errors.RequestException>(() => client.GetCacheTotalLookupsAsync());
 
         // Entry count should still work (doesn't require metrics)
         long entryCount = await client.GetCacheEntryCountAsync();
@@ -157,30 +144,32 @@ public class ClientSideCacheTests
 
     #region Multiple Keys
 
-    [Fact]
-    public async Task MultipleKeys_Standalone()
+    [Theory]
+    [MemberData(nameof(ClusterModes))]
+    public async Task MultipleKeys(bool clusterMode)
     {
-        var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlMs(60000)
+        var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))
             .WithMetrics(true);
 
-        await using var client = await CreateStandaloneClientWithCache(cache);
+        await using var client = await CreateClientWithCache(cache, clusterMode);
+
+        string prefix = Guid.NewGuid().ToString();
 
         // Set 3 keys
         for (int i = 1; i <= 3; i++)
         {
-            await client.SetAsync($"key{i}", $"value{i}");
+            await client.SetAsync($"{prefix}_key{i}", $"value{i}");
         }
 
         // GET each key twice (miss + hit)
         for (int i = 1; i <= 3; i++)
         {
             // First GET — miss
-            var value = await client.GetAsync($"key{i}");
+            var value = await client.GetAsync($"{prefix}_key{i}");
             Assert.Equal($"value{i}", value.ToString());
 
             // Second GET — hit
-            value = await client.GetAsync($"key{i}");
+            value = await client.GetAsync($"{prefix}_key{i}");
             Assert.Equal($"value{i}", value.ToString());
         }
 
@@ -191,6 +180,10 @@ public class ClientSideCacheTests
         // 3 misses + 3 hits = 50% hit rate
         double hitRate = await client.GetCacheHitRateAsync();
         Assert.Equal(0.5, hitRate, precision: 3);
+
+        // Total lookups should be 6
+        long totalLookups = await client.GetCacheTotalLookupsAsync();
+        Assert.Equal(6, totalLookups);
     }
 
     #endregion
@@ -200,30 +193,31 @@ public class ClientSideCacheTests
     [Fact]
     public async Task TTLExpiration_Standalone()
     {
-        var cache = new ClientSideCacheConfig(1024)
-            .WithEntryTtlMs(2000) // 2 seconds
+        var cache = new ClientSideCacheConfig(1024, TimeSpan.FromSeconds(2))
             .WithMetrics(true);
 
         await using var client = await CreateStandaloneClientWithCache(cache);
 
-        await client.SetAsync("ttl_key", "ttl_value");
+        string key = $"ttl_{Guid.NewGuid()}";
+
+        await client.SetAsync(key, "ttl_value");
 
         // First GET — miss
-        var value = await client.GetAsync("ttl_key");
+        var value = await client.GetAsync(key);
         Assert.Equal("ttl_value", value.ToString());
 
         long entryCount = await client.GetCacheEntryCountAsync();
         Assert.Equal(1, entryCount);
 
         // Second GET — from cache
-        value = await client.GetAsync("ttl_key");
+        value = await client.GetAsync(key);
         Assert.Equal("ttl_value", value.ToString());
 
         // Wait for TTL to expire
         await Task.Delay(TimeSpan.FromSeconds(3));
 
         // GET after expiration — should fetch from server again
-        value = await client.GetAsync("ttl_key");
+        value = await client.GetAsync(key);
         Assert.Equal("ttl_value", value.ToString());
 
         // Expiration count should be 1
@@ -232,7 +226,7 @@ public class ClientSideCacheTests
 
         // Miss rate should be 2 misses out of 3 total = 66.67%
         double missRate = await client.GetCacheMissRateAsync();
-        Assert.InRange(missRate, 2.0 / 3.0 - 0.001, 2.0 / 3.0 + 0.001);
+        Assert.Equal(2.0 / 3.0, missRate, precision: 3);
     }
 
     #endregion
@@ -242,19 +236,20 @@ public class ClientSideCacheTests
     [Fact]
     public async Task EvictionPolicyLRU_Standalone()
     {
-        var cache = new ClientSideCacheConfig(1) // 1 KB to force eviction
+        var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction
             .WithEvictionPolicy(EvictionPolicy.LRU)
             .WithMetrics(true);
 
         await using var client = await CreateStandaloneClientWithCache(cache);
 
+        string prefix = Guid.NewGuid().ToString();
         string largeValue = new('x', 250); // ~250 bytes
 
         // Set and cache 3 keys
         for (int i = 1; i <= 3; i++)
         {
-            await client.SetAsync($"lru_key{i}", largeValue);
-            var value = await client.GetAsync($"lru_key{i}");
+            await client.SetAsync($"{prefix}_lru{i}", largeValue);
+            var value = await client.GetAsync($"{prefix}_lru{i}");
             Assert.Equal(largeValue, value.ToString());
         }
 
@@ -263,14 +258,14 @@ public class ClientSideCacheTests
         Assert.Equal(3, entryCount);
 
         // Access key1 to make it recently used
-        var retrieved = await client.GetAsync("lru_key1");
+        var retrieved = await client.GetAsync($"{prefix}_lru1");
         Assert.Equal(largeValue, retrieved.ToString());
 
         // Add 2 more keys — should evict least recently used
         for (int i = 4; i <= 5; i++)
         {
-            await client.SetAsync($"lru_key{i}", largeValue);
-            var value = await client.GetAsync($"lru_key{i}");
+            await client.SetAsync($"{prefix}_lru{i}", largeValue);
+            var value = await client.GetAsync($"{prefix}_lru{i}");
             Assert.Equal(largeValue, value.ToString());
         }
 
@@ -290,33 +285,34 @@ public class ClientSideCacheTests
     [Fact]
     public async Task EvictionPolicyLFU_Standalone()
     {
-        var cache = new ClientSideCacheConfig(1) // 1 KB to force eviction
+        var cache = new ClientSideCacheConfig(1, TimeSpan.FromMinutes(1)) // 1 KB to force eviction
             .WithEvictionPolicy(EvictionPolicy.LFU)
             .WithMetrics(true);
 
         await using var client = await CreateStandaloneClientWithCache(cache);
 
+        string prefix = Guid.NewGuid().ToString();
         string largeValue = new('x', 250);
 
         // Set key1 and access it multiple times (high frequency)
-        await client.SetAsync("key1", largeValue);
+        await client.SetAsync($"{prefix}_key1", largeValue);
         for (int i = 0; i < 5; i++)
         {
-            var value = await client.GetAsync("key1");
+            var value = await client.GetAsync($"{prefix}_key1");
             Assert.Equal(largeValue, value.ToString());
         }
 
         // Set key2 with medium frequency
-        await client.SetAsync("key2", largeValue);
+        await client.SetAsync($"{prefix}_key2", largeValue);
         for (int i = 0; i < 2; i++)
         {
-            var value = await client.GetAsync("key2");
+            var value = await client.GetAsync($"{prefix}_key2");
             Assert.Equal(largeValue, value.ToString());
         }
 
         // Set key3 with low frequency
-        await client.SetAsync("key3", largeValue);
-        var retrieved = await client.GetAsync("key3");
+        await client.SetAsync($"{prefix}_key3", largeValue);
+        var retrieved = await client.GetAsync($"{prefix}_key3");
         Assert.Equal(largeValue, retrieved.ToString());
 
         // Cache should have 3 entries
@@ -324,8 +320,8 @@ public class ClientSideCacheTests
         Assert.Equal(3, entryCount);
 
         // Set key4 — should trigger eviction of key3 (lowest frequency)
-        await client.SetAsync("key4", largeValue);
-        retrieved = await client.GetAsync("key4");
+        await client.SetAsync($"{prefix}_key4", largeValue);
+        retrieved = await client.GetAsync($"{prefix}_key4");
         Assert.Equal(largeValue, retrieved.ToString());
 
         // Verify 1 eviction occurred
@@ -334,63 +330,10 @@ public class ClientSideCacheTests
 
         // key1 (highest frequency) should still be cached
         double oldHitRate = await client.GetCacheHitRateAsync();
-        retrieved = await client.GetAsync("key1");
+        retrieved = await client.GetAsync($"{prefix}_key1");
         Assert.Equal(largeValue, retrieved.ToString());
         double newHitRate = await client.GetCacheHitRateAsync();
         Assert.True(newHitRate > oldHitRate);
-    }
-
-    #endregion
-
-    #region Config Validation
-
-    [Fact]
-    public void ClientSideCacheConfig_MaxCacheKbMustBePositive()
-    {
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => new ClientSideCacheConfig(0));
-    }
-
-    [Fact]
-    public void ClientSideCacheConfig_EntryTtlMsMustBePositive()
-    {
-        var config = new ClientSideCacheConfig(1024);
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => config.WithEntryTtlMs(0));
-    }
-
-    [Fact]
-    public void ClientSideCacheConfig_FluentBuilderChaining()
-    {
-        var config = new ClientSideCacheConfig(2048)
-            .WithEntryTtlMs(120000)
-            .WithEvictionPolicy(EvictionPolicy.LFU)
-            .WithMetrics(true);
-
-        Assert.Equal(2048UL, config.MaxCacheKb);
-        Assert.Equal(120000UL, config.EntryTtlMs);
-        Assert.Equal(EvictionPolicy.LFU, config.EvictionPolicy);
-        Assert.True(config.EnableMetrics);
-        Assert.NotNull(config.CacheId);
-        Assert.NotEmpty(config.CacheId);
-    }
-
-    [Fact]
-    public void ClientSideCacheConfig_UniqueCacheIds()
-    {
-        var config1 = new ClientSideCacheConfig(1024);
-        var config2 = new ClientSideCacheConfig(1024);
-
-        Assert.NotEqual(config1.CacheId, config2.CacheId);
-    }
-
-    [Fact]
-    public void ClientSideCacheConfig_DefaultValues()
-    {
-        var config = new ClientSideCacheConfig(512);
-
-        Assert.Equal(512UL, config.MaxCacheKb);
-        Assert.Equal(0UL, config.EntryTtlMs);
-        Assert.Null(config.EvictionPolicy);
-        Assert.False(config.EnableMetrics);
     }
 
     #endregion

--- a/tests/Valkey.Glide.UnitTests/ClientSideCacheConfigTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ClientSideCacheConfigTests.cs
@@ -1,0 +1,59 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide.Tests;
+
+public class ClientSideCacheConfigTests
+{
+    [Fact]
+    public void ClientSideCacheConfig_MaxCacheKbMustBePositive()
+    {
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => new ClientSideCacheConfig(0, TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_EntryTtlMustNotBeNegative()
+    {
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => new ClientSideCacheConfig(1024, TimeSpan.FromMilliseconds(-1)));
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_EntryTtlZeroIsAllowed()
+    {
+        var config = new ClientSideCacheConfig(1024, TimeSpan.Zero);
+
+        Assert.Equal(TimeSpan.Zero, config.EntryTtl);
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_FluentBuilderChaining()
+    {
+        var config = new ClientSideCacheConfig(2048, TimeSpan.FromMinutes(2))
+            .WithEvictionPolicy(EvictionPolicy.LFU)
+            .WithMetrics(true);
+
+        Assert.Equal(2048UL, config.MaxCacheKb);
+        Assert.Equal(TimeSpan.FromMinutes(2), config.EntryTtl);
+        Assert.Equal(EvictionPolicy.LFU, config.EvictionPolicy);
+        Assert.True(config.EnableMetrics);
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_UniqueCacheIds()
+    {
+        var config1 = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1));
+        var config2 = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1));
+
+        Assert.NotEqual(config1.CacheId, config2.CacheId);
+    }
+
+    [Fact]
+    public void ClientSideCacheConfig_DefaultValues()
+    {
+        var config = new ClientSideCacheConfig(512, TimeSpan.FromSeconds(30));
+
+        Assert.Equal(512UL, config.MaxCacheKb);
+        Assert.Equal(TimeSpan.FromSeconds(30), config.EntryTtl);
+        Assert.Equal(EvictionPolicy.LRU, config.EvictionPolicy);
+        Assert.False(config.EnableMetrics);
+    }
+}

--- a/tests/Valkey.Glide.UnitTests/ClientSideCacheConfigTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ClientSideCacheConfigTests.cs
@@ -13,7 +13,7 @@ public class ClientSideCacheConfigTests
     [Fact]
     public void ClientSideCacheConfig_EntryTtlMustNotBeNegative()
     {
-        _ = Assert.Throws<ArgumentOutOfRangeException>(() => new ClientSideCacheConfig(1024, TimeSpan.FromMilliseconds(-1)));
+        _ = Assert.Throws<ArgumentException>(() => new ClientSideCacheConfig(1024, TimeSpan.FromMilliseconds(-1)));
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class ClientSideCacheConfigTests
 
         Assert.Equal(512UL, config.MaxCacheKb);
         Assert.Equal(TimeSpan.FromSeconds(30), config.EntryTtl);
-        Assert.Equal(EvictionPolicy.LRU, config.EvictionPolicy);
+        Assert.Null(config.EvictionPolicy);
         Assert.False(config.EnableMetrics);
     }
 }


### PR DESCRIPTION
### Summary

Add client-side caching support to the C# GLIDE client. This includes configuration, FFI, cache metric commands, and integration tests.

### Issue Link

Closes #342

### Features and Behaviour Changes

- New `ClientSideCacheConfig` class for configuring TTL-based local caching of read commands (GET, HGETALL, SMEMBERS)
- New `EvictionPolicy` enum (LRU, LFU)
- `WithClientSideCache()` builder method on both `StandaloneClientConfigurationBuilder` and `ClusterClientConfigurationBuilder`
- Cache metric methods on `BaseClient`:
  - `GetCacheHitRateAsync()` / `GetCacheMissRateAsync()` — rates (0.0–1.0)
  - `GetCacheEntryCountAsync()` — current entry count
  - `GetCacheEvictionsAsync()` / `GetCacheExpirationsAsync()` / `GetCacheTotalLookupsAsync()` — counters

### Implementation

- **C# config**: `ClientSideCacheConfig.cs` with fluent builder, auto-generated unique cache IDs, and `ToFfi()` marshalling
- **C# FFI**: Added `ClientSideCacheConfig` struct and `CacheMetricsType` enum to `FFI.structs.cs`, `GetCacheMetricsFfi` to `FFI.methods.cs`
- **C# client**: `BaseClient.ClientSideCacheCommands.cs` implements metrics via message container + FFI callback pattern
- **Rust FFI** (`rust/src/ffi.rs`): Added `ClientSideCacheConfig` and `EvictionPolicy` structs, wired into `ConnectionConfig` and `create_connection_request()`
- **Rust lib** (`rust/src/lib.rs`): Added `get_cache_metrics` FFI function that calls glide-core's `cache_hit_rate()`, `cache_miss_rate()`, etc.
- **ConnectionConfiguration**: Added `ClientSideCacheConfig?` field to internal `ConnectionConfig` record and `WithClientSideCache()` to the builder

### Limitations

- Only TTL-based caching is supported (no server-driven invalidation via `CLIENT TRACKING`)
- Lazy eviction only — expired entries are removed on access, not proactively
- Only GET, HGETALL, and SMEMBERS responses are cached (determined by glide-core)
- No StackExchange.Redis equivalent — this is a GLIDE-specific feature

### Testing

- new integration tests:
  - Basic cache hit/miss with metrics verification
  - Metrics disabled — rate calls throw, entry count still works
  - No cache configured — all metric calls throw
  - Multiple keys with hit rate validation
  - TTL expiration with expiration counter verification
  - LRU eviction policy behavior
  - LFU eviction policy behavior
  - Config validation (positive values, unique IDs, defaults, fluent chaining)

### Related Issues

⚪ None

### Checklist


- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
