### PR TITLE
docs: Update CHANGELOG for release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,27 @@
 # Changelog
 
+All notable changes to the Valkey GLIDE C# client will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+
 ## 1.1.0
 
-### Changes
+### Added
 
-- Add client-side caching support with TTL-based expiration, LRU/LFU eviction policies, and cache metrics (#330)
+- Valkey JSON (JSON.*) command support for clients and batches (#358)
+- Valkey Search (FT.*) command support for clients (#225)
+- Client-side caching with TTL-based expiration, LRU/LFU eviction policies, and cache metrics API (#330)
+- Compression support for CustomCommand with incompatible command detection and improved error messages (#348)
 
-## 0.10.0
+### Security
 
-### Changes
+- Remove credential leakage vectors from FFI debug output (#371)
 
-- Add support for Windows CI and testing with WSL (#184)
-- Add StackExchange.Redis compatible pub/sub API (#202)
-- Add transparent compression support with Zstd and LZ4 backends (#213)
-- Add Valkey Search command support (#225)
+## 1.0.0
+
+### Added
+
+- StackExchange.Redis compatible pub/sub API (#202)
+- Transparent compression support with Zstd and LZ4 backends (#213)
+- Windows CI and testing with WSL (#184)


### PR DESCRIPTION
### Summary

Update `CHANGELOG.md` for the upcoming 1.1.0 release. Adopts [Keep a Changelog](https://keepachangelog.com/) format, adds all user-facing changes since v1.0.0, and fixes the mislabeled `0.10.0` section (which should have been `1.0.0`).

### Issue Link

:white_circle: None

### Features and Behaviour Changes

Documentation-only change. No runtime behaviour changes.

### Implementation

- Replaced the single `### Changes` bullet for 1.1.0 with categorized sections (`Added`, `Security`) covering all user-facing PRs merged since v1.0.0.
- Renamed the `0.10.0` section to `1.0.0` (no 0.10.0 release ever existed).
- Renamed `### Changes` to `### Added` in the 1.0.0 section for consistency with [Keep a Changelog](https://keepachangelog.com/).
- Added a header block referencing [Keep a Changelog](https://keepachangelog.com/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

### Limitations

:white_circle: None

### Testing

:white_circle: Documentation-only change — no tests applicable.

### Related Issues

:white_circle: None

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.