### PR TITLE
Remove `NET8_0_OR_GREATER` preprocessor directives

### DIFF
--- a/sources/Valkey.Glide/Internals/FFI.methods.cs
+++ b/sources/Valkey.Glide/Internals/FFI.methods.cs
@@ -27,7 +27,6 @@ internal partial class FFI
         IntPtr patternPtr,
         ulong patternLen);
 
-#if NET8_0_OR_GREATER
     [LibraryImport("libglide_rs", EntryPoint = "command")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void CommandFfi(IntPtr client, ulong index, IntPtr cmdInfo, IntPtr routeInfo);
@@ -118,76 +117,4 @@ internal partial class FFI
     [LibraryImport("libglide_rs", EntryPoint = "get_cache_metrics")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial void GetCacheMetricsFfi(IntPtr client, ulong index, uint metricsType);
-#else
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "command")]
-    public static extern void CommandFfi(IntPtr client, ulong index, IntPtr cmdInfo, IntPtr routeInfo);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "batch")]
-    public static extern void BatchFfi(IntPtr client, ulong index, IntPtr batch, [MarshalAs(UnmanagedType.U1)] bool raiseOnError, IntPtr opts);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_response")]
-    public static extern void FreeResponse(IntPtr responsePtr);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_string")]
-    public static extern void FreeString(IntPtr strPtr);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "create_client")]
-    public static extern void CreateClientFfi(IntPtr config, IntPtr successCallback, IntPtr failureCallback, IntPtr pubsubCallback, IntPtr addressResolverCallback);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "close_client")]
-    public static extern void CloseClientFfi(IntPtr client);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "store_script")]
-    public static extern IntPtr StoreScriptFfi(IntPtr scriptPtr, UIntPtr scriptLen);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "drop_script")]
-    public static extern IntPtr DropScriptFfi(IntPtr hashPtr, UIntPtr hashLen);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "free_script_hash_buffer")]
-    public static extern void FreeScriptHashBuffer(IntPtr hashBuffer);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "script_invoke")]
-    public static extern void ScriptInvokeFfi(
-        IntPtr client,
-        ulong index,
-        IntPtr hash,
-        ulong keysCount,
-        IntPtr keys,
-        IntPtr keysLen,
-        ulong argsCount,
-        IntPtr args,
-        IntPtr argsLen,
-        IntPtr routeInfo,
-        ulong routeInfoLen);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "request_cluster_scan")]
-    public static extern void RequestClusterScanFfi(IntPtr client, ulong index, IntPtr cursor, ulong argCount, IntPtr args, IntPtr argLengths);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "remove_cluster_scan_cursor")]
-    public static extern void RemoveClusterScanCursorFfi(IntPtr cursorId);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "update_connection_password")]
-    public static extern void UpdateConnectionPasswordFfi(IntPtr client, ulong index, IntPtr password, [MarshalAs(UnmanagedType.U1)] bool immediateAuth);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "refresh_iam_token")]
-    public static extern void RefreshIamTokenFfi(IntPtr client, ulong index);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "init_otel")]
-    public static extern IntPtr InitOpenTelemetryFfi(IntPtr config);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "create_otel_span")]
-    public static extern IntPtr CreateOpenTelemetrySpanFfi(uint requestType);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "create_batch_otel_span")]
-    public static extern IntPtr CreateBatchOpenTelemetrySpanFfi();
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "drop_otel_span")]
-    public static extern void DropOpenTelemetrySpanFfi(IntPtr spanPtr);
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "get_statistics")]
-    public static extern Statistics GetStatisticsFfi();
-
-    [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "get_cache_metrics")]
-    public static extern void GetCacheMetricsFfi(IntPtr client, ulong index, uint metricsType);
-#endif
 }

--- a/sources/Valkey.Glide/Internals/Request.ServerManagement.cs
+++ b/sources/Valkey.Glide/Internals/Request.ServerManagement.cs
@@ -139,11 +139,7 @@ internal partial class Request
             long seconds = long.Parse(arr[0] is GlideString gs1 ? gs1.ToString() : arr[0].ToString()!);
             long microseconds = long.Parse(arr[1] is GlideString gs2 ? gs2.ToString() : arr[1].ToString()!);
             return DateTimeOffset.FromUnixTimeSeconds(seconds)
-#if NET8_0_OR_GREATER
                 .AddMicroseconds(microseconds);
-#else
-                .AddTicks(microseconds * 10);
-#endif
         });
 
     public static Cmd<GlideString, string> LolwutAsync(LolwutOptions? options = null)

--- a/sources/Valkey.Glide/abstract_Enums/SER/CommandFlags.cs
+++ b/sources/Valkey.Glide/abstract_Enums/SER/CommandFlags.cs
@@ -34,7 +34,6 @@ public enum CommandFlags
     /// </summary>
     PreferMaster = 0,
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// This operation should be performed on the replica if it is available, but will be performed on
     /// a primary if no replicas are available. Suitable for read operations only.
