### PR TITLE
fix(cd): Patch TestUtils project reference in CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -253,11 +253,14 @@ jobs:
                   fi
 
             - name: Patch IT suite to run tests using freshly published version
-              working-directory: tests/Valkey.Glide.IntegrationTests
               shell: bash
               run: |
-                  dotnet remove reference ../../sources/Valkey.Glide/Valkey.Glide.csproj
-                  dotnet add package Valkey.Glide --version $RELEASE_VERSION
+                  # Remove local project references to Valkey.Glide
+                  dotnet remove tests/Valkey.Glide.TestUtils reference sources/Valkey.Glide/Valkey.Glide.csproj
+                  dotnet remove tests/Valkey.Glide.IntegrationTests reference sources/Valkey.Glide/Valkey.Glide.csproj
+                  # Replace with the published NuGet package
+                  dotnet add tests/Valkey.Glide.TestUtils package Valkey.Glide --version $RELEASE_VERSION
+                  dotnet add tests/Valkey.Glide.IntegrationTests package Valkey.Glide --version $RELEASE_VERSION
                   git diff
 
             - name: Install server


### PR DESCRIPTION
### Summary

Fix the CD workflow to also patch the `TestUtils` project reference when swapping local project references for the published NuGet package. Without this, `TestUtils` retains its reference to `Valkey.Glide` version `255.255.255` (from the local csproj), causing a `NU1605` package downgrade error when the integration tests reference the published version.

### Issue Link

:white_circle: None (discovered during RC2 CD testing).

### Features and Behaviour Changes

The CD patch step now:

1. Removes the `Valkey.Glide` project reference from both `TestUtils` and `IntegrationTests`.
2. Adds the published NuGet package to both projects.

### Implementation

```diff
- working-directory: tests/Valkey.Glide.IntegrationTests
  shell: bash
  run: |
-     dotnet remove reference ../../sources/Valkey.Glide/Valkey.Glide.csproj
-     dotnet add package Valkey.Glide --version $RELEASE_VERSION
+     # Remove local project references to Valkey.Glide
+     dotnet remove tests/Valkey.Glide.TestUtils reference sources/Valkey.Glide/Valkey.Glide.csproj
+     dotnet remove tests/Valkey.Glide.IntegrationTests reference sources/Valkey.Glide/Valkey.Glide.csproj
+     # Replace with the published NuGet package
+     dotnet add tests/Valkey.Glide.TestUtils package Valkey.Glide --version $RELEASE_VERSION
+     dotnet add tests/Valkey.Glide.IntegrationTests package Valkey.Glide --version $RELEASE_VERSION
      git diff
```

### Limitations

:white_circle: None.

### Testing

Verify the CD workflow completes successfully with no `NU1605` errors.

### Related

- #329 — Previous CD fix (removed only the `Valkey.Glide` reference, but missed `TestUtils`).

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] ~~Create merge commit if merging release branch into `main`~~, squash otherwise.