### PR TITLE
Prevent implicit Valkey.Glide type resolution in example validation

### DIFF
--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -55,12 +55,12 @@ class ExamplesValidator:
 
     # Type imports (using static) to include when --add-imports is specified.
     _USING_TYPES = [
+        "Valkey.Glide.Commands.Options.BitFieldOptions.Encoding",
+        "Valkey.Glide.Commands.Options.BitFieldOptions",
+        "Valkey.Glide.Commands.Options.InfoOptions",
         "Valkey.Glide.Pipeline.Batch",
         "Valkey.Glide.Pipeline.ClusterBatch",
-        "Valkey.Glide.Commands.Options.InfoOptions",
-        "Valkey.Glide.Commands.Options.BitFieldOptions",
-        "Valkey.Glide.Commands.Options.BitFieldOptions.Encoding",
-        "Valkey.Glide.ServerModules.GlideJson",
+        "Valkey.Glide.Pipeline.Options",
     ]
 
     # Client fields to include when --add-clients is specified.

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -136,9 +136,10 @@ public class {class_name}
             add_imports: If True, include default using directives in the generated class.
             add_clients: If True, include static client fields in the generated class.
         """
-        self._examples = examples
-        self._add_imports = add_imports
-        self._add_clients = add_clients
+        self._examples: dict[str, str] = examples
+        self._add_imports: bool = add_imports
+        self._add_clients: bool = add_clients
+
         self._temp_dir = tempfile.TemporaryDirectory()
         self._glide_dll_path = os.path.abspath(glide_dll)
 
@@ -169,48 +170,58 @@ public class {class_name}
         """Validate the examples by compiling them.
 
         Returns:
-            A dict mapping source references to lists of error messages for
-            examples that failed compilation. An empty dict means all examples
-            compiled successfully.
+            A dict mapping source references to lists of error messages.
+            An empty dict means all examples were successfully validated.
         """
         if not self._examples:
             return {}
 
-        file_to_source = self._create_project()
-        return self._build_project(file_to_source)
+        self._file_to_source: dict[str, str] = {}
+        self._source_to_errors: dict[str, list[str]] = {}
 
-    def _create_project(self) -> dict[str, str]:
+        self._create_project()
+        self._build_project()
+
+        return self._source_to_errors
+
+    def _create_project(self) -> None:
         """Generate the .csproj and wrapper files in the temp directory."""
         csproj_content = self._PROJECT_TEMPLATE.format(dll_path=self._glide_dll_path)
 
         with open(os.path.join(self._temp_dir.name, "ExampleValidation.csproj"), "w") as f:
             f.write(csproj_content)
 
-        file_to_source: dict[str, str] = {}
         for source, content in self._examples.items():
-            filename = self._generate_class(source, content)
-            file_to_source[filename] = source
+            self._generate_class(source, content)
 
-        return file_to_source
-
-    def _generate_class(self, source: str, content: str) -> str:
+    def _generate_class(self, source: str, content: str) -> None:
         """Generate and write a C# class for a single example."""
 
+        using_directives = []
+
         # Extract 'using' directives from code.
-        usings = []
         code_lines = []
         for line in content.splitlines():
             if self._USING_DIRECTIVE.match(line):
-                usings.append(line)
+                using_directives.append(line)
             else:
                 code_lines.append(line)
 
+        # Add default 'using' directives.
         if self._add_imports:
-            usings = (
-                [f"using {ns};" for ns in self._USING_NAMESPACES]
-                + [f"using static {t};" for t in self._USING_TYPES]
-                + usings
-            )
+            using_directives += [f"using {ns};" for ns in self._USING_NAMESPACES]
+            using_directives += [f"using static {t};" for t in self._USING_TYPES]
+
+        # Detect duplicate using directives.
+        using_directives_set: set[str] = set()
+        for u in using_directives:
+            normalized = u.strip()
+            if normalized in using_directives_set:
+                self._source_to_errors.setdefault(source, []).append(
+                    f"Duplicate import: {normalized}"
+                )
+            else:
+                using_directives_set.add(normalized)
 
         # Get fields to include
         fields = []
@@ -218,7 +229,7 @@ public class {class_name}
             fields += self._CLIENT_FIELDS
 
         class_name = f"Example_{uuid.uuid4().hex}"
-        usings_str = "\n".join(dict.fromkeys(usings))
+        usings_str = "\n".join(using_directives_set)
         fields_str = "\n".join(f"    {f}" for f in fields)
         indented_code = textwrap.indent("\n".join(code_lines).strip(), "        ")
 
@@ -235,10 +246,10 @@ public class {class_name}
         with open(filepath, "w") as f:
             f.write(file_content)
 
-        return filename
+        self._file_to_source[filename] = source
 
-    def _build_project(self, file_to_source: dict[str, str]) -> dict[str, list[str]]:
-        """Run dotnet build and return errors mapped by source."""
+    def _build_project(self) -> None:
+        """Run dotnet build and record compilation errors."""
         result = subprocess.run(
             ["dotnet", "build", "--framework", "net8.0"],
             cwd=self._temp_dir.name,
@@ -248,26 +259,32 @@ public class {class_name}
             text=True,
         )
 
+        # Build succeeded:
         if result.returncode == 0:
-            return {}
+            return
 
-        errors: dict[str, list[str]] = {}
+        # Build failed with matching errors:
+        found_errors = False
         for line in result.stdout.splitlines():
             match = self._ERROR_PATTERN.search(line)
             if match:
+                found_errors = True
                 basename = os.path.basename(match.group("file"))
