### PR TITLE
Add Redis 7.1 and 7.2 to CI test matrix

### DIFF
--- a/.github/json_matrices/server-matrix.json
+++ b/.github/json_matrices/server-matrix.json
@@ -2,7 +2,7 @@
     {
         "type": "valkey",
         "version": "9.0",
-        "profiles": [ "standard", "full"]
+        "profiles": ["standard", "full"]
     },
     {
         "type": "valkey",
@@ -17,6 +17,16 @@
     {
         "type": "valkey",
         "version": "7.2",
+        "profiles": ["full"]
+    },
+    {
+        "type": "redis",
+        "version": "7.2",
+        "profiles": ["full"]
+    },
+    {
+        "type": "redis",
+        "version": "7.1",
         "profiles": ["full"]
     },
     {


### PR DESCRIPTION
# Pull Request

## Summary

Add Redis 7.1 and Redis 7.2 to the `full` CI test profile to ensure CI coverage matches the documented supported engine versions.

## Issue Link

Closes #382.

## Features and Behaviour Changes

- CI test matrix now includes Redis 7.1 and Redis 7.2 in the `full` profile.
- No functional code changes; this only affects which server versions are tested in CI.

## Implementation

Added two new entries to `.github/json_matrices/server-matrix.json` for Redis 7.1 and Redis 7.2.

## Limitations

:white_circle: None.

## Testing

No new tests added.

## Related Issues

:white_circle: None.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.