### PR TITLE
Cherry-pick `release-1.0` changes into `main`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -263,8 +263,16 @@ jobs:
                   dotnet add tests/Valkey.Glide.IntegrationTests package Valkey.Glide --version $RELEASE_VERSION
                   git diff
 
+            - name: Setup WSL (Windows only)
+              # WSL2 is not available on windows-11-arm runners (no Hyper-V).
+              if: ${{ matrix.host.OS == 'windows' && matrix.host.ARCH != 'arm64' }}
+              uses: Vampire/setup-wsl@v7
+              with:
+                  distribution: Ubuntu-22.04
+                  additional-packages: build-essential git make pkg-config libssl-dev
+
             - name: Install server
-              # WSL2 is not available on windows-11-arm runners (no Hyper-V), so we cannot run Valkey server there.
+              # WSL2 is not available on windows-11-arm runners (no Hyper-V).
               if: ${{ !(matrix.host.OS == 'windows' && matrix.host.ARCH == 'arm64') }}
               uses: ./.github/workflows/install-server
               with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -253,11 +253,14 @@ jobs:
                   fi
 
             - name: Patch IT suite to run tests using freshly published version
-              working-directory: tests/Valkey.Glide.IntegrationTests
               shell: bash
               run: |
-                  dotnet remove reference ../../sources/Valkey.Glide/Valkey.Glide.csproj
-                  dotnet add package Valkey.Glide --version $RELEASE_VERSION
+                  # Remove local project references to Valkey.Glide
+                  dotnet remove tests/Valkey.Glide.TestUtils reference sources/Valkey.Glide/Valkey.Glide.csproj
+                  dotnet remove tests/Valkey.Glide.IntegrationTests reference sources/Valkey.Glide/Valkey.Glide.csproj
+                  # Replace with the published NuGet package
+                  dotnet add tests/Valkey.Glide.TestUtils package Valkey.Glide --version $RELEASE_VERSION
+                  dotnet add tests/Valkey.Glide.IntegrationTests package Valkey.Glide --version $RELEASE_VERSION
                   git diff
 
             - name: Install server

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -256,7 +256,7 @@ jobs:
               working-directory: tests/Valkey.Glide.IntegrationTests
               shell: bash
               run: |
-                  dotnet remove reference $(dotnet list reference | tail -n +3)
+                  dotnet remove reference ../../sources/Valkey.Glide/Valkey.Glide.csproj
                   dotnet add package Valkey.Glide --version $RELEASE_VERSION
                   git diff
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Valkey General Language Independent Driver for the Enterprise (GLIDE) is the official open-source Valkey client library for C#. Built on a robust Rust core, it provides high-performance, reliable connectivity to Valkey and Redis OSS servers with comprehensive async/await support.
 
-> [!IMPORTANT]
-> Valkey.Glide C# wrapper is in a preview state and still has many features that remain to be implemented before GA.
-
 ## Why Choose Valkey GLIDE?
 
 - **Community and Open Source** – Join our vibrant community and contribute to the project. We are always here to respond, and the client is for the community.

--- a/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ServerManagementCommandTests.cs
@@ -10,7 +10,7 @@ namespace Valkey.Glide.IntegrationTests;
 /// </summary>
 [Collection(typeof(ServerManagementCommandTests))]
 [CollectionDefinition(DisableParallelization = true)]
-public class ServerManagementCommandTests(ServerManagementFixture fixture) : IClassFixture<ServerManagementFixture>
+public class ServerManagementCommandTests(ServerManagementCommandFixture fixture) : IClassFixture<ServerManagementCommandFixture>
 {
     private GlideClient StandaloneClient => fixture.StandaloneClient!;
     private GlideClusterClient ClusterClient => fixture.ClusterClient!;
@@ -132,51 +132,27 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
 
     [Fact]
     public async Task LolwutAsync_Standalone_WithVersion()
-    {
-        string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5 });
-        Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
-    }
+        => AssertContainsServerName(await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5 }));
 
     [Fact]
     public async Task LolwutAsync_Standalone_WithVersionAndParameters()
-    {
-        string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
-    }
+        => AssertContainsServerName(await StandaloneClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] }));
 
     [Fact]
     public async Task LolwutAsync_Cluster_WithVersion()
-    {
-        string result = await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5 });
-        Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
-    }
+        => AssertContainsServerName(await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5 }));
 
     [Fact]
     public async Task LolwutAsync_Cluster_WithVersionAndParameters()
-    {
-        string result = await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
-    }
+        => AssertContainsServerName(await ClusterClient.LolwutAsync(new LolwutOptions { Version = 5, Parameters = [40, 20] }));
 
     [Fact]
     public async Task LolwutAsync_Standalone_WithParametersOnly()
-    {
-        string result = await StandaloneClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
-    }
+        => AssertContainsServerName(await StandaloneClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] }));
 
     [Fact]
     public async Task LolwutAsync_Cluster_WithParametersOnly()
-    {
-        string result = await ClusterClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] });
-        Assert.NotEmpty(result);
-        Assert.Contains("Valkey", result, StringComparison.OrdinalIgnoreCase);
-    }
+        => AssertContainsServerName(await ClusterClient.LolwutAsync(new LolwutOptions { Parameters = [40, 20] }));
 
     #endregion
 
@@ -366,13 +342,19 @@ public class ServerManagementCommandTests(ServerManagementFixture fixture) : ICl
     }
 
     #endregion
+
+    /// <summary>
+    /// Asserts that the result contains the expected server name.
+    /// </summary>
+    private static void AssertContainsServerName(string result)
+        => Assert.Contains(["VALKEY", "REDIS"], name => result.Contains(name, StringComparison.OrdinalIgnoreCase));
 }
 
 /// <summary>
 /// Fixture that provides isolated Valkey server instances for server management tests.
 /// Tests that call FlushAll/FlushDB need their own servers to avoid interfering with other tests.
 /// </summary>
-public class ServerManagementFixture : IAsyncLifetime
+public class ServerManagementCommandFixture : IAsyncLifetime
 {
     private StandaloneServer? _standaloneServer;
     private ClusterServer? _clusterServer;


### PR DESCRIPTION
### Summary

Cherry-pick `release-1.0` changes back into `main` after the [v1.0.0](https://github.com/valkey-io/valkey-glide-csharp/releases/tag/v1.0.0) release.

### Issue Link

:white_circle: None

### Features and Behaviour Changes

- Remove "preview state" notice from `README.md`
- Fix CD pipeline project reference patching for `TestUtils` and `IntegrationTests`
- Add WSL setup step for Windows CD runners
- Fix `LOLWUT` assertions to accept both Valkey and Redis server names

### Implementation

:white_circle: All changes cherry-picked from the `release-1.0` branch (PRs #329, #331, #333, #334).

### Limitations

:white_circle: None

### Testing

:white_circle: None

### Related Issues

- #329
- #331
- #333
- #334

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] ~~Create merge commit if merging release branch into `main`, squash otherwise.~~