### PR TITLE
fix(cd): Add WSL setup and fix `LOLWUT` assertions for CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -263,8 +263,15 @@ jobs:
                   dotnet add tests/Valkey.Glide.IntegrationTests package Valkey.Glide --version $RELEASE_VERSION
                   git diff
 
+            - name: Setup WSL (Windows only)
+              # WSL2 is not available on windows-11-arm runners (no Hyper-V).
+              if: ${{ matrix.host.OS == 'windows' && matrix.host.ARCH != 'arm64' }}
+              uses: Vampire/setup-wsl@v7
+              with:
+                  distribution: Ubuntu-22.04
+
             - name: Install server
-              # WSL2 is not available on windows-11-arm runners (no Hyper-V), so we cannot run Valkey server there.
+              # WSL2 is not available on windows-11-arm runners (no Hyper-V).
               if: ${{ !(matrix.host.OS == 'windows' && matrix.host.ARCH == 'arm64') }}
               uses: ./.github/workflows/install-server
               with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -269,6 +269,7 @@ jobs:
               uses: Vampire/setup-wsl@v7
               with:
                   distribution: Ubuntu-22.04
+                  additional-packages: build-essential git make pkg-config libssl-dev
 
             - name: Install server
               # WSL2 is not available on windows-11-arm runners (no Hyper-V).

--- a/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
@@ -10,7 +10,7 @@ namespace Valkey.Glide.IntegrationTests;
 /// </summary>
 [Collection(typeof(ServerManagementCommandTests))]
 [CollectionDefinition(DisableParallelization = true)]
-public class ServerManagementCommandTests(ServerManagementFixture fixture) : IClassFixture<ServerManagementFixture>
+public class ServerManagementCommandTests(ServerManagementCommandFixture fixture) : IClassFixture<ServerManagementCommandFixture>
 {
     private GlideClient StandaloneClient => fixture.StandaloneClient!;
     private GlideClusterClient ClusterClient => fixture.ClusterClient!;
@@ -135,7 +135,7 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     {
         string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5 });
         Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
+        AssertContainsServerName(result);
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     {
         string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] });
         Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
+        AssertContainsServerName(result);
     }
 
     [Fact]
@@ -151,7 +151,7 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     {
         string result = await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5 });
         Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
+        AssertContainsServerName(result);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     {
         string result = await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] });
         Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
+        AssertContainsServerName(result);
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     {
         string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] });
         Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
+        AssertContainsServerName(result);
     }
 
     [Fact]
@@ -175,7 +175,7 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     {
         string result = await ClusterClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] });
         Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
+        AssertContainsServerName(result);
     }
 
     #endregion
@@ -366,13 +366,20 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     }
 
     #endregion
+
+    /// <summary>
+    /// Asserts that the result contains the expected server name.
+    /// </summary>
+    /// <param name="result"></param>
+    private static void AssertContainsServerName(string result)
+        => Assert.Contains(["VALKEY", "REDIS"], name => result.Contains(name, StringComparison.OrdinalIgnoreCase));
 }
 
 /// <summary>
 /// Fixture that provides isolated Valkey server instances for server management tests.
 /// Tests that call FlushAll/FlushDB need their own servers to avoid interfering with other tests.
 /// </summary>
-public class ServerManagementFixture : IAsyncLifetime
+public class ServerManagementCommandFixture : IAsyncLifetime
 {
     private StandaloneServer? _standaloneServer;
     private ClusterServer? _clusterServer;

--- a/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
@@ -346,7 +346,6 @@ public class ServerManagementCommandTests(ServerManagementCommandFixture fixture
     /// <summary>
     /// Asserts that the result contains the expected server name.
     /// </summary>
-    /// <param name="result"></param>
     private static void AssertContainsServerName(string result)
         => Assert.Contains(["VALKEY", "REDIS"], name => result.Contains(name, StringComparison.OrdinalIgnoreCase));
 }

--- a/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
@@ -132,51 +132,27 @@ public class ServerManagementCommandTests(ServerManagementCommandFixture fixture
 
     [Fact]
     public async Task LolwutAsync_Standalone_WithVersion()
-    {
-        string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5 });
-        Assert.NotEmpty(result);
-        AssertContainsServerName(result);
-    }
+        => AssertContainsServerName(await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5 }));
 
     [Fact]
     public async Task LolwutAsync_Standalone_WithVersionAndParameters()
-    {
-        string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        AssertContainsServerName(result);
-    }
+        => AssertContainsServerName(await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] }));
 
     [Fact]
     public async Task LolwutAsync_Cluster_WithVersion()
-    {
-        string result = await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5 });
-        Assert.NotEmpty(result);
-        AssertContainsServerName(result);
-    }
+        => AssertContainsServerName(await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5 }));
 
     [Fact]
     public async Task LolwutAsync_Cluster_WithVersionAndParameters()
-    {
-        string result = await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        AssertContainsServerName(result);
-    }
+        => AssertContainsServerName(await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] }));
 
     [Fact]
     public async Task LolwutAsync_Standalone_WithParametersOnly()
-    {
-        string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        AssertContainsServerName(result);
-    }
+        => AssertContainsServerName(await StandaloneClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] }));
 
     [Fact]
     public async Task LolwutAsync_Cluster_WithParametersOnly()
-    {
-        string result = await ClusterClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        AssertContainsServerName(result);
-    }
+        => AssertContainsServerName(await ClusterClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] }));
 
     #endregion
 


### PR DESCRIPTION
### Summary

Fixes two CD pipeline issues discovered during CD pipeline:

1. **Windows runners: `wsl-bash: command not found`** — The CD workflow was missing the `Vampire/setup-wsl` step that the CI workflow has via `install-shared-dependencies`. Without it, `install-server` fails on Windows x64 runners because WSL is not pre-installed.

2. **LOLWUT test failures on Redis/Valkey 8.x** — The `ServerManagementCommandTests` `LOLWUT` assertions expected "Valkey" in the output, but Valkey 8.x (which the CD tests against) still identifies as "Redis" in `LOLWUT` output.

### Issue Link

:white_circle: None

### Error Logs

**Issue 1: WSL not found on Windows x64 runner (`windows-2025`)**

```
Run sudo cp valkey/src/valkey-cli valkey/src/valkey-server /usr/local/bin
sudo cp valkey/src/valkey-cli valkey/src/valkey-server /usr/local/bin
Error: wsl-bash: command not found
```

**Issue 2: LOLWUT assertion failures on server 8.1.6**

```
Assert.Contains() Failure: Sub-string not found
String:    "Redis ver. 8.1.6\n"
Not found: "Valkey"
```

### Features and Behaviour Changes

**Issue 1:** Added `Vampire/setup-wsl@v7` step before `install-server` in the CD workflow, matching the pattern used in `install-shared-dependencies/action.yml`.

**Issue 2:** Extracted `AssertContainsServerName` helper that accepts either "Valkey" or "Redis" using `Assert.Contains` with a predicate, for compatibility with older server versions.

### Limitations

Testing still skipped for `windows-11-arm` runners (no Hyper-V), matching the existing guard in `install-shared-dependencies`.

### Testing

- `ServerManagementCommandTests` pass locally

### Related

- #329, #333 — Previous CD fixes in this release.

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] ~~Create merge commit if merging release branch into `main`~~, squash otherwise.