### PR TITLE
feat/stream trim modes

### DIFF
--- a/sources/Valkey.Glide/Abstract/Database.StreamCommands.cs
+++ b/sources/Valkey.Glide/Abstract/Database.StreamCommands.cs
@@ -256,15 +256,20 @@ internal partial class Database
     public Task<long> StreamTrimAsync(ValkeyKey key, int maxLength, bool useApproximateMaxLength = false, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        return Command(Request.StreamTrimAsync(key, maxLength, default, useApproximateMaxLength, null));
+        return Command(Request.StreamTrimAsync(key, maxLength, default, useApproximateMaxLength, null, StreamTrimMode.KeepReferences));
     }
 
     /// <inheritdoc cref="IDatabaseAsync.StreamTrimAsync(ValkeyKey, long?, bool, long?, StreamTrimMode, CommandFlags)"/>
     public Task<long> StreamTrimAsync(ValkeyKey key, long? maxLength = null, bool useApproximateMaxLength = false, long? limit = null, StreamTrimMode trimMode = StreamTrimMode.KeepReferences, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        ThrowIfUnsupportedTrimMode(trimMode);
-        return Command(Request.StreamTrimAsync(key, maxLength, default, useApproximateMaxLength, limit));
+        return Command(Request.StreamTrimAsync(
+            key,
+            maxLength,
+            default,
+            useApproximateMaxLength,
+            limit,
+            trimMode));
     }
 
     #endregion
@@ -274,8 +279,13 @@ internal partial class Database
     public Task<long> StreamTrimByMinIdAsync(ValkeyKey key, ValkeyValue minId, bool useApproximateMaxLength = false, long? limit = null, StreamTrimMode trimMode = StreamTrimMode.KeepReferences, CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        ThrowIfUnsupportedTrimMode(trimMode);
-        return Command(Request.StreamTrimAsync(key, null, minId, useApproximateMaxLength, limit));
+        return Command(Request.StreamTrimAsync(
+            key,
+            null,
+            minId,
+            useApproximateMaxLength,
+            limit,
+            trimMode));
     }
 
     #endregion
@@ -321,19 +331,6 @@ internal partial class Database
             ? new StreamTrimOptions.MaxLen { MaxLength = maxLength.Value, Exact = !useApproximateMaxLength, Limit = limit }
             : null
     };
-
-    /// <summary>
-    /// Throws a <see cref="NotImplementedException"/> if the stream trim mode is not supported.
-    /// </summary>
-    /// <param name="trimMode">The stream trim mode to validate.</param>
-    /// <exception cref="NotImplementedException">Thrown if <paramref name="trimMode"/> is not <see cref="StreamTrimMode.KeepReferences"/>.</exception>
-    private static void ThrowIfUnsupportedTrimMode(StreamTrimMode trimMode)
-    {
-        if (trimMode != StreamTrimMode.KeepReferences)
-        {
-            throw new NotImplementedException($"Stream trim mode {trimMode} is not supported by Valkey GLIDE");
-        }
-    }
 
     #endregion
 }

--- a/sources/Valkey.Glide/Commands/Options/StreamTrimModeExtensions.cs
+++ b/sources/Valkey.Glide/Commands/Options/StreamTrimModeExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide.Commands.Options;
+
+internal static class StreamTrimModeExtensions
+{
+    internal static GlideString? ToKeyword(this StreamTrimMode trimMode)
+        => trimMode switch
+        {
+            StreamTrimMode.KeepReferences => null,
+            StreamTrimMode.DeleteReferences => ValkeyLiterals.StreamDeleteReferencesTrim.ToGlideString(),
+            StreamTrimMode.Acknowledged => ValkeyLiterals.StreamAcknowledgedTrim.ToGlideString(),
+            _ => throw new ArgumentOutOfRangeException(nameof(trimMode), trimMode, null)
+        };
+}

--- a/sources/Valkey.Glide/Commands/Options/StreamTrimOptions.cs
+++ b/sources/Valkey.Glide/Commands/Options/StreamTrimOptions.cs
@@ -22,6 +22,12 @@ public abstract class StreamTrimOptions
     /// </summary>
     public long? Limit { get; init; } = null;
 
