### PR TITLE
fix: Correct client info default values

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,6 +70,20 @@ jobs:
                   echo "Release version detected: $R_VERSION (raw: $RAW_VERSION)"
                   echo "RELEASE_VERSION=$R_VERSION" >> "$GITHUB_OUTPUT"
 
+            - name: Checkout
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: rust/.cargo
+
+            - name: Verify GLIDE_VERSION matches release version
+              shell: bash
+              run: |
+                  GLIDE_VERSION=$(grep 'GLIDE_VERSION' rust/.cargo/config.toml | sed 's/.*= *"\(.*\)"/\1/')
+                  if [ "$GLIDE_VERSION" != "$RELEASE_VERSION" ]; then
+                      echo "::error::GLIDE_VERSION in rust/.cargo/config.toml ($GLIDE_VERSION) does not match release version ($RELEASE_VERSION)"
+                      exit 1
+                  fi
+
     create-binaries:
         needs: [load-platform-matrix]
         timeout-minutes: 35

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,9 +78,9 @@ jobs:
             - name: Verify GLIDE_VERSION matches release version
               shell: bash
               run: |
-                  GLIDE_VERSION=$(grep 'GLIDE_VERSION' rust/.cargo/config.toml | sed 's/.*= *"\(.*\)"/\1/')
-                  if [ "$GLIDE_VERSION" != "$RELEASE_VERSION" ]; then
-                      echo "::error::GLIDE_VERSION in rust/.cargo/config.toml ($GLIDE_VERSION) does not match release version ($RELEASE_VERSION)"
+                  EXPECTED="GLIDE_VERSION = \"$RELEASE_VERSION\""
+                  if ! grep -qF "$EXPECTED" rust/.cargo/config.toml; then
+                      echo "::error::Expected '$EXPECTED' in rust/.cargo/config.toml but not found"
                       exit 1
                   fi
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,22 +70,8 @@ jobs:
                   echo "Release version detected: $R_VERSION (raw: $RAW_VERSION)"
                   echo "RELEASE_VERSION=$R_VERSION" >> "$GITHUB_OUTPUT"
 
-            - name: Checkout
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  sparse-checkout: rust/.cargo
-
-            - name: Verify GLIDE_VERSION matches release version
-              shell: bash
-              run: |
-                  EXPECTED="GLIDE_VERSION = \"$RELEASE_VERSION\""
-                  if ! grep -qF "$EXPECTED" rust/.cargo/config.toml; then
-                      echo "::error::Expected '$EXPECTED' in rust/.cargo/config.toml but not found"
-                      exit 1
-                  fi
-
     create-binaries:
-        needs: [load-platform-matrix]
+        needs: [load-platform-matrix, set-release-version]
         timeout-minutes: 35
         strategy:
             # Run all jobs
@@ -119,6 +105,8 @@ jobs:
             - name: Build native libs (linux gnu)
               if: ${{ contains(matrix.host.target, 'linux-gnu') }}
               working-directory: rust
+              env:
+                  GLIDE_VERSION: ${{ needs.set-release-version.outputs.RELEASE_VERSION }}
               run: |
                   cargo zigbuild -r --target ${{ matrix.host.target }}.2.17
                   mkdir -p target/release
@@ -126,6 +114,8 @@ jobs:
             - name: Build native libs
               if: ${{ !contains(matrix.host.target, 'linux-gnu') }}
               working-directory: rust
+              env:
+                  GLIDE_VERSION: ${{ needs.set-release-version.outputs.RELEASE_VERSION }}
               run: cargo build --release --target ${{ matrix.host.target }}
 
             - name: Upload artifacts to publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ on:
 
 env:
     CARGO_TERM_COLOR: always
+    GLIDE_VERSION: ${{ inputs.package-version || 'unknown' }}
 
 jobs:
     load-matrix:

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,3 +1,3 @@
 [env]
 GLIDE_NAME = "GlideC#"
