### PR TITLE
refactor: Split check_examples.py into extraction, validation, and orchestration scripts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -212,4 +212,4 @@ tasks:
     check-examples:
         desc: "Extract and validate C# code examples in doc comments"
         cmds:
-            - python3 scripts/check_examples.py --glide_root .
+            - python3 scripts/check_examples.py

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -12,9 +12,36 @@ import sys
 import tempfile
 
 _SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.dirname(_SCRIPTS_DIR)
+
+
+def _find_glide_dll() -> str | None:
+    """Locate the built Valkey.Glide.dll, preferring Release over Debug."""
+    for config in ("Release", "Debug"):
+        path = os.path.join(
+            _PROJECT_ROOT,
+            "sources",
+            "Valkey.Glide",
+            "bin",
+            config,
+            "net8.0",
+            "Valkey.Glide.dll",
+        )
+        if os.path.exists(path):
+            return path
+    return None
 
 
 def main():
+    # Locate the built DLL before running extraction/validation.
+    glide_dll = _find_glide_dll()
+    if glide_dll is None:
+        print(
+            "Error: Built DLL not found. Run 'dotnet build' first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     tmp_path = os.path.join(tempfile.gettempdir(), f"examples_{os.getpid()}.json")
 
     try:
@@ -38,6 +65,8 @@ def main():
                 os.path.join(_SCRIPTS_DIR, "validate_examples.py"),
                 "--examples",
                 tmp_path,
+                "--glide-dll",
+                glide_dll,
                 "--add-imports",
                 "--add-clients",
             ],

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -2,428 +2,52 @@
 
 """Check Valkey GLIDE C# code examples by extracting and compiling them.
 
-Extracts example code blocks from Valkey GLIDE source files or loads them
-from a JSON file, wraps each in a compilable C# harness, runs `dotnet build`,
-and reports failures mapped back to their source.
-
-If provided, the examples JSON file should map from a source key to the
-associated code example:
-
-```json
-{
-    "sources/File.cs:123": "var client = new ValkeyClient(...);",
-    "sources/File.cs:456": "await client.SetAsync(\"key\", \"value\");"
-}
-```
-
 Usage:
     python scripts/check_examples.py
-      --glide_root path/to/valkey-glide-csharp
-      [--examples path/to/examples.json]
 """
 
-import argparse
-import html
-import json
 import os
-import re
 import subprocess
 import sys
 import tempfile
-import textwrap
-import uuid
 