+    /// <summary>
+    /// Controls how consumer group PEL references are handled for trimmed entries.
+    /// Requires Valkey 8.2 or later when set to a non-default value.
+    /// </summary>
+    public StreamTrimMode Mode { get; init; } = StreamTrimMode.KeepReferences;
+
     #endregion
     #region Internal Methods
 
@@ -58,6 +64,12 @@ public abstract class StreamTrimOptions
         {
             args.Add(ValkeyLiterals.LIMIT);
             args.Add(Limit.Value.ToGlideString());
+        }
+
+        GlideString? trimModeKeyword = Mode.ToKeyword();
+        if (trimModeKeyword is not null)
+        {
+            args.Add(trimModeKeyword);
         }
 
         return [.. args];

--- a/sources/Valkey.Glide/Internals/Request.StreamCommands.cs
+++ b/sources/Valkey.Glide/Internals/Request.StreamCommands.cs
@@ -663,27 +663,34 @@ internal partial class Request
     }
 
     // TODO SER only
-    public static Cmd<long, long> StreamTrimAsync(ValkeyKey key, long? maxLength, ValkeyValue minId, bool useApproximateMaxLength, long? limit)
+    public static Cmd<long, long> StreamTrimAsync(
+        ValkeyKey key,
+        long? maxLength,
+        ValkeyValue minId,
+        bool useApproximateMaxLength,
+        long? limit,
+        StreamTrimMode trimMode)
     {
         List<GlideString> args = [key.ToGlideString()];
 
         if (maxLength.HasValue)
         {
-            args.Add("MAXLEN");
+            args.Add(ValkeyLiterals.MAXLEN);
 
             if (useApproximateMaxLength)
             {
-                args.Add("~");
+                args.Add(ValkeyLiterals.StreamApproxTrim);
             }
 
             args.Add(maxLength.Value.ToGlideString());
         }
         else if (!minId.IsNull)
         {
-            args.Add("MINID");
+            args.Add(ValkeyLiterals.MINID);
+
             if (useApproximateMaxLength)
             {
-                args.Add("~");
+                args.Add(ValkeyLiterals.StreamApproxTrim);
             }
 
             args.Add(minId.ToGlideString());
@@ -691,8 +698,14 @@ internal partial class Request
 
         if (limit.HasValue && useApproximateMaxLength)
         {
-            args.Add("LIMIT");
+            args.Add(ValkeyLiterals.LIMIT);
             args.Add(limit.Value.ToGlideString());
+        }
+
+        GlideString? trimModeKeyword = trimMode.ToKeyword();
+        if (trimModeKeyword is not null)
+        {
+            args.Add(trimModeKeyword);
         }
 
         return new(RequestType.XTrim, [.. args], false, response => response);

--- a/sources/Valkey.Glide/abstract_APITypes/ValkeyLiterals.cs
+++ b/sources/Valkey.Glide/abstract_APITypes/ValkeyLiterals.cs
@@ -164,6 +164,8 @@ internal static class ValkeyLiterals
         StreamMaxId = "+",
         StreamExactTrim = "=",
         StreamApproxTrim = "~",
+        StreamDeleteReferencesTrim = "DELREF",
+        StreamAcknowledgedTrim = "ACKED",
 
         // Sorted set ranges
         RangeInclusive = "[",

--- a/sources/Valkey.Glide/abstract_Enums/SER/StreamTrimMode.cs
+++ b/sources/Valkey.Glide/abstract_Enums/SER/StreamTrimMode.cs
@@ -13,4 +13,15 @@ public enum StreamTrimMode
     /// entries in all consumer groups' PEL.
     /// </summary>
     KeepReferences = 0,
+
+    /// <summary>
+    /// Trims the stream according to the specified policy and removes references to trimmed
+    /// entries from all consumer groups' PEL.
+    /// </summary>
+    DeleteReferences = 1,
+
+    /// <summary>
+    /// Only trims entries that were acknowledged by all consumer groups.
+    /// </summary>
+    Acknowledged = 2,
 }

--- a/tests/Valkey.Glide.UnitTests/CommandTests.cs
+++ b/tests/Valkey.Glide.UnitTests/CommandTests.cs
@@ -889,6 +889,8 @@ public class CommandTests
             () => Assert.Equal(["XADD", "key", "*", "field", "value"], Request.StreamAddAsync("key", [new NameValueEntry("field", "value")], new StreamAddOptions()).GetArgs()),
             () => Assert.Equal(["XADD", "key", "1-0", "field1", "value1", "field2", "value2"], Request.StreamAddAsync("key", [new NameValueEntry("field1", "value1"), new NameValueEntry("field2", "value2")], new StreamAddOptions { Id = "1-0" }).GetArgs()),
             () => Assert.Equal(["XADD", "key", "MAXLEN", "~", "1000", "*", "field", "value"], Request.StreamAddAsync("key", [new NameValueEntry("field", "value")], new StreamAddOptions { Trim = new StreamTrimOptions.MaxLen { MaxLength = 1000, Exact = false } }).GetArgs()),
+            () => Assert.Equal(["XADD", "key", "MAXLEN", "~", "1000", "DELREF", "*", "field", "value"], Request.StreamAddAsync("key", [new NameValueEntry("field", "value")], new StreamAddOptions { Trim = new StreamTrimOptions.MaxLen { MaxLength = 1000, Exact = false, Mode = StreamTrimMode.DeleteReferences } }).GetArgs()),
+            () => Assert.Equal(["XADD", "key", "MAXLEN", "~", "1000", "ACKED", "*", "field", "value"], Request.StreamAddAsync("key", [new NameValueEntry("field", "value")], new StreamAddOptions { Trim = new StreamTrimOptions.MaxLen { MaxLength = 1000, Exact = false, Mode = StreamTrimMode.Acknowledged } }).GetArgs()),
             () => Assert.Equal(["XADD", "key", "MINID", "~", "0-1", "*", "field", "value"], Request.StreamAddAsync("key", [new NameValueEntry("field", "value")], new StreamAddOptions { Trim = new StreamTrimOptions.MinId { MinEntryId = "0-1", Exact = false } }).GetArgs()),
             () => Assert.Equal(["XADD", "key", "NOMKSTREAM", "*", "field", "value"], Request.StreamAddAsync("key", [new NameValueEntry("field", "value")], new StreamAddOptions { MakeStream = false }).GetArgs()),
 
@@ -910,9 +912,13 @@ public class CommandTests
             () => Assert.Equal(["XDEL", "key", "1-0", "2-0"], Request.StreamDeleteAsync("key", ["1-0", "2-0"]).GetArgs()),
 
             // StreamTrim
-            () => Assert.Equal(["XTRIM", "key", "MAXLEN", "1000"], Request.StreamTrimAsync("key", 1000, default, false, null).GetArgs()),
-            () => Assert.Equal(["XTRIM", "key", "MAXLEN", "~", "1000"], Request.StreamTrimAsync("key", 1000, default, true, null).GetArgs()),
-            () => Assert.Equal(["XTRIM", "key", "MINID", "0-1"], Request.StreamTrimAsync("key", null, "0-1", false, null).GetArgs()),
+            () => Assert.Equal(["XTRIM", "key", "MAXLEN", "1000"], Request.StreamTrimAsync("key", 1000, default, false, null, StreamTrimMode.KeepReferences).GetArgs()),
+            () => Assert.Equal(["XTRIM", "key", "MAXLEN", "~", "1000"], Request.StreamTrimAsync("key", 1000, default, true, null, StreamTrimMode.KeepReferences).GetArgs()),
+            () => Assert.Equal(["XTRIM", "key", "MAXLEN", "~", "1000", "LIMIT", "10", "DELREF"], Request.StreamTrimAsync("key", 1000, default, true, 10, StreamTrimMode.DeleteReferences).GetArgs()),
+            () => Assert.Equal(["XTRIM", "key", "MAXLEN", "1000", "DELREF"], Request.StreamTrimAsync("key", 1000, default, false, null, StreamTrimMode.DeleteReferences).GetArgs()),
+            () => Assert.Equal(["XTRIM", "key", "MAXLEN", "1000", "ACKED"], Request.StreamTrimAsync("key", 1000, default, false, null, StreamTrimMode.Acknowledged).GetArgs()),
+            () => Assert.Equal(["XTRIM", "key", "MINID", "0-1"], Request.StreamTrimAsync("key", null, "0-1", false, null, StreamTrimMode.KeepReferences).GetArgs()),
+            () => Assert.Equal(["XTRIM", "key", "MINID", "0-1", "DELREF"], Request.StreamTrimAsync("key", null, "0-1", false, null, StreamTrimMode.DeleteReferences).GetArgs()),
 
             // StreamCreateConsumerGroup
             () => Assert.Equal(["XGROUPCREATE", "key", "group", "$", "MKSTREAM"], Request.StreamCreateConsumerGroupAsync("key", "group", default, true, null).GetArgs()),
@@ -996,7 +1002,7 @@ public class CommandTests
             () => Assert.Equal(0L, Request.StreamDeleteAsync("key", ["1-0"]).Converter(0L)),
 
             // StreamTrim
-            () => Assert.Equal(10L, Request.StreamTrimAsync("key", 100, default, false, null).Converter(10L)),
+            () => Assert.Equal(10L, Request.StreamTrimAsync("key", 100, default, false, null, StreamTrimMode.KeepReferences).Converter(10L)),
 
             // StreamCreateConsumerGroup
             () => Assert.True(Request.StreamCreateConsumerGroupAsync("key", "group", default, true, null).Converter("OK")),


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our [contributing guidelines](https://github.com/valkey-io/valkey-glide-csharp/blob/main/CONTRIBUTING.md).
-->

### Summary

Adds support for the Valkey 8.2 stream trim modes `DELREF` and `ACKED` in the C# client.

### Issue Link

This pull request is linked to issue: [Closes #311 ](https://github.com/valkey-io/valkey-glide-csharp/issues/311)

### Features and Behaviour Changes

- Adds `DeleteReferences` and `Acknowledged` values to `StreamTrimMode`.
- Allows `StreamTrimOptions` to emit `DELREF` and `ACKED` for stream trimming.
- Adds trim mode support to `XTRIM` command argument construction.
- Keeps the default `KeepReferences` behavior unchanged and does not emit `KEEPREF`, preserving backward compatibility with older servers.

### Implementation

- Added stream trim mode literals for `DELREF` and `ACKED`.
- Added an internal `StreamTrimModeExtensions.ToKeyword()` helper to centralize mapping from `StreamTrimMode` to command keywords.
- Updated `StreamTrimOptions.ToArgs()` to append the trim mode keyword after `LIMIT`, matching the command syntax.
- Updated `Request.StreamTrimAsync()` to accept a `StreamTrimMode` and include the corresponding keyword in generated `XTRIM` arguments.
- Removed the previous unsupported-trim-mode guard from the database stream command path.
- Updated command argument tests to cover `DELREF`, `ACKED`, default behavior, and `LIMIT` ordering.

### Limitations


`DELREF` and `ACKED` require Valkey 8.2 or later. The client does not perform a local server-version check; unsupported servers will return the server-side command error.

`KeepReferences` remains the default mode and is not emitted as `KEEPREF` to preserve existing behavior and compatibility with older servers.

### Testing

Updated unit tests for stream command argument generation.


Ran:

```bash
dotnet test tests/Valkey.Glide.UnitTests/Valkey.Glide.UnitTests.csproj --filter "FullyQualifiedName~ValidateStreamCommandArgs"
dotnet test tests/Valkey.Glide.UnitTests/Valkey.Glide.UnitTests.csproj --filter "FullyQualifiedName~ValidateStreamCommandConverters"
```

### Related Issues

Closes #311 

### Checklist

<!--
Before submitting the PR make sure the following are checked.
Not applicable items should be crossed out, not removed.
-->

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [ ] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