-GLIDE_VERSION = "1.2.0"
+GLIDE_VERSION = "unknown"

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,3 +1,3 @@
 [env]
-GLIDE_NAME = { value = "GlideC#", force = true }
-GLIDE_VERSION = "unknown"
+GLIDE_NAME = "GlideC#"
+GLIDE_VERSION = "1.2.0"

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -250,7 +250,7 @@ pub(crate) unsafe fn create_connection_request(
             None
         },
         client_name: unsafe { ptr_to_opt_str(config.client_name) }?,
-        lib_name: option_env!("GLIDE_NAME").map(|s| s.to_string()),
+        lib_name: Some(env!("GLIDE_NAME").to_string()),
         authentication_info: if config.has_authentication_info {
             let auth_info = config.authentication_info;
             let iam_config = if auth_info.has_iam_credentials {

--- a/sources/Valkey.Glide/Abstract/ConfigurationOptions.cs
+++ b/sources/Valkey.Glide/Abstract/ConfigurationOptions.cs
@@ -137,7 +137,7 @@ public sealed class ConfigurationOptions : ICloneable
     /// <summary>
     /// Gets the library name to use for CLIENT SETINFO lib-name calls to server during handshake.
     /// </summary>
-    public string? LibraryName => "GlideCSharp";
+    public string? LibraryName => "GlideC#";
 
     /// <summary>
     /// A Boolean value that specifies whether the certificate revocation list is checked during authentication.

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -728,7 +728,7 @@ public abstract class ConnectionConfiguration
         /// </summary>
         public string? ClientName
         {
-            get => Config.ClientName ?? "GlideC#";
+            get => Config.ClientName;
             set => Config.ClientName = value;
         }
 

--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -56,7 +56,7 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
             : await ((GlideClient)client).CustomCommand(InfoCommand);
 
         Assert.Contains($"name={clientName} ", result!.ToString()!);
-}
+    }
 
     #endregion
 }

--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -10,7 +10,10 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
     #region Constants
 
     //TODO #414: Remove when ClientInfoAsync implemented.
-    private readonly GlideString[] _infoCommand = ["CLIENT", "INFO"];
+    private static readonly GlideString[] InfoCommand = ["CLIENT", "INFO"];
+
+    private static readonly string LibVersion =
+        Environment.GetEnvironmentVariable("GLIDE_VERSION") ?? "unknown";
 
     #endregion
     #region Public Properties