@@ -42,22 +41,11 @@ public enum CommandFlags
     [Obsolete("Starting with Valkey version 5, Valkey has moved to 'replica' terminology. Please use " + nameof(PreferReplica) + " instead, this will be removed in 3.0.")]
     [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
     PreferSlave = 8,
-#endif
 
     /// <summary>
     /// This operation should only be performed on the primary.
     /// </summary>
     DemandMaster = 4,
-
-#if !NET8_0_OR_GREATER
-    /// <summary>
-    /// This operation should be performed on the replica if it is available, but will be performed on
-    /// a primary if no replicas are available. Suitable for read operations only.
-    /// </summary>
-    [Obsolete("Starting with Valkey version 5, Valkey has moved to 'replica' terminology. Please use " + nameof(PreferReplica) + " instead, this will be removed in 3.0.")]
-    [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-    PreferSlave = 8,
-#endif
 
     /// <summary>
     /// This operation should be performed on the replica if it is available, but will be performed on
@@ -65,28 +53,17 @@ public enum CommandFlags
     /// </summary>
     PreferReplica = 8, // note: we're using a 2-bit set here, which [Flags] formatting hates; position is doing the best we can for reasonable outcomes here
 
-#if NET8_0_OR_GREATER
     /// <summary>
     /// This operation should only be performed on a replica. Suitable for read operations only.
     /// </summary>
     [Obsolete("Starting with Valkey version 5, Valkey has moved to 'replica' terminology. Please use " + nameof(DemandReplica) + " instead, this will be removed in 3.0.")]
     [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
     DemandSlave = 12,
-#endif
 
     /// <summary>
     /// This operation should only be performed on a replica. Suitable for read operations only.
     /// </summary>
     DemandReplica = 12, // note: we're using a 2-bit set here, which [Flags] formatting hates; position is doing the best we can for reasonable outcomes here
-
-#if !NET8_0_OR_GREATER
-    /// <summary>
-    /// This operation should only be performed on a replica. Suitable for read operations only.
-    /// </summary>
-    [Obsolete("Starting with Valkey version 5, Valkey has moved to 'replica' terminology. Please use " + nameof(DemandReplica) + " instead, this will be removed in 3.0.")]
-    [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
-    DemandSlave = 12,
-#endif
 
     // 16: reserved for additional "demand/prefer" options
 

--- a/tests/Valkey.Glide.IntegrationTests/BatchTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/BatchTests.cs
@@ -1021,10 +1021,6 @@ public class BatchTests(TestConfiguration config)
     {
         object[] arr = (object[])res!;
         return DateTime.UnixEpoch.AddSeconds(double.Parse((arr[0] as gs)!))
-#if NET8_0_OR_GREATER
             .AddMicroseconds(double.Parse((arr[1] as gs)!));
-#else
-            .AddMilliseconds(double.Parse((arr[1] as gs)!) / 1000);
-#endif
     }
 }

--- a/tests/Valkey.Glide.UnitTests/GlideStringTests.cs
+++ b/tests/Valkey.Glide.UnitTests/GlideStringTests.cs
@@ -8,9 +8,7 @@ public class GlideStringTests
     public void Sorting()
     {
         gs[] arr = ["abc", "abcd", "abcde", "abd", "abb", "ab1"];
-#if NET8_0_OR_GREATER
         Assert.Equal(new gs[] { "ab1", "abb", "abc", "abd", "abcd", "abcde" }, [.. arr.Order()]);
-#endif
         Assert.Equal(new gs[] { "ab1", "abb", "abc", "abd", "abcd", "abcde" }, [.. arr.OrderBy(s => s)]);
     }
 


### PR DESCRIPTION
## Summary

Remove all `#if NET8_0_OR_GREATER` preprocessor directives since the project now exclusively targets .NET 8.0+.

## Issue Link

:white_circle: None

## Features and Behaviour Changes

:white_circle: None — pure cleanup with no functional or behavioral changes.

## Implementation

- **FFI interop (`FFI.methods.cs`)**: Removed the entire `#else` block with legacy `[DllImport]` extern declarations, keeping only the modern `[LibraryImport]` / source-generated partial methods. Made the `using System.Runtime.CompilerServices` directive unconditional.
- **Time parsing (`Request.ServerManagement.cs`, `BatchTests.cs`)**: Removed `#if/#else/#endif` blocks and kept the `.AddMicroseconds()` API (available since .NET 8.0), dropping the `.AddTicks(x * 10)` workaround.
- **Enum definitions (`CommandFlags.cs`)**: Consolidated duplicate `PreferSlave` and `DemandSlave` definitions that were split across `#if` / `#if !` blocks into single definitions.
- **Unit tests (`GlideStringTests.cs`)**: Removed `#if` guard around `arr.Order()` assertion (LINQ `Order()` is unconditionally available on .NET 8+).