-
-class ExampleExtractor:
-    """Extracts C# code examples from XML doc comments in .cs files."""
-
-    # Matches an <example><code>...</code></example> block in XML doc comments.
-    # Captures the code content between <code> and </code> tags.
-    # Flexible with whitespace/newlines between tags.
-    _EXAMPLE_PATTERN = re.compile(
-        r"<example>\s*(?:///\s*)?<code>\s*\n"
-        r"(.*?)"
-        r"^\s*///\s*</code>\s*(?:///\s*)?</example>",
-        re.MULTILINE | re.DOTALL,
-    )
-
-    # Matches the /// prefix on a doc comment line (strips at most one space, not newlines).
-    _DOC_PREFIX = re.compile(r"^\s*/// ?", re.MULTILINE)
-
-    def __init__(self, glide_root: str):
-        """Initialize the extractor.
-
-        Args:
-            glide_root: Root directory of the valkey-glide-csharp repository.
-        """
-        self._source_dir = os.path.join(glide_root, "sources")
-
-        if not os.path.isdir(self._source_dir):
-            print(
-                f"Error: '{self._source_dir}' is not a directory", file=sys.stderr
-            )
-            sys.exit(1)
-
-    def extract(self) -> dict[str, str]:
-        """Extract all <example> code blocks from .cs files.
-
-        Returns:
-            A dict mapping source references (e.g. "path/to/File.cs:42")
-            to the raw code lines from the example block.
-        """
-        results: dict[str, str] = {}
-
-        for dirpath, _, filenames in os.walk(self._source_dir):
-            for filename in sorted(filenames):
-                if not filename.endswith(".cs"):
-                    continue
-
-                filepath = os.path.join(dirpath, filename)
-                results.update(self._extract_from_file(filepath))
-
-        return results
-
-    def _extract_from_file(self, filepath: str) -> dict[str, str]:
-        """Extract example blocks from a single .cs file."""
-        results: dict[str, str] = {}
-
-        with open(filepath, "r", encoding="utf-8-sig") as f:
-            content = f.read()
-
-        for match in self._EXAMPLE_PATTERN.finditer(content):
-            # Line number of the <example> tag (1-indexed).
-            line_number = content[: match.start()].count("\n") + 1
-
-            # Strip /// prefix from each captured code line.
-            code = self._DOC_PREFIX.sub("", match.group(1)).strip()
-
-            source = f"{filepath}:{line_number}"
-            results[source] = code
-
-        return results
-
-
-class ExampleChecker:
-    """Checks C# code examples by compiling them in a temporary .NET project."""
-
-    # Namespace imports to include by default.
-    _USING_NAMESPACES = [
-        "Valkey.Glide",
-        "Valkey.Glide.Pipeline",
-        "Valkey.Glide.Commands",
-        "Valkey.Glide.Commands.Options",
-    ]
-
-    # Type imports (using static) to include by default.
-    _USING_TYPES = [
-        "Valkey.Glide.Pipeline.Batch",
-        "Valkey.Glide.Pipeline.ClusterBatch",
-        "Valkey.Glide.Commands.Options.InfoOptions",
-        "Valkey.Glide.Commands.Options.BitFieldOptions",
-        "Valkey.Glide.Commands.Options.BitFieldOptions.Encoding",
-    ]
-
-    # Matches a C# using directive (e.g. "using Foo.Bar;" or "using static Foo.Bar;")
-    # but not a using declaration (e.g. "using var x = ...").
-    _USING_DIRECTIVE = re.compile(r"^\s*using\s+(static\s+)?[A-Z][\w.]*\s*;")
-
-    # Template for the .csproj that references the main library.
-    _CSPROJ_TEMPLATE = """\
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Valkey.Glide">
-      <HintPath>{dll_path}</HintPath>
-    </Reference>
-  </ItemGroup>
-</Project>
-"""
-
-    # Template for each generated .cs wrapper file:
-    #   - Declare static client, database, and server instances.
-    #   - Async method to allow 'await' in examples.
-    _WRAPPER_TEMPLATE = """\
-// Auto-generated from {source}
-
-{usings}
-
-namespace Valkey.Glide.ExampleValidation;
-
-public class {class_name}
-{{
-    // Valkey GLIDE
-    static GlideClient client = null!;
-    static GlideClusterClient clusterClient = null!;
-
-    // StackExchange.Redis
-    static IDatabase db = null!;
-    static IServer server = null!;
-
-    static async Task Run()
-    {{
-{indented_code}
-    }}
-}}
-"""
-
-    # Regex for matching dotnet build error lines.
-    # See: https://learn.microsoft.com/en-us/cpp/build/formatting-the-output-of-a-custom-build-step-or-build-event
-    # Format: {filename}({line},{column}): error {code}: {message} [{project}]
-    _ERROR_PATTERN = re.compile(
-        r"(?P<file>[^(]+)\(\d+,\d+\):\s*error\s+(?P<message>CS\d+:\s*[^[]*)"
-    )
-
-    def __init__(self, examples: dict[str, str], glide_root: str):
-        """Initialize the checker.
-
-        Use as a context manager to ensure cleanup of temporary files:
-
-            with ExampleChecker(examples, "path/to/valkey-glide-csharp") as checker:
-                errors = checker.check()
-
-        Args:
-            examples: Dict mapping source references (e.g. "File.cs:42")
-                to code example strings.
-            glide_root: Path to the Valkey GLIDE project
-        """
-        self._examples = examples
-        self._temp_dir = tempfile.TemporaryDirectory()
-        self._glide_root = os.path.abspath(glide_root)
-
-        # Verify that Valkey GLIDE root exists.
-        if not os.path.exists(self._glide_root):
-            print(
-                f"Error: Project not found at '{self._glide_root}'.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        # Verify that Valkey GLIDE DLL exists.
-        self._glide_dll_path = None
-
-        for config in ("Release", "Debug"):
-            path = os.path.join(
-                self._glide_root,
-                "sources",
-                "Valkey.Glide",
-                "bin",
-                config,
-                "net8.0",
-                "Valkey.Glide.dll",
-            )
-            if os.path.exists(path):
-                self._glide_dll_path = path
-                break
-
-        if self._glide_dll_path is None:
-            print(
-                f"Error: Built DLL. "
-                "Run 'dotnet build' first.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        # Verify that dotnet is installed.
-        try:
-            result = subprocess.run(
-                ["dotnet", "--version"],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                print(
-                    "Error: 'dotnet' is installed but returned an error.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-        except FileNotFoundError:
-            print("Error: 'dotnet' is not installed or not on PATH.", file=sys.stderr)
-            sys.exit(1)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_):
-        self._temp_dir.cleanup()
-
-    def check(self) -> dict[str, list[str]]:
-        """Check the examples by compiling them.
-
-        Returns:
-            A dict mapping source references to lists of error messages for
-            examples that failed compilation. An empty dict means all examples
-            compiled successfully.
-        """
-        if not self._examples:
-            return {}
-
-        # Create and populate the temp project,
-        # then build it and identify any example failures.
-        file_to_source = self._create_project()
-        return self._build_project(file_to_source)
-
-    def _create_project(self) -> dict[str, str]:
-        """Generate the .csproj and wrapper files in the temp directory.
-
-        Returns:
-            A dict mapping generated filenames to source references.
-        """
-        csproj_content = self._CSPROJ_TEMPLATE.format(dll_path=self._glide_dll_path)
-
-        with open(os.path.join(self._temp_dir.name, "ExampleValidation.csproj"), "w") as f:
-            f.write(csproj_content)
-
-        file_to_source: dict[str, str] = {}
-        for source, content in self._examples.items():
-            filename = self._generate_wrapper(source, content)
-            file_to_source[filename] = source
-
-        return file_to_source
-
-    def _generate_wrapper(self, source: str, content: str) -> str:
-        """Generate and write a .cs wrapper file for a single example.
-
-        Args:
-            source: Reference to the example source (e.g. "File.cs:42").
-            content: The raw code example to wrap.
-
-        Returns:
-            The filename (basename) of the generated file.
-        """
-        # Docstrings may contain character references like &gt;
-        # that need to be mapped to the corresponding character.
-        content = html.unescape(content)
-
-        # Extract using directives from the example and merge with defaults.
-        example_usings = []
-        code_lines = []
-        for line in content.splitlines():
-            if self._USING_DIRECTIVE.match(line):
-                example_usings.append(line.rstrip().rstrip(";") + ";")
-            else:
-                code_lines.append(line)
-        content = "\n".join(code_lines).strip()
-
-        default_usings = [f"using {ns};" for ns in self._USING_NAMESPACES] + [
-            f"using static {t};" for t in self._USING_TYPES
-        ]
-        all_usings = default_usings + example_usings
-        usings = "\n".join(dict.fromkeys(all_usings))  # deduplicate, preserve order
-
-        class_name = f"Example_{uuid.uuid4().hex}"
-        indented_code = textwrap.indent(content, "        ")
-
-        file_content = self._WRAPPER_TEMPLATE.format(
-            source=source,
-            usings=usings,
-            class_name=class_name,
-            indented_code=indented_code,
-        )
-
-        filename = f"{class_name}.cs"
-        filepath = os.path.join(self._temp_dir.name, filename)
-        with open(filepath, "w") as f:
-            f.write(file_content)
-
-        return filename
-
-    def _build_project(self, file_to_source: dict[str, str]) -> dict[str, list[str]]:
-        """Run dotnet build and return errors mapped by source.
-
-        Args:
-            file_to_source: Mapping from generated filenames to source references.
-
-        Returns:
-            A dict mapping source references to lists of error messages.
-        """
-
-        # Merge stderr into stdout so all build errors are captured in one stream.
-        result = subprocess.run(
-            ["dotnet", "build", "--framework", "net8.0"],
-            cwd=self._temp_dir.name,
-            capture_output=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-
-        if result.returncode == 0:
-            return {}
-
-        errors: dict[str, list[str]] = {}
-        for line in result.stdout.splitlines():
-            match = self._ERROR_PATTERN.search(line)
-            if match:
-                basename = os.path.basename(match.group("file"))
-                source = file_to_source.get(basename, basename)
-                errors.setdefault(source, []).append(match.group("message").strip())
-
-        # Fallback: if the build failed but no errors matched the regex,
-        # report the raw output so failures aren't silently swallowed.
-        if not errors:
-            fallback = [f"dotnet build failed with exit code {result.returncode}."]
-            raw = result.stdout.strip()
-            if raw:
-                fallback.append("Raw build output:")
-                fallback.extend(raw.splitlines())
-            errors["<build>"] = fallback
-
-        return errors
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Check C# code examples by extracting and compiling them."
-    )
-    parser.add_argument(
-        "--glide_root",
-        required=True,
-        help="Root directory of the valkey-glide-csharp repository.",
-    )
-    parser.add_argument(
-        "--examples",
-        default=None,
-        help="Path to a JSON file containing examples. "
-        "If not provided, examples are extracted from source files.",
-    )
-    args = parser.parse_args()
+    tmp_path = os.path.join(tempfile.gettempdir(), f"examples_{os.getpid()}.json")
 
-    # Load or extract examples.
-    if args.examples:
-        if not os.path.isfile(args.examples):
-            print(f"Error: '{args.examples}' not found", file=sys.stderr)
-            sys.exit(1)
+    try:
+        # Step 1: Extract examples
+        result = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(_SCRIPTS_DIR, "extract_examples.py"),
+                "--examples",
+                tmp_path,
+            ],
+            check=False,
+        )
+        if result.returncode != 0:
+            sys.exit(result.returncode)
 
-        with open(args.examples, "r") as f:
-            examples = json.load(f)
-    else:
-        extractor = ExampleExtractor(args.glide_root)
-        examples = extractor.extract()
+        # Step 2: Validate examples
+        result = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(_SCRIPTS_DIR, "validate_examples.py"),
+                "--examples",
+                tmp_path,
+                "--add-imports",
+                "--add-clients",
+            ],
+            check=False,
+        )
+        sys.exit(result.returncode)
 
