### PR TITLE
Fix broken language tab references in docs URLs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -372,7 +372,7 @@ The CSharp Valkey-Glide client uses xUnit v3 for testing code. The test code sty
 
 ## Documentation
 
-For user-facing documentation including quick start guides, tutorials, and how-to guides, visit the official [Valkey GLIDE documentation site](https://glide.valkey.io/getting-started/quickstart/?lang=csharp).
+For user-facing documentation including quick start guides, tutorials, and how-to guides, visit the official [Valkey GLIDE documentation site](https://glide.valkey.io/getting-started/quickstart/?lang=c%23).
 
 ## Benchmarking
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 Visit the official Valkey GLIDE [documentation site](https://glide.valkey.io).
 
 - [Key Features](https://glide.valkey.io/overview/#key-features)
-- [Quick Start](https://glide.valkey.io/getting-started/quickstart/?lang=csharp)
+- [Quick Start](https://glide.valkey.io/getting-started/quickstart/?lang=c%23)
 - [Supported Engine Versions](https://glide.valkey.io/overview/#supported-engine-versions)
 - [Basic Operations](https://glide.valkey.io/getting-started/basic-operations/)
 - [Client Initialization](https://glide.valkey.io/how-to/client-initialization/)


### PR DESCRIPTION
### Summary

Fix broken language tab references in documentation URLs. The `?lang=csharp` query parameter does not correctly select the C# language tab on the Valkey GLIDE documentation site — the correct value is `c#`, URL-encoded as `c%23`.

### Issue Link

:white_circle: None

### Features and Behaviour Changes

- Updated documentation links in `README.md` and `DEVELOPER.md` from `?lang=csharp` to `?lang=c%23` so the C# language tab is correctly selected when visiting the documentation site.

### Implementation

Simple find-and-replace of the query parameter value in two markdown files. No code changes.

### Limitations

:white_circle: None

### Testing

:white_circle: No tests required — documentation-only change. Verified the corrected URLs manually.

### Related Issues

:white_circle: None

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.