-                source = file_to_source.get(basename, basename)
-                errors.setdefault(source, []).append(match.group("message").strip())
+                source = self._file_to_source.get(basename, basename)
+                self._source_to_errors.setdefault(source, []).append(
+                    match.group("message").strip()
+                )
 
-        if not errors:
-            fallback = [f"dotnet build failed with exit code {result.returncode}."]
-            raw = result.stdout.strip()
-            if raw:
-                fallback.append("Raw build output:")
-                fallback.extend(raw.splitlines())
-            errors["<build>"] = fallback
+        if found_errors:
+            return
 
-        return errors
+        # Build failed without any matching errors:
+        fallback = [f"dotnet build failed with exit code {result.returncode}."]
+        raw = result.stdout.strip()
+        if raw:
+            fallback.append("Raw build output:")
+            fallback.extend(raw.splitlines())
+        self._source_to_errors.setdefault("<build>", []).extend(fallback)
 
 
 def main():

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -97,7 +97,7 @@ class ExamplesValidator:
 
 {usings}
 
-namespace Valkey.Glide.ExampleValidation;
+namespace ExampleValidation;
 
 public class {class_name}
 {{

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -24,10 +24,8 @@ Usage:
 Options:
     --examples      Path to an existing JSON file containing examples to validate.
     --glide-dll     Path to the built Valkey.Glide.dll to reference during compilation.
-    --add-imports   Include default using directives (Valkey.Glide namespaces) in
-                    the generated classes. Disabled by default.
-    --add-clients   Include static client fields (GlideClient, GlideClusterClient,
-                    IDatabase, IServer) in the generated classes. Disabled by default.
+    --add-imports   Include default using directives in the generated classes. Disabled by default.
+    --add-clients   Include static client fields in the generated classes. Disabled by default.
 """
 
 import argparse

--- a/sources/Valkey.Glide/Commands/IGenericClusterCommands.cs
+++ b/sources/Valkey.Glide/Commands/IGenericClusterCommands.cs
@@ -176,8 +176,7 @@ public interface IGenericClusterCommands
     /// <example>
     /// <code>
     /// // Example 1: Atomic Batch (Transaction) all keys must share the same hash slot
-    /// Pipeline.Options.ClusterBatchOptions options = new(
-    ///     timeout: 1000); // Set a timeout of 1000 milliseconds
+    /// var options = new ClusterBatchOptions(timeout: 1000); // Set a timeout of 1000 milliseconds
     ///
     /// var batch = new ClusterBatch(true) // Atomic (Transaction)
     ///     .SetAsync("key", "1")
@@ -191,8 +190,8 @@ public interface IGenericClusterCommands
     /// <example>
     /// <code>
     /// // Example 2: Non-Atomic Batch (Pipeline)
-    /// var retryStrategy = new Pipeline.Options.ClusterBatchRetryStrategy(retryServerError: true, retryConnectionError: false);
-    /// Pipeline.Options.ClusterBatchOptions options = new(retryStrategy: retryStrategy);
+    /// var retryStrategy = new ClusterBatchRetryStrategy(retryServerError: true, retryConnectionError: false);
+    /// var options = new ClusterBatchOptions(retryStrategy: retryStrategy);
     ///
     /// var batch = new ClusterBatch(false) // Non-Atomic (Pipeline) keys may span different hash slots
     ///     .SetAsync("key1", "value1")

--- a/sources/Valkey.Glide/Commands/IGenericCommands.cs
+++ b/sources/Valkey.Glide/Commands/IGenericCommands.cs
@@ -102,8 +102,7 @@ public interface IGenericCommands
     /// <example>
     /// <code>
     /// // Example 1: Atomic Batch (Transaction)
-    /// Pipeline.Options.BatchOptions options = new(
-    ///     timeout: 1000); // Set a timeout of 1000 milliseconds
+    /// var options = new BatchOptions(timeout: 1000); // Set a timeout of 1000 milliseconds
     ///
     /// var batch = new Batch(true) // Atomic (Transaction)
     ///     .SetAsync("key", "1")
@@ -117,8 +116,7 @@ public interface IGenericCommands
     /// <example>
     /// <code>
     /// // Example 2: Non-Atomic Batch (Pipeline)
-    /// Pipeline.Options.BatchOptions options = new(
-    ///     timeout: 1000); // Set a timeout of 1000 milliseconds
+    /// var options = new BatchOptions(timeout: 1000); // Set a timeout of 1000 milliseconds
     ///
     /// var batch = new Batch(false) // Non-Atomic (Pipeline) keys may span different hash slots
     ///     .SetAsync("key1", "value1")


### PR DESCRIPTION
### Summary

Prevent example validation wrapper classes from implicitly resolving `Valkey.Glide` types, and add duplicate import detection.

### Issue Link

:white_circle: None

### Features and Behaviour Changes

- Wrapper classes now use `namespace ExampleValidation` instead of `namespace Valkey.Glide.ExampleValidation`, so `Valkey.Glide` types are only available when `--add-imports` is specified.
- The validator now detects and reports duplicate `using` directives as errors.

### Implementation

- Changed the generated namespace from `Valkey.Glide.ExampleValidation` to `ExampleValidation`.
- Added `using static Valkey.Glide.Pipeline.Options` to the default imports to support examples that reference `Pipeline.Options.*` types.
- Added duplicate import detection in `_generate_class` that reports errors when a `using` directive appears more than once in the combined list.
- Refactored internal state to use `self._source_to_errors` and `self._file_to_source` attributes populated by helper methods.

### Limitations

:white_circle: None

### Testing

- `task check-examples` passes (534 examples compiled successfully).
- `task lint:csharp` passes with zero warnings/errors.

### Related Issues

:white_circle: None

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
