### PR TITLE
chore(ci): Add workflow to re-list unlisted NuGet packages

### DIFF
--- a/.github/workflows/relist-package.yml
+++ b/.github/workflows/relist-package.yml
@@ -18,16 +18,17 @@ jobs:
             - name: Re-list Valkey.Glide ${{ inputs.version }}
               env:
                   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+                  PACKAGE_VERSION: ${{ inputs.version }}
               run: |
-                  echo "Re-listing Valkey.Glide version ${{ inputs.version }}..."
+                  echo "Re-listing Valkey.Glide version $PACKAGE_VERSION..."
                   HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
                     -H "X-NuGet-ApiKey: $NUGET_API_KEY" \
-                    "https://www.nuget.org/api/v2/package/Valkey.Glide/${{ inputs.version }}")
+                    "https://www.nuget.org/api/v2/package/Valkey.Glide/$PACKAGE_VERSION")
 
                   echo "Response status: $HTTP_STATUS"
 
                   if [ "$HTTP_STATUS" -eq 200 ]; then
-                    echo "✅ Successfully re-listed Valkey.Glide ${{ inputs.version }}"
+                    echo "✅ Successfully re-listed Valkey.Glide $PACKAGE_VERSION"
                   else
                     echo "❌ Failed to re-list. HTTP status: $HTTP_STATUS"
                     exit 1

--- a/.github/workflows/relist-package.yml
+++ b/.github/workflows/relist-package.yml
@@ -1,0 +1,34 @@
+name: Re-list NuGet Package
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: "Package version to re-list"
+                required: true
+
+permissions:
+    contents: read
+
+jobs:
+    relist:
+        environment: Release
+        runs-on: ubuntu-latest
+        steps:
+            - name: Re-list Valkey.Glide ${{ inputs.version }}
+              env:
+                  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+              run: |
+                  echo "Re-listing Valkey.Glide version ${{ inputs.version }}..."
+                  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+                    -H "X-NuGet-ApiKey: $NUGET_API_KEY" \
+                    "https://www.nuget.org/api/v2/package/Valkey.Glide/${{ inputs.version }}")
+
+                  echo "Response status: $HTTP_STATUS"
+
+                  if [ "$HTTP_STATUS" -eq 200 ]; then
+                    echo "✅ Successfully re-listed Valkey.Glide ${{ inputs.version }}"
+                  else
+                    echo "❌ Failed to re-list. HTTP status: $HTTP_STATUS"
+                    exit 1
+                  fi


### PR DESCRIPTION
### Summary

Add a manual workflow to re-list NuGet packages that were unlisted by the CD pipeline's `remove-package-if-validation-fails` job (e.g. due to flaky test failures).

### Issue Link

:white_circle: None

### Features and Behaviour Changes

- New `relist-package.yml` workflow triggered via `workflow_dispatch` with a `version` input.
- Uses the existing `NUGET_API_KEY` from the `Release` environment to POST to the NuGet re-list endpoint.
- Reports success/failure with HTTP status code.

### Implementation

NuGet supports re-listing via `POST https://www.nuget.org/api/v2/package/{ID}/{VERSION}` with the same API key used for publish/unlist. This workflow wraps that call with proper error handling.

### Limitations

- Only works for packages that were unlisted.
- Requires the `Release` environment approval (same as publish).

### Testing

:white_circle: Cannot be tested without actually unlisting a package.

### Related Issues

:white_circle: None

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.