### PR TITLE
fix #430: Parse all values returned by XREADGROUP

### DIFF
--- a/sources/Valkey.Glide/Internals/Request.StreamCommands.cs
+++ b/sources/Valkey.Glide/Internals/Request.StreamCommands.cs
@@ -158,19 +158,17 @@ internal partial class Request
                             continue;
                         }
 
-                        // The value is an array containing a single element which is the field-value array
-                        if (outerArray[0] is not object[] fieldValues || fieldValues.Length == 0)
+                        var values = new NameValueEntry[outerArray.Length];
+                        for (int i = 0; i < outerArray.Length; i++)
                         {
-                            continue;
-                        }
-
-                        // Convert field-value array to NameValueEntry array
-                        var values = new NameValueEntry[fieldValues.Length / 2];
-                        for (int i = 0; i < values.Length; i++)
-                        {
+                            var field = outerArray[i];
+                            if (field is not object[] fieldValues || fieldValues.Length == 0)
+                            {
+                                continue;
+                            }
                             values[i] = new NameValueEntry(
-                                (GlideString)fieldValues[i * 2],
-                                (GlideString)fieldValues[(i * 2) + 1]
+                                (GlideString)fieldValues[0],
+                                (GlideString)fieldValues[1]
                             );
                         }
 
@@ -234,19 +232,17 @@ internal partial class Request
                             continue;
                         }
 
-                        // The value is an array containing a single element which is the field-value array
-                        if (outerArray[0] is not object[] fieldValues || fieldValues.Length == 0)
+                        var values = new NameValueEntry[outerArray.Length];
+                        for (int i = 0; i < outerArray.Length; i++)
                         {
-                            continue;
-                        }
-
-                        // Convert field-value array to NameValueEntry array
-                        var values = new NameValueEntry[fieldValues.Length / 2];
-                        for (int i = 0; i < values.Length; i++)
-                        {
+                            var field = outerArray[i];
+                            if (field is not object[] fieldValues || fieldValues.Length == 0)
+                            {
+                                continue;
+                            }
                             values[i] = new NameValueEntry(
-                                (GlideString)fieldValues[i * 2],
-                                (GlideString)fieldValues[(i * 2) + 1]
+                                (GlideString)fieldValues[0],
+                                (GlideString)fieldValues[1]
                             );
                         }
 


### PR DESCRIPTION
## Summary

Parse all values from XREADGROUP

## Issue Link

Closes #430 .

## Features and Behaviour Changes

No new features, only iterates through the outer array of a stream's data instead of grabbing the first one only

## Implementation

Updated both `ConvertSingleStreamRead` and `ConvertMultiStreamRead` as they both used the same logic. Replaced the `outerArray[0]` with a loop to build the NameValueEntry array.

## Limitations

N/A

## Testing

Ran the test suite locally

## Related Issues

N/A

## Checklist

<!--
Before submitting the PR make sure the following are checked.
Not applicable items should be crossed out, not removed.
-->

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
