### PR TITLE
feat(lint): Add `markdownlint` integration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,50 +1,57 @@
+# Pull Request
+
 <!--
 Thanks for contributing to Valkey GLIDE!
 
 Please make sure you are aware of our [contributing guidelines](https://github.com/valkey-io/valkey-glide-csharp/blob/main/CONTRIBUTING.md).
 -->
 
-### Summary
+## Summary
 
 <!--
 Add a summary describing the changes.
 -->
 
-### Issue Link
+## Issue Link
 
-This pull request is linked to issue: [REPLACE ME]
+<!--
+Link to the corresponding GitHub issue. Please raise an issue if none exists.
+Use "Closes" to automatically close the issue when this pull request is merged.
+-->
 
-### Features and Behaviour Changes
+Closes #[GITHUB-ISSUE-ID].
+
+## Features and Behaviour Changes
 
 <!--
 Outline the feature support and behaviour changes included in this pull request.
 -->
 
-### Implementation
+## Implementation
 
 <!--
 Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention.
 -->
 
-### Limitations
+## Limitations
 
 <!--
 Describe any features or use cases that are not implemented or are only partially supported.
 -->
 
-### Testing
+## Testing
 
 <!--
 Describe what tests have been conducted and any relevant test results.
 -->
 
-### Related Issues
+## Related Issues
 
 <!--
 List related issues and pull request such closed pull requests and open issues.
 -->
 
-### Checklist
+## Checklist
 
 <!--
 Before submitting the PR make sure the following are checked.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,9 +1,11 @@
 gitignore: true
 
 config:
+  # Line length — not auto-fixable.
   MD013: false
-  MD024: false
-  MD041: false
+  # Duplicate headings — allow under different parents only.
+  MD024:
+    siblings_only: true
 
 ignores:
   - "valkey-glide/**"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -9,4 +9,3 @@ config:
 
 ignores:
   - "valkey-glide/**"
-  - "THIRD_PARTY_LICENSES"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,12 @@
+config:
+  MD013: false
+  MD024: false
+  MD041: false
+  MD060: false
+
+ignores:
+  - "valkey-glide/**"
+  - "THIRD_PARTY_LICENSES"
+  - "reports/**"
+  - "rust/target/**"
+  - ".kiro/specs/**"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,5 @@
+gitignore: true
+
 config:
   MD013: false
   MD024: false
@@ -7,6 +9,3 @@ config:
 ignores:
   - "valkey-glide/**"
   - "THIRD_PARTY_LICENSES"
-  - "reports/**"
-  - "rust/target/**"
-  - ".kiro/specs/**"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,7 +4,6 @@ config:
   MD013: false
   MD024: false
   MD041: false
-  MD060: false
 
 ignores:
   - "valkey-glide/**"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ Common commands:
 
 - Prefer `task` commands for linting and formatting.
 - Lint checks (read-only, fail on issues):
-  - `task lint` (all checks), `task lint:rust`, `task lint:csharp`, `task lint:yaml`, `task lint:actions`
+  - `task lint` (all checks), `task lint:rust`, `task lint:csharp`, `task lint:yaml`, `task lint:actions`, `task lint:markdown`
 - Auto-fix formatting:
-  - `task format` (all languages), `task format:rust`, `task format:csharp`, `task format:yaml`
+  - `task format` (all languages), `task format:rust`, `task format:csharp`, `task format:yaml`, `task format:markdown`
 - Link checking (separate from lint, slower):
   - `task check-links`
 
@@ -163,7 +163,7 @@ Note: Conventional Commits apply to commit messages only. Do not enforce this fo
 ## Quality Gates (Agent Checklist)
 
 - Build passes on `net8.0`.
-- Lint passes: `task lint` (or individual `task lint:rust`, `task lint:csharp`, `task lint:yaml`).
+- Lint passes: `task lint` (or individual `task lint:rust`, `task lint:csharp`, `task lint:yaml`, `task lint:markdown`).
 - Tests pass; targeted via filters instead of per-file execution.
 - Generated outputs not committed.
 - Public API changes respect StackExchange.Redis compatibility.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -309,7 +309,8 @@ You can combine this with test filter as well:
 ```bash
 cluster-endpoints=localhost:7000 standalone-endpoints=localhost:6379 tls=true dotnet test --logger "console;verbosity=detailed" --filter "FullyQualifiedName~GetReturnsNull"
 ```
-#### IAM Authentication Tests
+
+### IAM Authentication Tests
 
 To run [IAM authentication tests](tests/Valkey.Glide.IntegrationTests/IamAuthTests.cs) locally, set the following environment variables:
 
@@ -355,10 +356,11 @@ Before making a contribution, ensure that all new user APIs and non-obvious code
 task lint
 
 # Run linters for specific languages:
-task lint:rust     # Run Rust linting
-task lint:csharp   # Run C# linting
-task lint:yaml     # Run YAML linting
-task lint:actions  # Run GitHub Actions linting
+task lint:rust      # Run Rust linting
+task lint:csharp    # Run C# linting
+task lint:yaml      # Run YAML linting
+task lint:actions   # Run GitHub Actions linting
+task lint:markdown  # Run Markdown linting
 
 # Run all formatters:
 task format
@@ -367,6 +369,7 @@ task format
 task format:rust
 task format:csharp
 task format:yaml
+task format:markdown
 
 # Check for broken links
 task check-links

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -146,8 +146,7 @@ tasks:
 
     build:
         desc: Build the solution
-        cmds:
-            - dotnet build {{.TARGET_PATH}} --configuration Release
+        cmd: dotnet build {{.TARGET_PATH}} --configuration Release
 
     test:
         desc: Build and run all tests
@@ -155,9 +154,17 @@ tasks:
         cmds:
             - task: test:coverage:all
 
+    # Lint
+    # --------------------------------------------------------------------------------
+
     lint:
         desc: "Run all linters"
-        deps: [lint:rust, lint:csharp, lint:yaml, lint:actions]
+        deps:
+            - lint:rust
+            - lint:csharp
+            - lint:yaml
+            - lint:actions
+            - lint:markdown
 
     lint:rust:
         desc: "Run Rust linting"
@@ -178,43 +185,51 @@ tasks:
 
     lint:yaml:
         desc: "Run YAML linting"
-        cmds:
-            - npx prettier --check "**/*.yml"
+        cmd: npx prettier --check "**/*.yml"
 
     lint:actions:
         desc: "Run GitHub Actions linting"
-        cmds:
-            - actionlint
+        cmd: actionlint
+
+    lint:markdown:
+        desc: "Run Markdown linting"
+        cmd: npx markdownlint-cli2 "**/*.md"
+
+    # Format
+    # --------------------------------------------------------------------------------
 
     format:
         desc: "Run all formatters"
-        cmds:
-            - task: format:rust
-            - task: format:csharp
-            - task: format:yaml
+        deps:
+            - format:rust
+            - format:csharp
+            - format:yaml
+            - format:markdown
 
     format:rust:
         desc: "Run Rust formatting"
         dir: rust
-        cmds:
-            - cargo fmt --all
+        cmd: cargo fmt --all
 
     format:csharp:
         desc: "Run C# formatting"
-        cmds:
-            - dotnet format
+        cmd: dotnet format
 
     format:yaml:
         desc: "Run YAML formatting"
-        cmds:
-            - npx prettier --write "**/*.yml"
+        cmd: npx prettier --write "**/*.yml"
+
+    format:markdown:
+        desc: "Run Markdown formatting"
+        cmd: npx markdownlint-cli2 --fix "**/*.md"
+
+    # Additional checks
+    # --------------------------------------------------------------------------------
 
     check-links:
         desc: "Check for broken links"
-        cmds:
-            - lychee --config lychee.toml .
+        cmd: lychee --config lychee.toml .
 
     check-examples:
-        desc: "Extract and validate C# code examples in doc comments"
-        cmds:
-            - python3 scripts/check_examples.py
+        desc: "Check C# examples in doc comments"
+        cmd: python3 scripts/check_examples.py

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -7,7 +7,7 @@ a set of platforms, versions, and tests to be run. The json files list our avail
 ## Files
 
 | File | Purpose |
-|------|---------|
+| ---- | ------- |
 | `os-matrix.json` | OS/runner platforms (VMs and containers) |
 | `server-matrix.json` | Valkey and Redis server versions |
 | `version-matrix.json` | .NET SDK versions |

--- a/docs/configuration-architecture-analysis.md
+++ b/docs/configuration-architecture-analysis.md
@@ -7,18 +7,20 @@ This document analyzes the configuration architecture in the Valkey.Glide C# cli
 ## Configuration Classes Relationship
 
 ### ConfigurationOptions
+
 - **Purpose**: External API configuration class that follows StackExchange.Redis compatibility patterns
 - **Location**: `sources/Valkey.Glide/Abstract/ConfigurationOptions.cs`
 - **Role**: User-facing configuration interface
 
 ### ConnectionConfiguration
+
 - **Purpose**: Internal configuration classes that map to the underlying FFI layer
 - **Location**: `sources/Valkey.Glide/ConnectionConfiguration.cs`
 - **Role**: Internal configuration representation and builder pattern implementation
 
 ## Configuration Flow
 
-```
+```text
 ConfigurationOptions → ClientConfigurationBuilder → ConnectionConfig → FFI.ConnectionConfig
 ```
 
@@ -53,10 +55,12 @@ internal static T CreateClientConfigBuilder<T>(ConfigurationOptions configuratio
 ### Configuration Builders
 
 The builder pattern is implemented through:
+
 - `StandaloneClientConfigurationBuilder` (line 525)
 - `ClusterClientConfigurationBuilder` (line 550)
 
 Both inherit from `ClientConfigurationBuilder<T>` which provides:
+
 - Fluent API methods (`WithXxx()`)
 - Property setters
 - Internal `ConnectionConfig Build()` method
@@ -92,6 +96,7 @@ internal ConfigurationOptions RawConfig { private set; get; }
 ## Potential Configuration Change Approaches
 
 ### 1. Connection Recreation (Current Pattern)
+
 ```csharp
 // Current approach - requires new connection
 var newConfig = oldConfig.Clone();
@@ -136,12 +141,15 @@ public async Task<bool> TryUpdateConfigurationAsync<T>(Action<T> configure)
 ## ReadFrom Configuration Specifics
 
 ### Current Implementation
+
 - `ReadFrom` is a struct (line 74) with `ReadFromStrategy` enum and optional AZ string
 - Mapped in `CreateClientConfigBuilder()` at line 199
 - Flows through to FFI layer via `ConnectionConfig.ToFfi()` method
 
 ### ReadFrom Change Requirements
+
 To change `ReadFrom` configuration at runtime would require:
+
 1. **API Design**: Method to accept new `ReadFrom` configuration
 2. **Validation**: Ensure new configuration is compatible with current connection type
 3. **FFI Updates**: Update the underlying client configuration
@@ -150,8 +158,10 @@ To change `ReadFrom` configuration at runtime would require:
 ## Recommendations
 
 ### Short Term
+
 1. **Document Current Limitations**: Clearly document that configuration changes require connection recreation
 2. **Helper Methods**: Provide utility methods for common reconfiguration scenarios:
+
    ```csharp
    public static async Task<ConnectionMultiplexer> RecreateWithReadFromAsync(
        ConnectionMultiplexer current,
@@ -159,6 +169,7 @@ To change `ReadFrom` configuration at runtime would require:
    ```
 
 ### Long Term
+
 1. **Runtime Reconfiguration API**: Implement selective runtime configuration updates for non-disruptive changes
 2. **Configuration Validation**: Add validation to determine which changes require reconnection vs. runtime updates
 3. **Connection Pool Management**: Consider connection pooling to minimize disruption during reconfiguration


### PR DESCRIPTION
## Summary

Integrate `markdownlint-cli2` into the project's lint and format pipelines to enforce consistent markdown style across all `.md` files. This adds automated structural validation and auto-fix capability for markdown, complementing the existing C#, Rust, YAML, and GitHub Actions linting.

## Issue Link

Closes #380.

## Features and Behaviour Changes

- `task lint:markdown` — checks all markdown files for style violations.
- `task format:markdown` — auto-fixes markdown violations in-place.
- Both are wired into `task lint` and `task format` respectively.
- Uses `npx markdownlint-cli2` (no separate install step needed, matches existing prettier pattern).
- Respects `.gitignore` via `gitignore: true` config option.

## Implementation

- `gitignore: true` — automatically excludes gitignored directories (`.kiro/`, `rust/target/`, etc.).
- MD013 (line length) disabled — not auto-fixable, too noisy for prose-heavy docs.
- MD024 (duplicate headings) set to `siblings_only` — allows repeated headings under different parents.
- Explicit ignore for `valkey-glide/**` (read-only submodule containing `.md` files).

## Limitations

:white_circle: None.

## Testing

- `task lint:markdown` passes with 0 errors across 10 linted files
- `task format:markdown` runs successfully

## Related Issues

:white_circle: None.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~ (No tests applicable — CI/config tooling only)
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.