### PR TITLE
Cherry-pick `release-1.1` CHANGELOG into `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,27 @@
 # Changelog
 
+All notable changes to the Valkey GLIDE C# client will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+
 ## 1.1.0
 
-### Changes
+### Added
 
-- Add client-side caching support with TTL-based expiration, LRU/LFU eviction policies, and cache metrics (#330)
+- Valkey JSON (JSON.*) command support for clients and batches (#358)
+- Valkey Search (FT.*) command support for clients (#225)
+- Client-side caching with TTL-based expiration, LRU/LFU eviction policies, and cache metrics API (#330)
+- Compression support for CustomCommand with incompatible command detection and improved error messages (#348)
 
-## 0.10.0
+### Security
 
-### Changes
+- Remove credential leakage vectors from FFI debug output (#371)
 
-- Add support for Windows CI and testing with WSL (#184)
-- Add StackExchange.Redis compatible pub/sub API (#202)
-- Add transparent compression support with Zstd and LZ4 backends (#213)
-- Add Valkey Search command support (#225)
+## 1.0.0
+
+### Added
+
+- StackExchange.Redis compatible pub/sub API (#202)
+- Transparent compression support with Zstd and LZ4 backends (#213)
+- Windows CI and testing with WSL (#184)


### PR DESCRIPTION
### Summary

Cherry-pick the CHANGELOG update from `release-1.1` back into `main` after the v1.1.0 release.

### Commits

- c2e996ab (#397)

### Checklist

- [x] ~~This Pull Request is related to one issue.~~
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.