@@ -26,12 +29,12 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
     public async Task TestClientInfo_ReportsCorrectLibNameAndVersion(BaseClient client)
     {
         var result = client is GlideClusterClient clusterClient
-            ? (await clusterClient.CustomCommand(_infoCommand, Route.Random)).SingleValue
-            : await ((GlideClient)client).CustomCommand(_infoCommand);
+            ? (await clusterClient.CustomCommand(InfoCommand, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(InfoCommand);
         var info = result!.ToString()!;
 
         Assert.Contains("lib-name=GlideC#", info);
-        Assert.Contains("lib-ver=1.2.0", info);
+        Assert.Contains($"lib-ver={LibVersion}", info);
         Assert.Contains("name= ", info);
     }
 
@@ -52,8 +55,8 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
                     .Build());
 
         var result = client is GlideClusterClient clusterClient
-            ? (await clusterClient.CustomCommand(_infoCommand, Route.Random)).SingleValue
-            : await ((GlideClient)client).CustomCommand(_infoCommand);
+            ? (await clusterClient.CustomCommand(InfoCommand, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(InfoCommand);
 
         Assert.Contains($"name={clientName} ", result!.ToString()!);
     }

--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -12,6 +12,8 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
     //TODO #414: Remove when ClientInfoAsync implemented.
     private static readonly GlideString[] InfoCommand = ["CLIENT", "INFO"];
 
+    // Library version is set dynamically by the CD workflow,
+    // and defaults to "unknown" for local and CI builds.
     private static readonly string LibVersion =
         Environment.GetEnvironmentVariable("GLIDE_VERSION") ?? "unknown";
 

--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -1,0 +1,62 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+using Valkey.Glide.TestUtils;
+
+namespace Valkey.Glide.IntegrationTests;
+
+[Collection("GlideTests")]
+public class ConnectionManagementCommandTests(TestConfiguration config)
+{
+    #region Constants
+
+    //TODO #414: Remove when ClientInfoAsync implemented.
+    private readonly GlideString[] InfoCommand = ["CLIENT", "INFO"];
+
+    #endregion
+    #region Public Properties
+
+    public TestConfiguration Config { get; } = config;
+
+    #endregion
+    #region Tests
+
+    // TODO #414: Update when ClientInfoAsync implemented.
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task TestClientInfo_ReportsCorrectLibNameAndVersion(BaseClient client)
+    {
+        var result = client is GlideClusterClient clusterClient
+            ? (await clusterClient.CustomCommand(InfoCommand, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(InfoCommand);
+        var info = result!.ToString()!;
+
+        Assert.Contains("lib-name=GlideC#", info);
+        Assert.Contains("lib-ver=1.2.0", info);
+        Assert.Contains("name= ", info);
+    }
+
+    // TODO #414: Update when ClientInfoAsync implemented.
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
+    public async Task TestClientInfo_WithClientName_ReportsName(bool useCluster)
+    {
+        const string clientName = "client";
+        using BaseClient client = useCluster
+            ? await GlideClusterClient.CreateClient(
+                TestConfiguration.DefaultClusterClientConfig()
+                    .WithClientName(clientName)
+                    .Build())
+            : await GlideClient.CreateClient(
+                TestConfiguration.DefaultClientConfig()
+                    .WithClientName(clientName)
+                    .Build());
+
+        var result = client is GlideClusterClient clusterClient
+            ? (await clusterClient.CustomCommand(InfoCommand, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(InfoCommand);
+
+        Assert.Contains($"name={clientName} ", result!.ToString()!);
+}
+
+    #endregion
+}

--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -10,7 +10,7 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
     #region Constants
 
     //TODO #414: Remove when ClientInfoAsync implemented.
-    private readonly GlideString[] InfoCommand = ["CLIENT", "INFO"];
+    private readonly GlideString[] _infoCommand = ["CLIENT", "INFO"];
 
     #endregion
     #region Public Properties
@@ -26,8 +26,8 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
     public async Task TestClientInfo_ReportsCorrectLibNameAndVersion(BaseClient client)
     {
         var result = client is GlideClusterClient clusterClient
-            ? (await clusterClient.CustomCommand(InfoCommand, Route.Random)).SingleValue
-            : await ((GlideClient)client).CustomCommand(InfoCommand);
+            ? (await clusterClient.CustomCommand(_infoCommand, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(_infoCommand);
         var info = result!.ToString()!;
 
         Assert.Contains("lib-name=GlideC#", info);
@@ -52,8 +52,8 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
                     .Build());
 
         var result = client is GlideClusterClient clusterClient
-            ? (await clusterClient.CustomCommand(InfoCommand, Route.Random)).SingleValue
-            : await ((GlideClient)client).CustomCommand(InfoCommand);
+            ? (await clusterClient.CustomCommand(_infoCommand, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(_infoCommand);
 
         Assert.Contains($"name={clientName} ", result!.ToString()!);
     }

--- a/tests/Valkey.Glide.IntegrationTests/ServerTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ServerTests.cs
@@ -151,20 +151,4 @@ public class ServerTests(TestConfiguration config)
             Assert.Equal(ValkeyValue.Null, clientName); // No name should be set initially
         }
     }
-
-    [Theory(DisableDiscoveryEnumeration = true)]
-    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
-    public async Task ClientInfo_ReportsCorrectLibNameAndVersion(BaseClient client)
-    {
-        var command = new GlideString[] { "CLIENT", "INFO" };
-        var result =
-            client is GlideClusterClient clusterClient
-            ? (await clusterClient.CustomCommand(command, Route.Random)).SingleValue
-            : await ((GlideClient)client).CustomCommand(command);
-        var info = result!.ToString()!;
-
-        Assert.Contains("lib-name=GlideC#", info);
-        Assert.Contains("lib-ver=1.2.0", info);
-        Assert.Contains("name= ", info);
-    }
 }

--- a/tests/Valkey.Glide.IntegrationTests/ServerTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ServerTests.cs
@@ -5,7 +5,7 @@ using System.Net;
 namespace Valkey.Glide.IntegrationTests;
 
 /// <summary>
-/// Tests for <see cref="ValkeyServer" /> class.
+/// Tests for <see cref="ValkeyServer"/> class.
 /// </summary>
 public class ServerTests(TestConfiguration config)
 {
@@ -150,5 +150,21 @@ public class ServerTests(TestConfiguration config)
             ValkeyValue clientName = await server.ClientGetNameAsync();
             Assert.Equal(ValkeyValue.Null, clientName); // No name should be set initially
         }
+    }
+
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Config.TestClients), MemberType = typeof(TestConfiguration))]
+    public async Task ClientInfo_ReportsCorrectLibNameAndVersion(BaseClient client)
+    {
+        var command = new GlideString[] { "CLIENT", "INFO" };
+        var result =
+            client is GlideClusterClient clusterClient
+            ? (await clusterClient.CustomCommand(command, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(command);
+        var info = result!.ToString()!;
+
+        Assert.Contains("lib-name=GlideC#", info);
+        Assert.Contains("lib-ver=1.2.0", info);
+        Assert.Contains("name= ", info);
     }
 }


### PR DESCRIPTION
## Summary

Fix incorrect `lib-name` and `lib-ver` values reported by `CLIENT INFO` / `CLIENT LIST`, harden the build to require these values, and add integration tests to verify the connection sets these fields correctly.

## Issue Link

Closes #277.

## Features and Behaviour Changes

- `CLIENT INFO` now reports `lib-name=GlideC#` (was `GlideCSharp`).
- `CLIENT INFO` now reports `lib-ver=1.2.0` (was unset/incorrect).
- When no explicit client name is configured, `CLIENT SETNAME` is no longer issued during the connection handshake.
- `GLIDE_NAME` is now required at compile time — the Rust build will fail if it is not set.
- The CD workflow now validates that `GLIDE_VERSION` in `rust/.cargo/config.toml` matches the release version, failing fast before building binaries if there is a mismatch.

## Implementation

- **`ConfigurationOptions.LibraryName`**: Changed from `"GlideCSharp"` to `"GlideC#"` to match the `GLIDE_NAME` compile-time variable used by glide-core.
- **`ConnectionConfiguration.ClientName`**: Removed the `"GlideC#"` fallback so the getter returns `null` when no name is explicitly set. This prevents an unnecessary `CLIENT SETNAME` command during handshake.
- **`rust/.cargo/config.toml`**: Set `GLIDE_VERSION = "1.2.0"` so `CLIENT SETINFO lib-ver` reports the correct version.
- **`rust/src/ffi.rs`**: Changed `option_env!("GLIDE_NAME")` to `env!("GLIDE_NAME")` so the build fails if the env var is missing.
- **`.github/workflows/cd.yml`**: Added a verification step in `set-release-version` that reads `GLIDE_VERSION` from `rust/.cargo/config.toml` and fails the pipeline if it doesn't match the release version.

## Limitations

:white_circle: None

## Testing

- Added `ConnectionManagementCommandTests` with a GLIDE-native integration test (`TestClientInfo_WithClientName_ReportsName`) verifying custom client name is reported correctly via `CLIENT INFO`.

## Related Issues

- #277 - `CLIENT LIST` command support.
- #414 — `CLIENT INFO` command support.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [ ] Create merge commit if merging release branch into `main`, squash otherwise.