-    with ExampleChecker(examples, args.glide_root) as checker:
-        print(f"Checking {len(examples)} examples...")
-        errors = checker.check()
-
-    if errors:
-        print(f"\n{'='*60}")
-        print(f"FAILURES ({len(errors)} of {len(examples)} examples)")
-        print(f"{'='*60}\n")
-
-        for source, messages in errors.items():
-            print(f"  FAIL: {source}")
-            for message in messages:
-                print(f"        {message}")
-            print()
-
-        print(f"{len(examples) - len(errors)} passed, {len(errors)} failed")
-        sys.exit(1)
-    else:
-        print(f"\nAll {len(examples)} examples compiled successfully.")
-        sys.exit(0)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 if __name__ == "__main__":

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -42,7 +42,10 @@ def main():
         )
         sys.exit(1)
 
-    tmp_path = os.path.join(tempfile.gettempdir(), f"examples_{os.getpid()}.json")
+    with tempfile.NamedTemporaryFile(
+        suffix=".json", prefix="examples_", delete=False
+    ) as tmp_file:
+        tmp_path = tmp_file.name
 
     try:
         # Step 1: Extract examples

--- a/scripts/extract_examples.py
+++ b/scripts/extract_examples.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+"""Extract C# code examples from Valkey GLIDE source files.
+
+Walks the sources/ directory, finds <example><code>...</code></example> blocks
+in XML doc comments, and writes them to a JSON file mapping source references
+to code snippets.
+
+Usage:
+    python scripts/extract_examples.py --examples path/to/output.json
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+
+# Project root is one level up from this script's directory (scripts/).
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class ExamplesExtractor:
+    """Extracts C# code examples from XML doc comments in .cs files."""
+
+    # Matches an <example><code>...</code></example> block in XML doc comments.
+    _EXAMPLE_PATTERN = re.compile(
+        r"<example>\s*(?:///\s*)?<code>\s*\n"
+        r"(.*?)"
+        r"^\s*///\s*</code>\s*(?:///\s*)?</example>",
+        re.MULTILINE | re.DOTALL,
+    )
+
+    # Matches the /// prefix on a doc comment line.
+    _DOC_PREFIX = re.compile(r"^\s*/// ?", re.MULTILINE)
+
+    def __init__(self):
+        """Initialize the extractor using the project root."""
+        self._source_dir = os.path.join(_PROJECT_ROOT, "sources")
+
+        if not os.path.isdir(self._source_dir):
+            print(
+                f"Error: '{self._source_dir}' is not a directory", file=sys.stderr
+            )
+            sys.exit(1)
+
+    def extract(self) -> dict[str, str]:
+        """Extract all <example> code blocks from .cs files.
+
+        Returns:
+            A dict mapping source references (e.g. "path/to/File.cs:42")
+            to the raw code lines from the example block.
+        """
+        results: dict[str, str] = {}
+
+        for dirpath, _, filenames in os.walk(self._source_dir):
+            for filename in sorted(filenames):
+                if not filename.endswith(".cs"):
+                    continue
+
+                filepath = os.path.join(dirpath, filename)
+                results.update(self._extract_from_file(filepath))
+
+        return results
+
+    def _extract_from_file(self, filepath: str) -> dict[str, str]:
+        """Extract example blocks from a single .cs file."""
+        results: dict[str, str] = {}
+
+        with open(filepath, "r", encoding="utf-8-sig") as f:
+            content = f.read()
+
+        for match in self._EXAMPLE_PATTERN.finditer(content):
+            line_number = content[: match.start()].count("\n") + 1
+            code = self._DOC_PREFIX.sub("", match.group(1)).strip()
+            source = f"{filepath}:{line_number}"
+            results[source] = code
+
+        return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract C# code examples from Valkey GLIDE source files."
+    )
+    parser.add_argument(
+        "--examples",
+        required=True,
+        help="Path to write the extracted examples JSON file.",
+    )
+    args = parser.parse_args()
+
+    extractor = ExamplesExtractor()
+    examples = extractor.extract()
+
+    print(f"Extracted {len(examples)} examples from sources/")
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.examples)), exist_ok=True)
+
+    with open(args.examples, "w") as f:
+        json.dump(examples, f, indent=2)
+
+    print(f"Written to {args.examples}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_examples.py
+++ b/scripts/extract_examples.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import argparse
+import html
 import json
 import os
 import re
@@ -73,7 +74,7 @@ class ExamplesExtractor:
 
         for match in self._EXAMPLE_PATTERN.finditer(content):
             line_number = content[: match.start()].count("\n") + 1
-            code = self._DOC_PREFIX.sub("", match.group(1)).strip()
+            code = html.unescape(self._DOC_PREFIX.sub("", match.group(1)).strip())
             source = f"{filepath}:{line_number}"
             results[source] = code
 

--- a/scripts/extract_examples.py
+++ b/scripts/extract_examples.py
@@ -72,10 +72,14 @@ class ExamplesExtractor:
         with open(filepath, "r", encoding="utf-8-sig") as f:
             content = f.read()
 
+        relative_filepath = os.path.relpath(filepath, _PROJECT_ROOT).replace(
+            os.sep, "/"
+        )
+
         for match in self._EXAMPLE_PATTERN.finditer(content):
             line_number = content[: match.start()].count("\n") + 1
             code = html.unescape(self._DOC_PREFIX.sub("", match.group(1)).strip())
-            source = f"{filepath}:{line_number}"
+            source = f"{relative_filepath}:{line_number}"
             results[source] = code
 
         return results

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -63,10 +63,10 @@ class ExamplesValidator:
 
     # Client fields to include when --add-clients is specified.
     _CLIENT_FIELDS = [
-        "static GlideClient client = null!;",
-        "static GlideClusterClient clusterClient = null!;",
-        "static IDatabase db = null!;",
-        "static IServer server = null!;",
+        "static Valkey.Glide.GlideClient client = null!;",
+        "static Valkey.Glide.GlideClusterClient clusterClient = null!;",
+        "static Valkey.Glide.IDatabase db = null!;",
+        "static Valkey.Glide.IServer server = null!;",
     ]
 
     # Matches a C# using directive (e.g. "using Foo.Bar;" or "using static Foo.Bar;")
@@ -138,7 +138,7 @@ public class {class_name}
         self._add_imports = add_imports
         self._add_clients = add_clients
         self._temp_dir = tempfile.TemporaryDirectory()
-        self._glide_dll_path = glide_dll
+        self._glide_dll_path = os.path.abspath(glide_dll)
 
         # Verify that dotnet is installed.
         try:

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+
+"""Validate C# code examples by compiling them in a temporary .NET project.
+
+Loads examples from a JSON file, wraps each in a C# class with a .NET project,
+runs `dotnet build`, and reports failures mapped back to their source.
+
+The examples JSON file must map from a source key to the associated code example:
+
+```json
+{
+    "sources/File.cs:123": "var client = new ValkeyClient(...);",
+    "sources/File.cs:456": "await client.SetAsync(\"key\", \"value\");"
+}
+```
+
+Usage:
+    python scripts/validate_examples.py --examples path/to/examples.json
+"""
+
+import argparse
+import html
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import uuid
+
+
+# Project root is one level up from this script's directory (scripts/).
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class ExampleChecker:
+    """Checks C# code examples by compiling them in a temporary .NET project."""
+
+    # Namespace imports to include by default.
+    _USING_NAMESPACES = [
+        "Valkey.Glide",
+        "Valkey.Glide.Pipeline",
+        "Valkey.Glide.Commands",
+        "Valkey.Glide.Commands.Options",
+    ]
+
+    # Type imports (using static) to include by default.
+    _USING_TYPES = [
+        "Valkey.Glide.Pipeline.Batch",
+        "Valkey.Glide.Pipeline.ClusterBatch",
+        "Valkey.Glide.Commands.Options.InfoOptions",
+        "Valkey.Glide.Commands.Options.BitFieldOptions",
+        "Valkey.Glide.Commands.Options.BitFieldOptions.Encoding",
+    ]
+
+    # Matches a C# using directive (e.g. "using Foo.Bar;" or "using static Foo.Bar;")
+    # but not a using declaration (e.g. "using var x = ...").
+    _USING_DIRECTIVE = re.compile(r"^\s*using\s+(static\s+)?[A-Z][\w.]*\s*;")
+
+    # Template for the .csproj that references the main library.
+    _CSPROJ_TEMPLATE = """\
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Valkey.Glide">
+      <HintPath>{dll_path}</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>
+"""
+
+    # Template for each generated .cs wrapper file.
+    _WRAPPER_TEMPLATE = """\
+// Auto-generated from {source}
+
+{usings}
+
+namespace Valkey.Glide.ExampleValidation;
+
+public class {class_name}
+{{
+    // Valkey GLIDE
+    static GlideClient client = null!;
+    static GlideClusterClient clusterClient = null!;
+
+    // StackExchange.Redis
+    static IDatabase db = null!;
+    static IServer server = null!;
+
+    static async Task Run()
+    {{
+{indented_code}
+    }}
+}}
+"""
+
+    # Regex for matching dotnet build error lines.
+    _ERROR_PATTERN = re.compile(
+        r"(?P<file>[^(]+)\(\d+,\d+\):\s*error\s+(?P<message>CS\d+:\s*[^[]*)"
+    )
+
+    def __init__(self, examples: dict[str, str]):
+        """Initialize the checker.
+
+        Use as a context manager to ensure cleanup of temporary files:
+
+            with ExampleChecker(examples) as checker:
+                errors = checker.check()
+
+        Args:
+            examples: Dict mapping source references (e.g. "File.cs:42")
+                to code example strings.
+        """
+        self._examples = examples
+        self._temp_dir = tempfile.TemporaryDirectory()
+
+        # Locate the built Valkey GLIDE DLL.
+        self._glide_dll_path = None
+
+        for config in ("Release", "Debug"):
+            path = os.path.join(
+                _PROJECT_ROOT,
+                "sources",
+                "Valkey.Glide",
+                "bin",
+                config,
+                "net8.0",
+                "Valkey.Glide.dll",
+            )
+            if os.path.exists(path):
+                self._glide_dll_path = path
+                break
+
+        if self._glide_dll_path is None:
+            print(
+                "Error: Built DLL not found. Run 'dotnet build' first.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # Verify that dotnet is installed.
+        try:
+            result = subprocess.run(
+                ["dotnet", "--version"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                print(
+                    "Error: 'dotnet' is installed but returned an error.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        except FileNotFoundError:
+            print("Error: 'dotnet' is not installed or not on PATH.", file=sys.stderr)
+            sys.exit(1)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self._temp_dir.cleanup()
+
+    def check(self) -> dict[str, list[str]]:
+        """Check the examples by compiling them.
+
+        Returns:
+            A dict mapping source references to lists of error messages for
+            examples that failed compilation. An empty dict means all examples
+            compiled successfully.
+        """
+        if not self._examples:
+            return {}
+
+        file_to_source = self._create_project()
+        return self._build_project(file_to_source)
+
+    def _create_project(self) -> dict[str, str]:
+        """Generate the .csproj and wrapper files in the temp directory."""
+        csproj_content = self._CSPROJ_TEMPLATE.format(dll_path=self._glide_dll_path)
+
+        with open(os.path.join(self._temp_dir.name, "ExampleValidation.csproj"), "w") as f:
+            f.write(csproj_content)
+
+        file_to_source: dict[str, str] = {}
+        for source, content in self._examples.items():
+            filename = self._generate_wrapper(source, content)
+            file_to_source[filename] = source
+
+        return file_to_source
+
+    def _generate_wrapper(self, source: str, content: str) -> str:
+        """Generate and write a .cs wrapper file for a single example."""
+        content = html.unescape(content)
+
+        example_usings = []
+        code_lines = []
+        for line in content.splitlines():
+            if self._USING_DIRECTIVE.match(line):
+                example_usings.append(line.rstrip().rstrip(";") + ";")
+            else:
+                code_lines.append(line)
+        content = "\n".join(code_lines).strip()
+
+        default_usings = [f"using {ns};" for ns in self._USING_NAMESPACES] + [
+            f"using static {t};" for t in self._USING_TYPES
+        ]
+        all_usings = default_usings + example_usings
+        usings = "\n".join(dict.fromkeys(all_usings))
+
+        class_name = f"Example_{uuid.uuid4().hex}"
+        indented_code = textwrap.indent(content, "        ")
+
+        file_content = self._WRAPPER_TEMPLATE.format(
+            source=source,
+            usings=usings,
+            class_name=class_name,
+            indented_code=indented_code,
+        )
+
+        filename = f"{class_name}.cs"
+        filepath = os.path.join(self._temp_dir.name, filename)
+        with open(filepath, "w") as f:
+            f.write(file_content)
+
+        return filename
+
+    def _build_project(self, file_to_source: dict[str, str]) -> dict[str, list[str]]:
+        """Run dotnet build and return errors mapped by source."""
+        result = subprocess.run(
+            ["dotnet", "build", "--framework", "net8.0"],
+            cwd=self._temp_dir.name,
+            capture_output=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        if result.returncode == 0:
+            return {}
+
+        errors: dict[str, list[str]] = {}
+        for line in result.stdout.splitlines():
+            match = self._ERROR_PATTERN.search(line)
+            if match:
+                basename = os.path.basename(match.group("file"))
+                source = file_to_source.get(basename, basename)
+                errors.setdefault(source, []).append(match.group("message").strip())
+
+        if not errors:
+            fallback = [f"dotnet build failed with exit code {result.returncode}."]
+            raw = result.stdout.strip()
+            if raw:
+                fallback.append("Raw build output:")
+                fallback.extend(raw.splitlines())
+            errors["<build>"] = fallback
+
+        return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate C# code examples by compiling them."
+    )
+    parser.add_argument(
+        "--examples",
+        required=True,
+        help="Path to an existing JSON file containing examples to validate.",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.examples):
+        print(f"Error: '{args.examples}' not found", file=sys.stderr)
+        sys.exit(1)
+
+    with open(args.examples, "r") as f:
+        examples = json.load(f)
+
+    if not examples:
+        print("No examples found in the provided file.")
+        sys.exit(0)
+
+    with ExampleChecker(examples) as checker:
+        print(f"Checking {len(examples)} examples...")
+        errors = checker.check()
+
+    if errors:
+        print(f"\n{'='*60}")
+        print(f"FAILURES ({len(errors)} of {len(examples)} examples)")
+        print(f"{'='*60}\n")
+
+        for source, messages in errors.items():
+            print(f"  FAIL: {source}")
+            for message in messages:
+                print(f"        {message}")
+            print()
+
+        print(f"{len(examples) - len(errors)} passed, {len(errors)} failed")
+        sys.exit(1)
+    else:
+        print(f"\nAll {len(examples)} examples compiled successfully.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -17,11 +17,13 @@ The examples JSON file must map from a source key to the associated code example
 Usage:
     python scripts/validate_examples.py
         --examples path/to/examples.json
+        --glide-dll path/to/Valkey.Glide.dll
         [--add-imports]
         [--add-clients]
 
 Options:
     --examples      Path to an existing JSON file containing examples to validate.
+    --glide-dll     Path to the built Valkey.Glide.dll to reference during compilation.
     --add-imports   Include default using directives (Valkey.Glide namespaces) in
                     the generated classes. Disabled by default.
     --add-clients   Include static client fields (GlideClient, GlideClusterClient,
@@ -37,10 +39,6 @@ import sys
 import tempfile
 import textwrap
 import uuid
-
-
-# Project root is one level up from this script's directory (scripts/).
-_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class ExamplesValidator:
@@ -117,8 +115,9 @@ public class {class_name}
 
     def __init__(
         self,
-        examples: dict[str, str],
         *,
+        examples: dict[str, str],
+        glide_dll: str,
         add_imports: bool = False,
         add_clients: bool = False,
     ):
@@ -126,12 +125,12 @@ public class {class_name}
 
         Use as a context manager to ensure cleanup of temporary files:
 
-            with ExamplesValidator(examples, add_imports=True, add_clients=True) as validator:
+            with ExamplesValidator(examples=examples, glide_dll=path) as validator:
                 errors = validator.validate()
 
         Args:
-            examples: Dict mapping source references (e.g. "File.cs:42")
-                to code example strings.
+            examples: Dict mapping source references to code example strings.
+            glide_dll: Path to the built Valkey.Glide.dll to reference during compilation.
             add_imports: If True, include default using directives in the generated class.
             add_clients: If True, include static client fields in the generated class.
         """
@@ -139,30 +138,7 @@ public class {class_name}
         self._add_imports = add_imports
         self._add_clients = add_clients
         self._temp_dir = tempfile.TemporaryDirectory()
-
-        # Locate the built Valkey GLIDE DLL.
-        self._glide_dll_path = None
-
-        for config in ("Release", "Debug"):
-            path = os.path.join(
-                _PROJECT_ROOT,
-                "sources",
-                "Valkey.Glide",
-                "bin",
-                config,
-                "net8.0",
-                "Valkey.Glide.dll",
-            )
-            if os.path.exists(path):
-                self._glide_dll_path = path
-                break
-
-        if self._glide_dll_path is None:
-            print(
-                "Error: Built DLL not found. Run 'dotnet build' first.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        self._glide_dll_path = glide_dll
 
         # Verify that dotnet is installed.
         try:
@@ -302,6 +278,11 @@ def main():
         help="Path to an existing JSON file containing examples to validate.",
     )
     parser.add_argument(
+        "--glide-dll",
+        required=True,
+        help="Path to the built Valkey.Glide.dll to reference during compilation.",
+    )
+    parser.add_argument(
         "--add-imports",
         action="store_true",
         default=False,
@@ -319,6 +300,10 @@ def main():
         print(f"Error: '{args.examples}' not found", file=sys.stderr)
         sys.exit(1)
 
+    if not os.path.isfile(args.glide_dll):
+        print(f"Error: '{args.glide_dll}' not found", file=sys.stderr)
+        sys.exit(1)
+
     with open(args.examples, "r") as f:
         examples = json.load(f)
 
@@ -327,7 +312,10 @@ def main():
         sys.exit(0)
 
     with ExamplesValidator(
-        examples, add_imports=args.add_imports, add_clients=args.add_clients
+        examples=examples,
+        glide_dll=args.glide_dll,
+        add_imports=args.add_imports,
+        add_clients=args.add_clients,
     ) as validator:
         print(f"Validating {len(examples)} examples...")
         errors = validator.validate()

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -15,11 +15,20 @@ The examples JSON file must map from a source key to the associated code example
 ```
 
 Usage:
-    python scripts/validate_examples.py --examples path/to/examples.json
+    python scripts/validate_examples.py
+        --examples path/to/examples.json
+        [--add-imports]
+        [--add-clients]
+
+Options:
+    --examples      Path to an existing JSON file containing examples to validate.
+    --add-imports   Include default using directives (Valkey.Glide namespaces) in
+                    the generated classes. Disabled by default.
+    --add-clients   Include static client fields (GlideClient, GlideClusterClient,
+                    IDatabase, IServer) in the generated classes. Disabled by default.
 """
 
 import argparse
-import html
 import json
 import os
 import re
@@ -34,10 +43,10 @@ import uuid
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-class ExampleChecker:
-    """Checks C# code examples by compiling them in a temporary .NET project."""
+class ExamplesValidator:
+    """Validates C# code examples by compiling them in a temporary .NET project."""
 
-    # Namespace imports to include by default.
+    # Namespace imports to include when --add-imports is specified.
     _USING_NAMESPACES = [
         "Valkey.Glide",
         "Valkey.Glide.Pipeline",
@@ -45,7 +54,7 @@ class ExampleChecker:
         "Valkey.Glide.Commands.Options",
     ]
 
-    # Type imports (using static) to include by default.
+    # Type imports (using static) to include when --add-imports is specified.
     _USING_TYPES = [
         "Valkey.Glide.Pipeline.Batch",
         "Valkey.Glide.Pipeline.ClusterBatch",
@@ -54,12 +63,20 @@ class ExampleChecker:
         "Valkey.Glide.Commands.Options.BitFieldOptions.Encoding",
     ]
 
+    # Client fields to include when --add-clients is specified.
+    _CLIENT_FIELDS = [
+        "static GlideClient client = null!;",
+        "static GlideClusterClient clusterClient = null!;",
+        "static IDatabase db = null!;",
+        "static IServer server = null!;",
+    ]
+
     # Matches a C# using directive (e.g. "using Foo.Bar;" or "using static Foo.Bar;")
     # but not a using declaration (e.g. "using var x = ...").
     _USING_DIRECTIVE = re.compile(r"^\s*using\s+(static\s+)?[A-Z][\w.]*\s*;")
 
     # Template for the .csproj that references the main library.
-    _CSPROJ_TEMPLATE = """\
+    _PROJECT_TEMPLATE = """\
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -74,8 +91,8 @@ class ExampleChecker:
 </Project>
 """
 
-    # Template for each generated .cs wrapper file.
-    _WRAPPER_TEMPLATE = """\
+    # Template for each generated C# class.
+    _CLASS_TEMPLATE = """\
 // Auto-generated from {source}
 
 {usings}
@@ -84,13 +101,7 @@ namespace Valkey.Glide.ExampleValidation;
 
 public class {class_name}
 {{
-    // Valkey GLIDE
-    static GlideClient client = null!;
-    static GlideClusterClient clusterClient = null!;
-
-    // StackExchange.Redis
-    static IDatabase db = null!;
-    static IServer server = null!;
+{fields}
 
     static async Task Run()
     {{
@@ -104,19 +115,29 @@ public class {class_name}
         r"(?P<file>[^(]+)\(\d+,\d+\):\s*error\s+(?P<message>CS\d+:\s*[^[]*)"
     )
 
-    def __init__(self, examples: dict[str, str]):
-        """Initialize the checker.
+    def __init__(
+        self,
+        examples: dict[str, str],
+        *,
+        add_imports: bool = False,
+        add_clients: bool = False,
+    ):
+        """Initialize the validator.
 
         Use as a context manager to ensure cleanup of temporary files:
 
-            with ExampleChecker(examples) as checker:
-                errors = checker.check()
+            with ExamplesValidator(examples, add_imports=True, add_clients=True) as validator:
+                errors = validator.validate()
 
         Args:
             examples: Dict mapping source references (e.g. "File.cs:42")
                 to code example strings.
+            add_imports: If True, include default using directives in the generated class.
+            add_clients: If True, include static client fields in the generated class.
         """
         self._examples = examples
+        self._add_imports = add_imports
+        self._add_clients = add_clients
         self._temp_dir = tempfile.TemporaryDirectory()
 
         # Locate the built Valkey GLIDE DLL.
@@ -166,8 +187,8 @@ public class {class_name}
     def __exit__(self, *_):
         self._temp_dir.cleanup()
 
-    def check(self) -> dict[str, list[str]]:
-        """Check the examples by compiling them.
+    def validate(self) -> dict[str, list[str]]:
+        """Validate the examples by compiling them.
 
         Returns:
             A dict mapping source references to lists of error messages for
@@ -182,44 +203,52 @@ public class {class_name}
 
     def _create_project(self) -> dict[str, str]:
         """Generate the .csproj and wrapper files in the temp directory."""
-        csproj_content = self._CSPROJ_TEMPLATE.format(dll_path=self._glide_dll_path)
+        csproj_content = self._PROJECT_TEMPLATE.format(dll_path=self._glide_dll_path)
 
         with open(os.path.join(self._temp_dir.name, "ExampleValidation.csproj"), "w") as f:
             f.write(csproj_content)
 
         file_to_source: dict[str, str] = {}
         for source, content in self._examples.items():
-            filename = self._generate_wrapper(source, content)
+            filename = self._generate_class(source, content)
             file_to_source[filename] = source
 
         return file_to_source
 
-    def _generate_wrapper(self, source: str, content: str) -> str:
-        """Generate and write a .cs wrapper file for a single example."""
-        content = html.unescape(content)
+    def _generate_class(self, source: str, content: str) -> str:
+        """Generate and write a C# class for a single example."""
 
-        example_usings = []
+        # Extract 'using' directives from code.
+        usings = []
         code_lines = []
         for line in content.splitlines():
             if self._USING_DIRECTIVE.match(line):
-                example_usings.append(line.rstrip().rstrip(";") + ";")
+                usings.append(line)
             else:
                 code_lines.append(line)
-        content = "\n".join(code_lines).strip()
 
-        default_usings = [f"using {ns};" for ns in self._USING_NAMESPACES] + [
-            f"using static {t};" for t in self._USING_TYPES
-        ]
-        all_usings = default_usings + example_usings
-        usings = "\n".join(dict.fromkeys(all_usings))
+        if self._add_imports:
+            usings = (
+                [f"using {ns};" for ns in self._USING_NAMESPACES]
+                + [f"using static {t};" for t in self._USING_TYPES]
+                + usings
+            )
+
+        # Get fields to include
+        fields = []
+        if self._add_clients:
+            fields += self._CLIENT_FIELDS
 
         class_name = f"Example_{uuid.uuid4().hex}"
-        indented_code = textwrap.indent(content, "        ")
+        usings_str = "\n".join(dict.fromkeys(usings))
+        fields_str = "\n".join(f"    {f}" for f in fields)
+        indented_code = textwrap.indent("\n".join(code_lines).strip(), "        ")
 
-        file_content = self._WRAPPER_TEMPLATE.format(
-            source=source,
-            usings=usings,
+        file_content = self._CLASS_TEMPLATE.format(
             class_name=class_name,
+            source=source,
+            usings=usings_str,
+            fields=fields_str + "\n" if fields_str else "",
             indented_code=indented_code,
         )
 
@@ -272,6 +301,18 @@ def main():
         required=True,
         help="Path to an existing JSON file containing examples to validate.",
     )
+    parser.add_argument(
+        "--add-imports",
+        action="store_true",
+        default=False,
+        help="Include default using directives in the generated classes.",
+    )
+    parser.add_argument(
+        "--add-clients",
+        action="store_true",
+        default=False,
+        help="Include static client fields in the generated classes.",
+    )
     args = parser.parse_args()
 
     if not os.path.isfile(args.examples):
@@ -285,9 +326,11 @@ def main():
         print("No examples found in the provided file.")
         sys.exit(0)
 
-    with ExampleChecker(examples) as checker:
-        print(f"Checking {len(examples)} examples...")
-        errors = checker.check()
+    with ExamplesValidator(
+        examples, add_imports=args.add_imports, add_clients=args.add_clients
+    ) as validator:
+        print(f"Validating {len(examples)} examples...")
+        errors = validator.validate()
 
     if errors:
         print(f"\n{'='*60}")


### PR DESCRIPTION
### Summary

Refactors the monolithic `check_examples.py` script into three independently scripts. Simplies implementation and (more importantly) allow [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) to call `validate_examples.py` directly.

### Issue Link

:white_circle: None

### Features and Behaviour Changes

- `extract_examples.py`: New standalone script that extracts C# code examples from XML doc comments and writes them to a JSON file.
- `validate_examples.py`: New standalone script that compiles extracted examples against the Valkey.Glide DLL. Accepts `--glide-dll` as a CLI argument.
- `check_examples.py`: Simplified to an orchestrator that locates the DLL, runs extraction to a temp file, then validates.
- `Taskfile.yml`: Simplified `check-examples` task invocation (removed `--glide_root` flag).

### Implementation

The original `check_examples.py` contained all extraction, validation, and project-generation logic in a single file. This PR splits it into:

1. `extract_examples.py` — walks `sources/`, finds `<example><code>` blocks, outputs JSON.
2. `validate_examples.py` — reads the JSON, generates a temporary .csproj with one class per example, and compiles it. Now takes `--glide-dll` as an explicit argument rather than discovering it internally.
3. `check_examples.py` — thin orchestrator that finds the DLL (Release preferred over Debug), calls extraction, then validation via subprocess.

### Limitations

:white_circle: None

### Testing

- All three Python scripts pass `py_compile` checks.
- YAML lint passes.
- Functionality is validated by the existing `check-examples` CI workflow.

### Related Issues

- Builds on #350 which introduced the original `check_examples.py` and CI workflow.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.