### PR TITLE
fix(ci): Add Content-Length header to NuGet re-list request

### DIFF
--- a/.github/workflows/relist-package.yml
+++ b/.github/workflows/relist-package.yml
@@ -23,6 +23,7 @@ jobs:
                   echo "Re-listing Valkey.Glide version $PACKAGE_VERSION..."
                   HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
                     -H "X-NuGet-ApiKey: $NUGET_API_KEY" \
+                    -H "Content-Length: 0" \
                     "https://www.nuget.org/api/v2/package/Valkey.Glide/$PACKAGE_VERSION")
 
                   echo "Response status: $HTTP_STATUS"


### PR DESCRIPTION
### Summary

Fix the re-list NuGet workflow that fails with HTTP 411 (Length Required).

### Issue Link

:white_circle: None

### Features and Behaviour Changes

:white_circle: None — bug fix for the workflow added in #400.

### Implementation

The NuGet re-list API (`POST /api/v2/package/{ID}/{VERSION}`) requires a `Content-Length: 0` header when the request has no body. Without it, the server returns HTTP 411. Added the missing header to the curl command.

### Limitations

:white_circle: None

### Testing

:white_circle: Will be validated by re-running the "Re-list NuGet Package" workflow with version `1.1.0` after merge.

### Related Issues

- #400 — chore(ci): Add workflow to re-list unlisted NuGet packages

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.