### PR TITLE
refactor: remove PreExecCheck leaky abstraction and fix sync-over-async in ValkeyTransaction

### DIFF
--- a/sources/Valkey.Glide/Abstract/ValkeyBatch.cs
+++ b/sources/Valkey.Glide/Abstract/ValkeyBatch.cs
@@ -30,8 +30,6 @@ internal class ValkeyBatch(BaseClient client) : Database(false), IBatch
                 : (T)batchResult[idx]!;
     }
 
-    protected virtual bool PreExecCheck() => true;
-
     protected async Task ExecuteImpl()
     {
         if (_tcs.Task.Status == TaskStatus.RanToCompletion)
@@ -39,23 +37,16 @@ internal class ValkeyBatch(BaseClient client) : Database(false), IBatch
             // a batch is already executed
             return;
         }
-        if (PreExecCheck())
+        if (_commands.Count == 0)
         {
-            if (_commands.Count == 0)
-            {
-                _tcs.SetResult([]);
-                return;
-            }
-            Batch b = new(_isAtomic);
-            b.Commands.AddRange(_commands);
+            _tcs.SetResult([]);
+            return;
+        }
+        Batch b = new(_isAtomic);
+        b.Commands.AddRange(_commands);
 
-            object?[]? res = await _client.Batch(b, false);
-            _tcs.SetResult(res);
-        }
-        else
-        {
-            _tcs.SetResult(null);
-        }
+        object?[]? res = await _client.Batch(b, false);
+        _tcs.SetResult(res);
     }
 
     public void Execute() => ExecuteImpl().GetAwaiter().GetResult();

--- a/sources/Valkey.Glide/Abstract/ValkeyTransaction.cs
+++ b/sources/Valkey.Glide/Abstract/ValkeyTransaction.cs
@@ -27,28 +27,33 @@ internal class ValkeyTransaction : ValkeyBatch, ITransaction
     public async Task<bool> ExecuteAsync(CommandFlags flags = CommandFlags.None)
     {
         GuardClauses.ThrowIfCommandFlags(flags);
-        await ExecuteImpl();
-        return _tcs.Task.Result is not null;
-    }
 
-    protected override bool PreExecCheck()
-    {
-        bool allConditionsPassed = true;
+        // Evaluate all conditions asynchronously before submitting the transaction.
+        // This replaces the former sync-over-async PreExecCheck() override in the
+        // base class, keeping transaction-specific logic here rather than leaking
+        // it into ValkeyBatch.
         foreach (ConditionResult condition in _conditions)
         {
-            // We can't access internals of batch, but we can create a transaction, "downcast" it to batch and patch it
-            ValkeyTransaction b = new(_client)
+            // Execute the condition commands in a non-atomic batch to check the
+            // current state of the watched keys.
+            ValkeyTransaction conditionBatch = new(_client)
             {
                 _isAtomic = false
             };
-            b._commands.AddRange(condition.Condition.CreateCommands());
-            b.ExecuteImpl().GetAwaiter().GetResult();
-            condition.WasSatisfied = condition.Condition.Validate(b._tcs.Task.Result);
+            conditionBatch._commands.AddRange(condition.Condition.CreateCommands());
+            await conditionBatch.ExecuteImpl();
+
+            condition.WasSatisfied = condition.Condition.Validate(conditionBatch._tcs.Task.Result);
             if (!condition.WasSatisfied)
             {
-                allConditionsPassed = false;
+                // At least one condition failed — cancel the transaction without
+                // submitting the MULTI/EXEC block.
+                _tcs.SetResult(null);
+                return false;
             }
         }
-        return allConditionsPassed;
+
+        await ExecuteImpl();
+        return _tcs.Task.Result is not null;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #266

## Problems

**1. Leaky abstraction**
`ValkeyBatch` defined a `virtual bool PreExecCheck()` hook called from `ExecuteImpl()`. The base implementation was a no-op (`return true`), and `ValkeyTransaction` overrode it to evaluate preconditions before submitting the `MULTI`/`EXEC` block. Batches have no concept of preconditions — this was transaction-specific logic leaking into the base class.

**2. Sync-over-async**
`ValkeyTransaction.PreExecCheck()` called `b.ExecuteImpl().GetAwaiter().GetResult()` — the last remaining sync-over-async call in the codebase. This risks deadlocks in environments with a synchronization context (e.g. ASP.NET, UI frameworks).

## Changes

**`ValkeyBatch.cs`**
- Remove `virtual bool PreExecCheck()`
- Remove the `if (PreExecCheck()) { ... } else { _tcs.SetResult(null); }` guard from `ExecuteImpl()`. `ExecuteImpl()` now unconditionally executes the batch, which is correct — conditions are a transaction concern only.

**`ValkeyTransaction.cs`**
- Remove `protected override bool PreExecCheck()`
- Move condition evaluation into `ExecuteAsync()` directly, using `await` instead of `.GetAwaiter().GetResult()`
- Short-circuit early (set `_tcs` result to `null` and return `false`) as soon as any condition fails, avoiding unnecessary work
- Rename inner batch variable from `b` to `conditionBatch` for clarity