### PR TITLE
Security hardening: FFI integer overflow prevention, credential leakage fix, and CI/CD pinning

### DIFF
--- a/.github/workflows/_reusable-test.yml
+++ b/.github/workflows/_reusable-test.yml
@@ -48,7 +48,7 @@ jobs:
                       exit 1
                   fi
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   sparse-checkout: .github/json_matrices
 
@@ -74,7 +74,7 @@ jobs:
             VALKEY_GLIDE_DNS_TESTS_ENABLED: "1"
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
@@ -90,7 +90,7 @@ jobs:
                   echo "Package version: $PACKAGE_VERSION"
 
             - name: Set up dotnet ${{ matrix.dotnet }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: |
                       9
@@ -100,7 +100,7 @@ jobs:
 
             - name: Download package artifact
               if: ${{ inputs.package-artifact-name != '' }}
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: ${{ inputs.package-artifact-name }}
                   path: nuget.local
@@ -146,7 +146,7 @@ jobs:
                       echo "$ENTRIES" | sudo tee -a /etc/hosts
                   fi
 
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               if: ${{ inputs.package-version == '' }}
               with:
                   path: rust/target
@@ -190,7 +190,7 @@ jobs:
             - name: Upload test reports
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.server.type }}-${{ matrix.server.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
@@ -222,7 +222,7 @@ jobs:
                   yum update -y
                   yum install -y git tar findutils libicu
 
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
@@ -238,7 +238,7 @@ jobs:
                   echo "Package version: $PACKAGE_VERSION"
 
             - name: Set up dotnet ${{ matrix.dotnet }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: |
                       9
@@ -261,7 +261,7 @@ jobs:
                   ::1 valkey.glide.test.no_tls.com"
                   echo "$ENTRIES" | tee -a /etc/hosts
 
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: rust/target
                   key: rust-${{ matrix.host.IMAGE }}
@@ -295,7 +295,7 @@ jobs:
             - name: Upload test reports
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.server.type }}-${{ matrix.server.version }}-${{ matrix.host.IMAGE }}-${{ matrix.host.ARCH }}
                   path: |

--- a/.github/workflows/api-compatibility.yml
+++ b/.github/workflows/api-compatibility.yml
@@ -25,12 +25,12 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: |
                       8.x
@@ -91,7 +91,7 @@ jobs:
 
             - name: Upload API Diff Report (net8.0)
               if: always()
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: api-diff-net8.0
                   path: api-diff/api-changes-net8.0.html

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
             PLATFORM_MATRIX: ${{ steps.load-platform-matrix.outputs.PLATFORM_MATRIX }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: load-platform-matrix
               id: load-platform-matrix
@@ -77,7 +77,7 @@ jobs:
         runs-on: ${{ matrix.host.RUNNER }}
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
@@ -94,7 +94,7 @@ jobs:
                   target: ${{ matrix.host.TARGET }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: rust/target
                   key: rust-${{ matrix.host.TARGET }}
@@ -113,7 +113,7 @@ jobs:
 
             - name: Upload artifacts to publish
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: ${{ matrix.host.TARGET }}
                   if-no-files-found: error
@@ -128,10 +128,10 @@ jobs:
         env:
             RELEASE_VERSION: ${{ needs.set-release-version.outputs.RELEASE_VERSION }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Download published artifacts
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   path: bin
 
@@ -142,7 +142,7 @@ jobs:
                   tree -h
 
             - name: Set up dotnet
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   # install all supported versions + latest dotnet too to use language features
                   dotnet-version: |
@@ -163,7 +163,7 @@ jobs:
                   SkipCargo: true
 
             - name: Upload artifacts to publish
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: package
                   if-no-files-found: error
@@ -178,7 +178,7 @@ jobs:
             RELEASE_VERSION: ${{ needs.set-release-version.outputs.RELEASE_VERSION }}
         steps:
             - name: Download package
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: package
 
@@ -220,19 +220,19 @@ jobs:
         env:
             RELEASE_VERSION: ${{ needs.set-release-version.outputs.RELEASE_VERSION }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
             - name: Download package
               if: ${{ needs.publish.result == 'skipped' }}
-              uses: actions/download-artifact@v8
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   name: package
                   path: nuget.local
 
             - name: Set up dotnet
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   # install latest dotnet to use language features
                   dotnet-version: |
@@ -266,7 +266,7 @@ jobs:
             - name: Setup WSL (Windows only)
               # WSL2 is not available on windows-11-arm runners (no Hyper-V).
               if: ${{ matrix.host.OS == 'windows' && matrix.host.ARCH != 'arm64' }}
-              uses: Vampire/setup-wsl@v7
+              uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
               with:
                   distribution: Ubuntu-22.04
                   additional-packages: build-essential git make pkg-config libssl-dev
@@ -289,7 +289,7 @@ jobs:
             - name: Upload test reports
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: test-reports-${{ matrix.host.TARGET }}
                   path: |

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -17,17 +17,17 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: "8.0.x"
 
             - name: Setup Python
-              uses: actions/setup-python@v6
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: "3.12"
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,13 +17,13 @@ jobs:
         timeout-minutes: 10
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   # Allow validation of links to files in the valkey-glide submodule.
                   submodules: true
 
             - name: Check links
-              uses: lycheeverse/lychee-action@v2.8.0
+              uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
               with:
                   args: --config lychee.toml .
                   fail: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,19 +29,19 @@ jobs:
             security-events: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
               with:
                   languages: csharp
                   build-mode: manual
 
             # C# Build
             - name: Setup .NET
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: "8.0.x"
 
@@ -50,6 +50,6 @@ jobs:
               run: dotnet build sources/Valkey.Glide/Valkey.Glide.csproj --configuration Lint --framework net8.0
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
               with:
                   category: "/language:csharp"

--- a/.github/workflows/git-secrets-scan.yml
+++ b/.github/workflows/git-secrets-scan.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install git-secrets
               run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,20 +17,20 @@ jobs:
         timeout-minutes: 20
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
             - name: Install Rust toolchain
               uses: ./.github/workflows/install-rust
 
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: rust/target
                   key: rust-x86_64-unknown-linux-gnu
 
             - name: Set up dotnet
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: |
                       9

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -42,7 +42,7 @@ jobs:
         env:
             ATTRIBUTIONS_FILE: THIRD_PARTY_LICENSES
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
@@ -51,13 +51,13 @@ jobs:
                   echo "TARGET_COMMIT=`git rev-parse HEAD`" >> $GITHUB_ENV
 
             - name: Set up JDK 11 for the ORT package
-              uses: actions/setup-java@v5
+              uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
               with:
                   distribution: "temurin"
                   java-version: 11
 
             - name: Cache ORT and Gradle packages
-              uses: actions/cache@v5
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               id: cache-ort
               with:
                   path: |
@@ -68,7 +68,7 @@ jobs:
 
             - name: Checkout ORT Repository
               if: steps.cache-ort.outputs.cache-hit != 'true'
-              uses: actions/checkout@v6
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   repository: oss-review-toolkit/ort
                   path: ./ort
@@ -81,7 +81,7 @@ jobs:
               run: mv ./ort /tmp
 
             - name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
             - name: Install ScanCode Toolkit
               run: |
@@ -108,7 +108,7 @@ jobs:
                   cat ~/.ort/config/config.yml
 
             - name: Set up dotnet
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: |
                       6
@@ -142,7 +142,7 @@ jobs:
             - name: Upload ORT results
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: ort_results
                   path: |
@@ -167,7 +167,7 @@ jobs:
 
             - name: Upload the final package list
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: final-package-list-${{ steps.date.outputs.date }}
                   path: |
@@ -176,7 +176,7 @@ jobs:
 
             - name: Upload the skipped package list
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: skipped-package-list-${{ steps.date.outputs.date }}
                   path: |
@@ -185,7 +185,7 @@ jobs:
 
             - name: Upload the unknown/unapproved package list
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: unapproved-package-list-${{ steps.date.outputs.date }}
                   path: |
@@ -217,7 +217,7 @@ jobs:
             - name: Create or update pull request
               if: ${{ env.FOUND_DIFF  == 'true' }}
               id: create-pr
-              uses: peter-evans/create-pull-request@v8
+              uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   sign-commits: true

--- a/.github/workflows/report-failures.yml
+++ b/.github/workflows/report-failures.yml
@@ -19,7 +19,7 @@ jobs:
         steps:
             - name: Download inputs.json artifact (if present)
               id: inputs
-              uses: dawidd6/action-download-artifact@v21
+              uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
               continue-on-error: true
               with:
                   run_id: ${{ github.event.workflow_run.id }}
@@ -28,7 +28,7 @@ jobs:
 
             - name: Gate on full-matrix runs
               id: gate
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               with:
                   github-token: ${{ github.token }}
                   script: |
@@ -63,7 +63,7 @@ jobs:
                       return should;
 
             - name: Download artifacts from triggering run
-              uses: dawidd6/action-download-artifact@v21
+              uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
               if: ${{ steps.gate.outputs.result == 'true' }}
               with:
                   run_id: ${{ github.event.workflow_run.id }}
@@ -163,7 +163,7 @@ jobs:
 
             - name: Find or create rolling failure issue
               id: ensure_issue
-              uses: actions/github-script@v9
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               if: ${{ steps.gate.outputs.result == 'true' }}
               env:
                   SUMMARY_PATH: ${{ steps.aggregate.outputs.summary_path }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,6 +37,6 @@ jobs:
 
         steps:
             # Fetch project source with GitHub Actions Checkout.
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             # Run the "semgrep ci" command on the command line of the docker image.
             - run: semgrep ci --config auto --no-suppress-errors --exclude-rule generic.secrets.security.detected-private-key.detected-private-key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
             VALKEY_GLIDE_DNS_TESTS_ENABLED: "1"
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
@@ -69,7 +69,7 @@ jobs:
                   echo "${{ toJson(matrix) }}"
 
             - name: Set up dotnet ${{ matrix.dotnet }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   # install latest dotnet too to use language features
                   dotnet-version: |
@@ -99,7 +99,7 @@ jobs:
                       echo "$ENTRIES" | sudo tee -a /etc/hosts
                   fi
 
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: rust/target
                   key: rust-${{ matrix.host.TARGET }}
@@ -146,7 +146,7 @@ jobs:
             - name: Upload test reports
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.server.type }}-${{ matrix.server.version }}-${{ matrix.host.OS }}-${{ matrix.host.ARCH }}
                   path: |
@@ -164,12 +164,12 @@ jobs:
             matrix:
                 dotnet: ["8.0"]
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
             - name: Set up dotnet ${{ matrix.dotnet }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   dotnet-version: |
                       9
@@ -185,7 +185,7 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   server-version: "9.0"
 
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: rust/target
                   key: rust-x86_64-unknown-linux-gnu
@@ -230,7 +230,7 @@ jobs:
             - name: Upload test reports
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: module-test-reports-net${{ matrix.dotnet }}
                   path: |
@@ -247,7 +247,7 @@ jobs:
             version-matrix-output: ${{ steps.get-matrices.outputs.version-matrix-output }}
 
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - id: get-matrices
               uses: ./.github/workflows/create-test-matrices
               with:
@@ -276,12 +276,12 @@ jobs:
                   yum install -y git tar findutils libicu
                   echo IMAGE=amazonlinux:latest | sed -r 's/:/-/g' >> $GITHUB_ENV
             # Replace `:` in the variable otherwise it can't be used in `upload-artifact`
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   submodules: true
 
             - name: Set up dotnet ${{ matrix.dotnet }}
-              uses: actions/setup-dotnet@v5
+              uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
               with:
                   # install latest dotnet too to use language features
                   dotnet-version: |
@@ -305,7 +305,7 @@ jobs:
                   ::1 valkey.glide.test.no_tls.com"
                   echo "$ENTRIES" | tee -a /etc/hosts
 
-            - uses: actions/cache@v5
+            - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
               with:
                   path: rust/target
                   key: rust-${{ matrix.host.IMAGE }}
@@ -344,7 +344,7 @@ jobs:
             - name: Upload test reports
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v7
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: test-reports-dotnet-${{ matrix.dotnet }}-${{ matrix.server.type }}-${{ matrix.server.version }}-${{ matrix.host.IMAGE }}-${{ matrix.host.ARCH }}
                   path: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of
 
 ## Security issue notifications
 
-[Reporting a Vulnerability](./SECURITY.md)
+[Reporting a Vulnerability](https://github.com/valkey-io/valkey-glide-csharp/security/policy)
 
 ## Licensing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,0 @@
-# Reporting a Vulnerability
-
-If you believe you've discovered a security vulnerability, please contact the Valkey team at <security@lists.valkey.io>.
-Please *DO NOT* create an issue.
-We follow a responsible disclosure procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publicly.
-If you would like to be added to our list of vendors, please reach out to the Valkey team at <valkey-glide@lists.valkey.io>.

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -620,16 +620,20 @@ pub struct ResponseValue {
 }
 
 impl ResponseValue {
-    /// Safely convert a `usize` length to `u32`, returning an error if it exceeds `u32::MAX`.
-    fn checked_size(len: usize, context: &str) -> Result<u32, String> {
-        u32::try_from(len).map_err(|_| {
+    /// Validate that `vec.len()` fits in `u32`, then transfer ownership of the vec to a raw
+    /// pointer with the validated size. The size check happens *before* the ownership transfer,
+    /// so the vec is dropped normally if validation fails.
+    fn convert_vec_to_ffi<T>(vec: Vec<T>, context: &str) -> Result<(*const T, u32), String> {
+        let size = u32::try_from(vec.len()).map_err(|_| {
             format!(
                 "Response {} size ({}) exceeds maximum FFI size ({})",
                 context,
-                len,
+                vec.len(),
                 u32::MAX
             )
-        })
+        })?;
+        let (ptr, _) = convert_vec_to_pointer(vec);
+        Ok((ptr, size))
     }
 
     /// Build [`ResponseValue`] from a [`Value`].
@@ -648,8 +652,7 @@ impl ResponseValue {
                 size: 0,
             }),
             Value::BulkString(text) => {
-                let (vec_ptr, len) = convert_vec_to_pointer(text);
-                let size = Self::checked_size(len, "BulkString")?;
+                let (vec_ptr, size) = Self::convert_vec_to_ffi(text, "BulkString")?;
                 Ok(ResponseValue {
                     typ: ValueType::BulkString,
                     val: vec_ptr as i64,
@@ -661,8 +664,7 @@ impl ResponseValue {
                     .into_iter()
                     .map(ResponseValue::from_value)
                     .collect::<Result<Vec<_>, _>>()?;
-                let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                let size = Self::checked_size(len, "Array")?;
+                let (vec_ptr, size) = Self::convert_vec_to_ffi(vec, "Array")?;
                 Ok(ResponseValue {
                     typ: ValueType::Array,
                     val: vec_ptr as i64,
@@ -674,8 +676,7 @@ impl ResponseValue {
                     .into_iter()
                     .map(ResponseValue::from_value)
                     .collect::<Result<Vec<_>, _>>()?;
-                let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                let size = Self::checked_size(len, "Set")?;
+                let (vec_ptr, size) = Self::convert_vec_to_ffi(vec, "Set")?;
                 Ok(ResponseValue {
                     typ: ValueType::Set,
                     val: vec_ptr as i64,
@@ -699,8 +700,7 @@ impl ResponseValue {
                     .into_iter()
                     .flatten()
                     .collect();
-                let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                let size = Self::checked_size(len, "Map")?;
+                let (vec_ptr, size) = Self::convert_vec_to_ffi(vec, "Map")?;
                 Ok(ResponseValue {
                     typ: ValueType::Map,
                     val: vec_ptr as i64,
@@ -718,8 +718,7 @@ impl ResponseValue {
                 size: 0,
             }),
             Value::VerbatimString { format: _, text } | Value::SimpleString(text) => {
-                let (vec_ptr, len) = convert_vec_to_pointer(text.into_bytes());
-                let size = Self::checked_size(len, "String")?;
+                let (vec_ptr, size) = Self::convert_vec_to_ffi(text.into_bytes(), "String")?;
                 Ok(ResponseValue {
                     typ: ValueType::String,
                     val: vec_ptr as i64,
@@ -727,9 +726,8 @@ impl ResponseValue {
                 })
             }
             Value::ServerError(err) => {
-                let (vec_ptr, len) =
-                    convert_vec_to_pointer(err.details().unwrap().as_bytes().to_vec());
-                let size = Self::checked_size(len, "Error")?;
+                let (vec_ptr, size) =
+                    Self::convert_vec_to_ffi(err.details().unwrap().as_bytes().to_vec(), "Error")?;
                 Ok(ResponseValue {
                     typ: ValueType::Error,
                     val: vec_ptr as i64,

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -620,90 +620,121 @@ pub struct ResponseValue {
 }
 
 impl ResponseValue {
+    /// Safely convert a `usize` length to `u32`, returning an error if it exceeds `u32::MAX`.
+    fn checked_size(len: usize, context: &str) -> Result<u32, String> {
+        u32::try_from(len).map_err(|_| {
+            format!(
+                "Response {} size ({}) exceeds maximum FFI size ({})",
+                context,
+                len,
+                u32::MAX
+            )
+        })
+    }
+
     /// Build [`ResponseValue`] from a [`Value`].
-    pub(crate) fn from_value(value: Value) -> Self {
+    ///
+    /// Returns an error if any size component exceeds `u32::MAX`, preventing
+    /// silent truncation across the FFI boundary.
+    pub(crate) fn from_value(value: Value) -> Result<Self, String> {
         match value {
-            Value::Nil => ResponseValue {
+            Value::Nil => Ok(ResponseValue {
                 typ: ValueType::Null,
                 ..Default::default()
-            },
-            Value::Int(int) => ResponseValue {
+            }),
+            Value::Int(int) => Ok(ResponseValue {
                 typ: ValueType::Int,
                 val: int,
                 size: 0,
-            },
+            }),
             Value::BulkString(text) => {
                 let (vec_ptr, len) = convert_vec_to_pointer(text);
-                ResponseValue {
+                let size = Self::checked_size(len, "BulkString")?;
+                Ok(ResponseValue {
                     typ: ValueType::BulkString,
                     val: vec_ptr as i64,
-                    size: len as u32,
-                }
+                    size,
+                })
             }
             Value::Array(values) => {
-                let vec: Vec<ResponseValue> =
-                    values.into_iter().map(ResponseValue::from_value).collect();
+                let vec: Vec<ResponseValue> = values
+                    .into_iter()
+                    .map(ResponseValue::from_value)
+                    .collect::<Result<Vec<_>, _>>()?;
                 let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                ResponseValue {
+                let size = Self::checked_size(len, "Array")?;
+                Ok(ResponseValue {
                     typ: ValueType::Array,
                     val: vec_ptr as i64,
-                    size: len as u32,
-                }
+                    size,
+                })
             }
             Value::Set(values) => {
-                let vec: Vec<ResponseValue> =
-                    values.into_iter().map(ResponseValue::from_value).collect();
+                let vec: Vec<ResponseValue> = values
+                    .into_iter()
+                    .map(ResponseValue::from_value)
+                    .collect::<Result<Vec<_>, _>>()?;
                 let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                ResponseValue {
+                let size = Self::checked_size(len, "Set")?;
+                Ok(ResponseValue {
                     typ: ValueType::Set,
                     val: vec_ptr as i64,
-                    size: len as u32,
-                }
+                    size,
+                })
             }
-            Value::Okay => ResponseValue {
+            Value::Okay => Ok(ResponseValue {
                 typ: ValueType::OK,
                 ..Default::default()
-            },
+            }),
             Value::Map(items) => {
                 let vec: Vec<ResponseValue> = items
                     .into_iter()
-                    .flat_map(|(k, v)| {
-                        vec![ResponseValue::from_value(k), ResponseValue::from_value(v)]
+                    .map(|(k, v)| {
+                        Ok::<_, String>(vec![
+                            ResponseValue::from_value(k)?,
+                            ResponseValue::from_value(v)?,
+                        ])
                     })
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .flatten()
                     .collect();
                 let (vec_ptr, len) = convert_vec_to_pointer(vec);
-                ResponseValue {
+                let size = Self::checked_size(len, "Map")?;
+                Ok(ResponseValue {
                     typ: ValueType::Map,
                     val: vec_ptr as i64,
-                    size: len as u32,
-                }
+                    size,
+                })
             }
-            Value::Double(num) => ResponseValue {
+            Value::Double(num) => Ok(ResponseValue {
                 typ: ValueType::Float,
                 val: num.to_bits() as i64,
                 size: 0,
-            },
-            Value::Boolean(boolean) => ResponseValue {
+            }),
+            Value::Boolean(boolean) => Ok(ResponseValue {
                 typ: ValueType::Bool,
                 val: if boolean { 1 } else { 0 },
                 size: 0,
-            },
+            }),
             Value::VerbatimString { format: _, text } | Value::SimpleString(text) => {
                 let (vec_ptr, len) = convert_vec_to_pointer(text.into_bytes());
-                ResponseValue {
+                let size = Self::checked_size(len, "String")?;
+                Ok(ResponseValue {
                     typ: ValueType::String,
                     val: vec_ptr as i64,
-                    size: len as u32,
-                }
+                    size,
+                })
             }
             Value::ServerError(err) => {
                 let (vec_ptr, len) =
                     convert_vec_to_pointer(err.details().unwrap().as_bytes().to_vec());
-                ResponseValue {
+                let size = Self::checked_size(len, "Error")?;
+                Ok(ResponseValue {
                     typ: ValueType::Error,
                     val: vec_ptr as i64,
-                    size: len as u32,
-                }
+                    size,
+                })
             }
             _ => todo!(), // push, bigint, attribute
         }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -734,7 +734,7 @@ impl ResponseValue {
                     size,
                 })
             }
-            _ => todo!(), // push, bigint, attribute
+            _ => Err("Unsupported Redis value type in FFI response serialization".into()),
         }
     }
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -22,27 +22,34 @@ use redis::{
 
 /// Convert raw C string to a rust string.
 ///
+/// Returns an error if the pointer is non-null but the data is not valid UTF-8.
+///
 /// # Safety
 ///
 /// * `ptr` must be able to be safely casted to a valid [`CStr`] via [`CStr::from_ptr`]. See the safety documentation of [`std::ffi::CStr::from_ptr`].
-unsafe fn ptr_to_str(ptr: *const c_char) -> String {
+unsafe fn ptr_to_str(ptr: *const c_char) -> Result<String, String> {
     if !ptr.is_null() {
-        unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().into()
+        unsafe { CStr::from_ptr(ptr) }
+            .to_str()
+            .map(|s| s.to_owned())
+            .map_err(|e| format!("Invalid UTF-8 in C string: {e}"))
     } else {
-        "".into()
+        Ok(String::new())
     }
 }
 
 /// Convert raw C string to a rust string wrapped by [Option].
 ///
+/// Returns an error if the pointer is non-null but the data is not valid UTF-8.
+///
 /// # Safety
 ///
 /// * `ptr` must be able to be safely casted to a valid [`CStr`] via [`CStr::from_ptr`]. See the safety documentation of [`std::ffi::CStr::from_ptr`].
-unsafe fn ptr_to_opt_str(ptr: *const c_char) -> Option<String> {
+unsafe fn ptr_to_opt_str(ptr: *const c_char) -> Result<Option<String>, String> {
     if !ptr.is_null() {
-        Some(unsafe { ptr_to_str(ptr) })
+        unsafe { ptr_to_str(ptr) }.map(Some)
     } else {
-        None
+        Ok(None)
     }
 }
 
@@ -223,33 +230,33 @@ unsafe fn convert_pubsub_config(
 ///   See the safety documentation of [`convert_node_addresses`], [`ptr_to_str`] and [`ptr_to_opt_str`].
 pub(crate) unsafe fn create_connection_request(
     config_ptr: *const ConnectionConfig,
-) -> ConnectionRequest {
+) -> Result<ConnectionRequest, String> {
     let config = unsafe { *config_ptr };
-    ConnectionRequest {
+    Ok(ConnectionRequest {
         read_from: if config.has_read_from {
             Some(match config.read_from.strategy {
                 ReadFromStrategy::Primary => coreReadFrom::Primary,
                 ReadFromStrategy::PreferReplica => coreReadFrom::PreferReplica,
                 ReadFromStrategy::AZAffinity => {
-                    coreReadFrom::AZAffinity(unsafe { ptr_to_str(config.read_from.az) })
+                    coreReadFrom::AZAffinity(unsafe { ptr_to_str(config.read_from.az) }?)
                 }
                 ReadFromStrategy::AZAffinityReplicasAndPrimary => {
                     coreReadFrom::AZAffinityReplicasAndPrimary(unsafe {
                         ptr_to_str(config.read_from.az)
-                    })
+                    }?)
                 }
             })
         } else {
             None
         },
-        client_name: unsafe { ptr_to_opt_str(config.client_name) },
+        client_name: unsafe { ptr_to_opt_str(config.client_name) }?,
         lib_name: option_env!("GLIDE_NAME").map(|s| s.to_string()),
         authentication_info: if config.has_authentication_info {
             let auth_info = config.authentication_info;
             let iam_config = if auth_info.has_iam_credentials {
                 Some(glide_core::client::IamAuthenticationConfig {
-                    cluster_name: unsafe { ptr_to_str(auth_info.iam_credentials.cluster_name) },
-                    region: unsafe { ptr_to_str(auth_info.iam_credentials.region) },
+                    cluster_name: unsafe { ptr_to_str(auth_info.iam_credentials.cluster_name) }?,
+                    region: unsafe { ptr_to_str(auth_info.iam_credentials.region) }?,
                     service_type: match auth_info.iam_credentials.service_type {
                         ServiceType::ElastiCache => glide_core::iam::ServiceType::ElastiCache,
                         ServiceType::MemoryDB => glide_core::iam::ServiceType::MemoryDB,
@@ -268,8 +275,8 @@ pub(crate) unsafe fn create_connection_request(
             };
 
             Some(CoreAuthenticationInfo {
-                username: unsafe { ptr_to_opt_str(auth_info.username) },
-                password: unsafe { ptr_to_opt_str(auth_info.password) },
+                username: unsafe { ptr_to_opt_str(auth_info.username) }?,
+                password: unsafe { ptr_to_opt_str(auth_info.password) }?,
                 iam_config,
             })
         } else {
@@ -278,7 +285,7 @@ pub(crate) unsafe fn create_connection_request(
         database_id: config.database_id.into(),
         protocol: config.has_protocol.then_some(config.protocol),
         tls_mode: config.has_tls.then_some(config.tls_mode),
-        addresses: unsafe { convert_node_addresses(config.addresses, config.address_count) },
+        addresses: unsafe { convert_node_addresses(config.addresses, config.address_count) }?,
         cluster_mode_enabled: config.cluster_mode,
         request_timeout: config.has_request_timeout.then_some(config.request_timeout),
         connection_timeout: config
@@ -327,7 +334,7 @@ pub(crate) unsafe fn create_connection_request(
             use redis::cache::EvictionPolicy as CoreEvictionPolicy;
             let csc = config.client_side_cache_config;
             Some(glide_core::client::ClientSideCache {
-                cache_id: unsafe { ptr_to_str(csc.cache_id) },
+                cache_id: unsafe { ptr_to_str(csc.cache_id) }?,
                 max_cache_kb: csc.max_cache_kb,
                 entry_ttl_ms: csc.entry_ttl_ms,
                 eviction_policy: if csc.has_eviction_policy {
@@ -351,7 +358,7 @@ pub(crate) unsafe fn create_connection_request(
         periodic_checks: None,
         inflight_requests_limit: None,
         node_discovery_mode: glide_core::client::NodeDiscoveryMode::default(),
-    }
+    })
 }
 
 /// A mirror of [`NodeAddress`] adopted for FFI.
@@ -359,15 +366,6 @@ pub(crate) unsafe fn create_connection_request(
 pub struct Address {
     pub host: *const c_char,
     pub port: u16,
-}
-
-impl From<&Address> for NodeAddress {
-    fn from(addr: &Address) -> Self {
-        NodeAddress {
-            host: unsafe { ptr_to_str(addr.host) },
-            port: addr.port,
-        }
-    }
 }
 
 /// Convert raw array pointer of [`Address`]es to a vector of [`NodeAddress`]es.
@@ -378,10 +376,18 @@ impl From<&Address> for NodeAddress {
 /// * `data` must not be `null`.
 /// * `data` must point to `len` consecutive properly initialized [`Address`] structs.
 /// * Each [`Address`] dereferenced by `data` must contain a valid string pointer. See the safety documentation of [`ptr_to_str`].
-unsafe fn convert_node_addresses(data: *const *const Address, len: usize) -> Vec<NodeAddress> {
+unsafe fn convert_node_addresses(
+    data: *const *const Address,
+    len: usize,
+) -> Result<Vec<NodeAddress>, String> {
     unsafe { std::slice::from_raw_parts(data as *mut Address, len) }
         .iter()
-        .map(NodeAddress::from)
+        .map(|addr| {
+            Ok(NodeAddress {
+                host: unsafe { ptr_to_str(addr.host) }?,
+                port: addr.port,
+            })
+        })
         .collect()
 }
 
@@ -486,37 +492,41 @@ pub struct RouteInfo {
 pub(crate) unsafe fn create_route(
     route_ptr: *const RouteInfo,
     cmd: Option<&Cmd>,
-) -> Option<RoutingInfo> {
+) -> Result<Option<RoutingInfo>, String> {
     if route_ptr.is_null() {
-        return None;
+        return Ok(None);
     }
     let route = unsafe { *route_ptr };
     match route.route_type {
-        RouteType::Random => Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)),
-        RouteType::AllNodes => Some(RoutingInfo::MultiNode((
+        RouteType::Random => Ok(Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))),
+        RouteType::AllNodes => Ok(Some(RoutingInfo::MultiNode((
             MultipleNodeRoutingInfo::AllNodes,
             cmd.and_then(|c| ResponsePolicy::for_command(&c.command().unwrap())),
-        ))),
-        RouteType::AllPrimaries => Some(RoutingInfo::MultiNode((
+        )))),
+        RouteType::AllPrimaries => Ok(Some(RoutingInfo::MultiNode((
             MultipleNodeRoutingInfo::AllMasters,
             cmd.and_then(|c| ResponsePolicy::for_command(&c.command().unwrap())),
-        ))),
-        RouteType::SlotId => Some(RoutingInfo::SingleNode(
+        )))),
+        RouteType::SlotId => Ok(Some(RoutingInfo::SingleNode(
             SingleNodeRoutingInfo::SpecificNode(Route::new(
                 route.slot_id as u16,
                 (&route.slot_type).into(),
             )),
-        )),
-        RouteType::SlotKey => Some(RoutingInfo::SingleNode(
+        ))),
+        RouteType::SlotKey => Ok(Some(RoutingInfo::SingleNode(
             SingleNodeRoutingInfo::SpecificNode(Route::new(
-                redis::cluster_topology::get_slot(unsafe { ptr_to_str(route.slot_key) }.as_bytes()),
+                redis::cluster_topology::get_slot(
+                    unsafe { ptr_to_str(route.slot_key) }?.as_bytes(),
+                ),
                 (&route.slot_type).into(),
             )),
-        )),
-        RouteType::ByAddress => Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
-            host: unsafe { ptr_to_str(route.hostname) },
-            port: route.port as u16,
-        })),
+        ))),
+        RouteType::ByAddress => Ok(Some(RoutingInfo::SingleNode(
+            SingleNodeRoutingInfo::ByAddress {
+                host: unsafe { ptr_to_str(route.hostname) }?,
+                port: route.port as u16,
+            },
+        ))),
     }
 }
 
@@ -873,9 +883,9 @@ pub(crate) unsafe fn create_pipeline(
 ///   See description of [`RouteInfo`] and the safety documentation of [`create_route`].
 pub(crate) unsafe fn get_pipeline_options(
     ptr: *const BatchOptionsInfo,
-) -> (Option<RoutingInfo>, Option<u32>, PipelineRetryStrategy) {
+) -> Result<(Option<RoutingInfo>, Option<u32>, PipelineRetryStrategy), String> {
     if ptr.is_null() {
-        return (None, None, PipelineRetryStrategy::new(false, false));
+        return Ok((None, None, PipelineRetryStrategy::new(false, false)));
     }
     let info = unsafe { *ptr };
     let timeout = if info.has_timeout {
@@ -883,13 +893,13 @@ pub(crate) unsafe fn get_pipeline_options(
     } else {
         None
     };
-    let route = unsafe { create_route(info.route_info, None) };
+    let route = unsafe { create_route(info.route_info, None) }?;
 
-    (
+    Ok((
         route,
         timeout,
         PipelineRetryStrategy::new(info.retry_server_error, info.retry_connection_error),
-    )
+    ))
 }
 
 /// FFI-safe version of [`redis::PushKind`] for C# interop.

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -55,7 +55,7 @@ unsafe fn ptr_to_opt_str(ptr: *const c_char) -> Result<Option<String>, String> {
 
 /// A mirror of [`ConnectionRequest`] adopted for FFI.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct CompressionConfig {
     pub min_compression_size: usize,
     pub has_compression_level: bool,
@@ -67,7 +67,7 @@ pub struct CompressionConfig {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum CompressionBackend {
     Zstd = 0,
     Lz4 = 1,
@@ -75,7 +75,7 @@ pub enum CompressionBackend {
 
 /// A mirror of [`EvictionPolicy`] adopted for FFI.
 #[repr(u32)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum EvictionPolicy {
     Lru = 0,
     Lfu = 1,
@@ -83,7 +83,7 @@ pub enum EvictionPolicy {
 
 /// A mirror of [`glide_core::client::ClientSideCache`] adopted for FFI.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ClientSideCacheConfig {
     pub cache_id: *const c_char,
     pub max_cache_kb: u64,
@@ -95,7 +95,7 @@ pub struct ClientSideCacheConfig {
 
 /// A mirror of [`ConnectionRequest`] adopted for FFI.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ConnectionConfig {
     pub address_count: usize,
     /// Pointer to an array.
@@ -143,7 +143,7 @@ pub struct ConnectionConfig {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct PubSubConfigInfo {
     pub channels_ptr: *const *const c_char,
     pub channel_count: u32,
@@ -393,14 +393,14 @@ unsafe fn convert_node_addresses(
 
 /// A mirror of [`coreReadFrom`] adopted for FFI.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ReadFrom {
     pub strategy: ReadFromStrategy,
     pub az: *const c_char,
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum ReadFromStrategy {
     Primary,
     PreferReplica,
@@ -410,7 +410,7 @@ pub enum ReadFromStrategy {
 
 /// A mirror of [`AuthenticationInfo`] adopted for FFI.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct AuthenticationInfo {
     pub username: *const c_char,
     pub password: *const c_char,
@@ -420,7 +420,7 @@ pub struct AuthenticationInfo {
 
 /// A mirror of [`IamCredentials`] adopted for FFI.
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct IamCredentials {
     pub cluster_name: *const c_char,
     pub region: *const c_char,
@@ -430,14 +430,14 @@ pub struct IamCredentials {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum ServiceType {
     ElastiCache = 0,
     MemoryDB = 1,
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum RouteType {
     Random,
     AllNodes,
@@ -449,7 +449,7 @@ pub enum RouteType {
 
 /// A mirror of [`SlotAddr`]
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub enum SlotType {
     Primary,
     Replica,
@@ -471,7 +471,7 @@ impl From<&SlotType> for SlotAddr {
 /// * `route_type`, `slot_key` and `slot_type`, if route is a Slot key route;
 /// * `route_type`, `hostname` and `port`, if route is a Address route;
 #[repr(C)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct RouteInfo {
     pub route_type: RouteType,
     pub slot_id: i32,
@@ -584,7 +584,7 @@ pub(crate) fn convert_vec_to_pointer<T>(mut vec: Vec<T>) -> (*const T, usize) {
 }
 
 #[repr(C)]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 pub enum ValueType {
     #[default]
     Null = 0,
@@ -610,7 +610,7 @@ pub enum ValueType {
 ///   [`ResponseValue::val`] a pointer to an array of another [`ResponseValue`] is stored and [`ResponseValue::size`] contains
 ///   the array length (for a map - it is 2x map size).
 #[repr(C)]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 pub struct ResponseValue {
     pub typ: ValueType,
     pub val: i64,
@@ -740,7 +740,7 @@ impl ResponseValue {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Copy)]
 pub struct CmdInfo {
     pub request_type: RequestType,
     pub args: *const *const u8,
@@ -749,7 +749,7 @@ pub struct CmdInfo {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Copy)]
 pub struct BatchInfo {
     pub cmd_count: usize,
     pub cmds: *const *const CmdInfo,
@@ -757,7 +757,7 @@ pub struct BatchInfo {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Copy)]
 pub struct BatchOptionsInfo {
     // two params from PipelineRetryStrategy
     pub retry_server_error: bool,
@@ -908,7 +908,7 @@ pub(crate) unsafe fn get_pipeline_options(
 /// The `#[repr(u32)]` attribute ensures a stable memory layout compatible with C# marshaling.
 /// Each variant corresponds to a specific Redis/Valkey PubSub notification type.
 #[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PushKind {
     /// Disconnection notification sent from the library when connection is closed.
     Disconnection = 0,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -167,7 +167,21 @@ pub unsafe extern "C-unwind" fn create_client(
         callback_index: 0,
     };
 
-    let request = unsafe { create_connection_request(config) };
+    let request = match unsafe { create_connection_request(config) } {
+        Ok(req) => req,
+        Err(err) => {
+            panic_guard.panicked = false;
+            unsafe {
+                report_error(
+                    failure_callback,
+                    0,
+                    err,
+                    RequestErrorType::Unspecified,
+                );
+            }
+            return;
+        }
+    };
 
     let runtime = Builder::new_multi_thread()
         .enable_all()
@@ -538,7 +552,21 @@ pub unsafe extern "C-unwind" fn command(
         }
     };
 
-    let route = unsafe { create_route(route_info, Some(&cmd)) };
+    let route = match unsafe { create_route(route_info, Some(&cmd)) } {
+        Ok(route) => route,
+        Err(err) => {
+            panic_guard.panicked = false;
+            unsafe {
+                report_error(
+                    core.failure_callback,
+                    callback_index,
+                    err,
+                    RequestErrorType::Unspecified,
+                );
+            }
+            return;
+        }
+    };
 
     let request_type = unsafe { (*cmd_ptr).request_type };
 
@@ -641,7 +669,22 @@ pub unsafe extern "C-unwind" fn batch(
             }
         };
 
-    let (routing, timeout, pipeline_retry_strategy) = unsafe { get_pipeline_options(options_ptr) };
+    let (routing, timeout, pipeline_retry_strategy) =
+        match unsafe { get_pipeline_options(options_ptr) } {
+            Ok(opts) => opts,
+            Err(err) => {
+                panic_guard.panicked = false;
+                unsafe {
+                    report_error(
+                        core.failure_callback,
+                        callback_index,
+                        err,
+                        RequestErrorType::Unspecified,
+                    );
+                }
+                return;
+            }
+        };
 
     // Clone compression manager for use in async block
     let compression_manager = core.client.compression_manager();
@@ -782,36 +825,55 @@ pub unsafe extern "C" fn log(
     log_identifier: *const c_char,
     message: *const c_char,
 ) {
-    logger_core::log(
-        log_level.into(),
-        unsafe { CStr::from_ptr(log_identifier) }
-            .to_str()
-            .expect("Can not read log_identifier argument."),
-        unsafe { CStr::from_ptr(message) }
-            .to_str()
-            .expect("Can not read message argument."),
-    );
+    let log_id = match unsafe { CStr::from_ptr(log_identifier) }.to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            // Cannot log with invalid UTF-8 identifier; silently skip.
+            return;
+        }
+    };
+    let msg = match unsafe { CStr::from_ptr(message) }.to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            // Cannot log with invalid UTF-8 message; silently skip.
+            return;
+        }
+    };
+    logger_core::log(log_level.into(), log_id, msg);
 }
 
+/// Initializes the logger with the given level and optional file name.
+///
+/// Returns a null pointer on success, or a pointer to a C string error message on failure.
+/// On success, the resolved log level is written to `*level_out`.
+/// The caller is responsible for freeing the error message using `free_string`.
+///
 /// # Safety
 ///
-/// * `file_name` must not be `null`.
-/// * `file_name` must be able to be safely casted to a valid [`CStr`] via [`CStr::from_ptr`]. See the safety documentation of [`CStr::from_ptr`].
+/// * `file_name` may be `null` (logs to console). If non-null, it must be a valid C string.
+/// * `level_out` must not be `null` and must point to a valid writable `Level`.
 #[unsafe(no_mangle)]
 #[allow(improper_ctypes_definitions)]
-pub unsafe extern "C" fn init(level: Option<Level>, file_name: *const c_char) -> Level {
+pub unsafe extern "C" fn init_logger(
+    level: Option<Level>,
+    file_name: *const c_char,
+    level_out: *mut Level,
+) -> *const c_char {
     let file_name_as_str = if file_name.is_null() {
         None
     } else {
-        Some(
-            unsafe { CStr::from_ptr(file_name) }
-                .to_str()
-                .expect("Can not read string argument."),
-        )
+        match unsafe { CStr::from_ptr(file_name) }.to_str() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                let error_msg = format!("Invalid UTF-8 in file name: {e}");
+                return CString::new(error_msg).unwrap().into_raw();
+            }
+        }
     };
 
     let logger_level = logger_core::init(level.map(|level| level.into()), file_name_as_str);
-    logger_level.into()
+    unsafe { *level_out = logger_level.into() };
+    std::ptr::null()
 }
 
 #[repr(C)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -877,7 +877,7 @@ pub unsafe extern "C" fn init_logger(
     level: Option<Level>,
     file_name: *const c_char,
     level_out: *mut Level,
-) -> *const c_char {
+) -> *mut c_char {
     let file_name_as_str = if file_name.is_null() {
         None
     } else {
@@ -892,7 +892,7 @@ pub unsafe extern "C" fn init_logger(
 
     let logger_level = logger_core::init(level.map(|level| level.into()), file_name_as_str);
     unsafe { *level_out = logger_level.into() };
-    std::ptr::null()
+    std::ptr::null_mut()
 }
 
 #[repr(C)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -172,12 +172,7 @@ pub unsafe extern "C-unwind" fn create_client(
         Err(err) => {
             panic_guard.panicked = false;
             unsafe {
-                report_error(
-                    failure_callback,
-                    0,
-                    err,
-                    RequestErrorType::Unspecified,
-                );
+                report_error(failure_callback, 0, err, RequestErrorType::Unspecified);
             }
             return;
         }
@@ -601,8 +596,20 @@ pub unsafe extern "C-unwind" fn command(
                     );
                     original
                 });
-                let ptr = Box::into_raw(Box::new(ResponseValue::from_value(value)));
-                unsafe { (core.success_callback)(callback_index, ptr) };
+                match ResponseValue::from_value(value) {
+                    Ok(response) => {
+                        let ptr = Box::into_raw(Box::new(response));
+                        unsafe { (core.success_callback)(callback_index, ptr) };
+                    }
+                    Err(err) => unsafe {
+                        report_error(
+                            core.failure_callback,
+                            callback_index,
+                            err,
+                            RequestErrorType::Unspecified,
+                        );
+                    },
+                }
             }
             Err(err) => unsafe {
                 report_error(
@@ -737,8 +744,20 @@ pub unsafe extern "C-unwind" fn batch(
                 } else {
                     value
                 };
-                let ptr = Box::into_raw(Box::new(ResponseValue::from_value(final_value)));
-                unsafe { (core.success_callback)(callback_index, ptr) };
+                match ResponseValue::from_value(final_value) {
+                    Ok(response) => {
+                        let ptr = Box::into_raw(Box::new(response));
+                        unsafe { (core.success_callback)(callback_index, ptr) };
+                    }
+                    Err(err) => unsafe {
+                        report_error(
+                            core.failure_callback,
+                            callback_index,
+                            err,
+                            RequestErrorType::Unspecified,
+                        );
+                    },
+                }
             }
             Err(err) => unsafe {
                 report_error(
@@ -1058,10 +1077,20 @@ pub unsafe extern "C-unwind" fn invoke_script(
             .await;
 
         match result {
-            Ok(value) => {
-                let ptr = Box::into_raw(Box::new(ResponseValue::from_value(value)));
-                unsafe { (core.success_callback)(callback_index, ptr) };
-            }
+            Ok(value) => match ResponseValue::from_value(value) {
+                Ok(response) => {
+                    let ptr = Box::into_raw(Box::new(response));
+                    unsafe { (core.success_callback)(callback_index, ptr) };
+                }
+                Err(err) => unsafe {
+                    report_error(
+                        core.failure_callback,
+                        callback_index,
+                        err,
+                        RequestErrorType::Unspecified,
+                    );
+                },
+            },
             Err(err) => unsafe {
                 report_error(
                     core.failure_callback,
@@ -1165,10 +1194,20 @@ pub unsafe extern "C-unwind" fn request_cluster_scan(
             .cluster_scan(&scan_state_cursor, cluster_scan_args)
             .await;
         match result {
-            Ok(value) => {
-                let ptr = Box::into_raw(Box::new(ResponseValue::from_value(value)));
-                unsafe { (core.success_callback)(callback_index, ptr) };
-            }
+            Ok(value) => match ResponseValue::from_value(value) {
+                Ok(response) => {
+                    let ptr = Box::into_raw(Box::new(response));
+                    unsafe { (core.success_callback)(callback_index, ptr) };
+                }
+                Err(err) => unsafe {
+                    report_error(
+                        core.failure_callback,
+                        callback_index,
+                        err,
+                        RequestErrorType::Unspecified,
+                    );
+                },
+            },
             Err(err) => unsafe {
                 report_error(
                     core.failure_callback,
@@ -1427,11 +1466,20 @@ pub unsafe extern "C-unwind" fn refresh_iam_token(
 
         let result = core.client.clone().refresh_iam_token().await;
         match result {
-            Ok(()) => {
-                let response = ResponseValue::from_value(redis::Value::Okay);
-                let ptr = Box::into_raw(Box::new(response));
-                unsafe { (core.success_callback)(callback_index, ptr) };
-            }
+            Ok(()) => match ResponseValue::from_value(redis::Value::Okay) {
+                Ok(response) => {
+                    let ptr = Box::into_raw(Box::new(response));
+                    unsafe { (core.success_callback)(callback_index, ptr) };
+                }
+                Err(err) => unsafe {
+                    report_error(
+                        core.failure_callback,
+                        callback_index,
+                        err,
+                        RequestErrorType::Unspecified,
+                    );
+                },
+            },
             Err(err) => unsafe {
                 report_error(
                     core.failure_callback,
@@ -1520,11 +1568,20 @@ pub unsafe extern "C-unwind" fn update_connection_password(
             .update_connection_password(password, immediate_auth)
             .await;
         match result {
-            Ok(value) => {
-                let response = ResponseValue::from_value(value);
-                let ptr = Box::into_raw(Box::new(response));
-                unsafe { (core.success_callback)(callback_index, ptr) };
-            }
+            Ok(value) => match ResponseValue::from_value(value) {
+                Ok(response) => {
+                    let ptr = Box::into_raw(Box::new(response));
+                    unsafe { (core.success_callback)(callback_index, ptr) };
+                }
+                Err(err) => unsafe {
+                    report_error(
+                        core.failure_callback,
+                        callback_index,
+                        err,
+                        RequestErrorType::Unspecified,
+                    );
+                },
+            },
             Err(err) => unsafe {
                 report_error(
                     core.failure_callback,
@@ -1850,10 +1907,20 @@ pub unsafe extern "C-unwind" fn get_cache_metrics(
     };
 
     match result {
-        Ok(value) => {
-            let ptr = Box::into_raw(Box::new(ResponseValue::from_value(value)));
-            unsafe { (core.success_callback)(callback_index, ptr) };
-        }
+        Ok(value) => match ResponseValue::from_value(value) {
+            Ok(response) => {
+                let ptr = Box::into_raw(Box::new(response));
+                unsafe { (core.success_callback)(callback_index, ptr) };
+            }
+            Err(err) => unsafe {
+                report_error(
+                    core.failure_callback,
+                    callback_index,
+                    err,
+                    RequestErrorType::Unspecified,
+                );
+            },
+        },
         Err(err) => unsafe {
             report_error(
                 core.failure_callback,

--- a/sources/Valkey.Glide/Logger.cs
+++ b/sources/Valkey.Glide/Logger.cs
@@ -118,19 +118,31 @@ public class Logger
     /// If provided the target of the logs will be the file mentioned.<br />
     /// Otherwise, logs will be printed to the console.
     /// </param>
+    /// <exception cref="InvalidOperationException">Thrown when the native logger fails to initialize.</exception>
     public static void SetLoggerConfig(Level level, string? filename = null)
     {
         byte[]? buffer = filename is null ? null : Encoding.UTF8.GetBytes(filename);
-        s_loggerLevel = InitInternalLogger(Convert.ToInt32(level), buffer);
+        IntPtr errorPtr = InitInternalLogger(Convert.ToInt32(level), buffer, out Level resolvedLevel);
+        if (errorPtr != IntPtr.Zero)
+        {
+            string? errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            FreeString(errorPtr);
+            throw new InvalidOperationException($"Failed to initialize logger: {errorMessage}");
+        }
+        s_loggerLevel = resolvedLevel;
     }
+
     #endregion public methods
 
     #region FFI function declaration
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "log")]
     private static extern void log(int logLevel, byte[] logIdentifier, byte[] message);
 
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "init")]
-    private static extern Level InitInternalLogger(int level, byte[]? filename);
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "init_logger")]
+    private static extern IntPtr InitInternalLogger(int level, byte[]? filename, out Level levelOut);
+
+    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_string")]
+    private static extern void FreeString(IntPtr strPtr);
 
     #endregion
 }

--- a/sources/Valkey.Glide/Logger.cs
+++ b/sources/Valkey.Glide/Logger.cs
@@ -1,7 +1,6 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Valkey.Glide;
 
@@ -103,7 +102,7 @@ public class Logger
         {
             message += $": {error}";
         }
-        log(Convert.ToInt32(logLevel), Encoding.UTF8.GetBytes(logIdentifier), Encoding.UTF8.GetBytes(message));
+        log(Convert.ToInt32(logLevel), logIdentifier, message);
     }
 
     /// <summary>
@@ -121,11 +120,10 @@ public class Logger
     /// <exception cref="InvalidOperationException">Thrown when the native logger fails to initialize.</exception>
     public static void SetLoggerConfig(Level level, string? filename = null)
     {
-        byte[]? buffer = filename is null ? null : Encoding.UTF8.GetBytes(filename);
-        IntPtr errorPtr = InitInternalLogger(Convert.ToInt32(level), buffer, out Level resolvedLevel);
+        IntPtr errorPtr = InitInternalLogger(Convert.ToInt32(level), filename, out Level resolvedLevel);
         if (errorPtr != IntPtr.Zero)
         {
-            string? errorMessage = Marshal.PtrToStringAnsi(errorPtr);
+            string? errorMessage = Marshal.PtrToStringUTF8(errorPtr);
             FreeString(errorPtr);
             throw new InvalidOperationException($"Failed to initialize logger: {errorMessage}");
         }
@@ -136,10 +134,16 @@ public class Logger
 
     #region FFI function declaration
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "log")]
-    private static extern void log(int logLevel, byte[] logIdentifier, byte[] message);
+    private static extern void log(
+        int logLevel,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string logIdentifier,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string message);
 
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "init_logger")]
-    private static extern IntPtr InitInternalLogger(int level, byte[]? filename, out Level levelOut);
+    private static extern IntPtr InitInternalLogger(
+        int level,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string? filename,
+        out Level levelOut);
 
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_string")]
     private static extern void FreeString(IntPtr strPtr);


### PR DESCRIPTION
### Summary

Security hardening for the `release-1.1`:

- Fixes possible integer overflow in the FFI response serialization layer.
- Removes credential leakage vectors.
- Hardens CI/CD against supply-chain attacks.
- Improves panic safety at the FFI boundary.

### Issue Link

:white_circle: None

### Features and Behaviour Changes

- `ResponseValue::from_value` now returns `Result` instead of `Self`. If a response component exceeds `u32::MAX` in size, the error is routed through the existing failure callback rather than silently truncating.
- FFI structs containing credentials no longer implement `Debug`, preventing accidental exposure in logs.
- Invalid UTF-8 in FFI string conversions now returns an error instead of panicking (undefined behavior at FFI boundary).

### Implementation

**Integer overflow fix (`rust/src/ffi.rs`):**

- Added `ResponseValue::convert_vec_to_ffi()` helper that validates `vec.len()` fits in `u32` before transferring ownership to a raw pointer.
- Changed `from_value` to return `Result<Self, String>`.
- All 6 size-bearing variants (BulkString, Array, Set, Map, String, Error) use `convert_vec_to_ffi()`.
- Recursive calls in collection types propagate inner errors.

**CI/CD hardening (`.github/workflows/*.yml`):**

- All GitHub Actions references pinned to full SHA hashes (12 workflow files).

### Limitations

- The `u32::MAX` limit means single response values cannot exceed ~4GB: supporting >4GB responses would require a deeper redesign.

### Testing

Existing tests pass.

### Related Issues

Supersedes #370 (reopened from upstream branch to fix ORT workflow permissions).

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.