### PR TITLE
Add `NodeDiscoveryMode` configuration option for standalone clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RESET` (#435)
   - `SAVE` (#440)
 - Custom socket address resolution support via callback (#392)
+- `NodeDiscoveryMode` configuration option for standalone clients, with `Standard`, `Static` (proxy-compatible, e.g. Envoy), and `DiscoverAll` modes (#131)
 
 ## 1.1.0
 

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -81,6 +81,17 @@ pub enum EvictionPolicy {
     Lfu = 1,
 }
 
+/// A mirror of [`glide_core::client::NodeDiscoveryMode`] adopted for FFI.
+///
+/// The discriminants must match the C# `ConnectionConfiguration.NodeDiscoveryMode` enum.
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum NodeDiscoveryMode {
+    Standard = 0,
+    Static = 1,
+    DiscoverAll = 2,
+}
+
 /// A mirror of [`glide_core::client::ClientSideCache`] adopted for FFI.
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -134,6 +145,7 @@ pub struct ConnectionConfig {
     pub has_compression_config: bool,
     pub compression_config: CompressionConfig,
     pub read_only: bool,
+    pub node_discovery_mode: NodeDiscoveryMode,
     pub has_client_side_cache_config: bool,
     pub client_side_cache_config: ClientSideCacheConfig,
     /*
@@ -353,13 +365,18 @@ pub(crate) unsafe fn create_connection_request(
             None
         },
 
+        node_discovery_mode: match config.node_discovery_mode {
+            NodeDiscoveryMode::Standard => glide_core::client::NodeDiscoveryMode::Standard,
+            NodeDiscoveryMode::Static => glide_core::client::NodeDiscoveryMode::Static,
+            NodeDiscoveryMode::DiscoverAll => glide_core::client::NodeDiscoveryMode::DiscoverAll,
+        },
+
         // Unimplemented configuration options.
         client_cert: Vec::new(),
         client_key: Vec::new(),
         tcp_nodelay: false,
         periodic_checks: None,
         inflight_requests_limit: None,
-        node_discovery_mode: glide_core::client::NodeDiscoveryMode::default(),
         address_resolver: None,
         client_circuit_breaker: None,
     })

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -60,7 +60,7 @@ public abstract class ConnectionConfiguration
         public TimeSpan? PubSubReconciliationInterval;
         public CompressionConfig? CompressionConfig;
         public bool ReadOnly;
-        public NodeDiscoveryMode NodeDiscoveryMode;
+        public NodeDiscoveryMode NodeDiscoveryMode = NodeDiscoveryMode.Standard;
         public ClientSideCacheConfig? ClientSideCacheConfig;
         public AddressResolverDelegate? AddressResolver;
 
@@ -223,40 +223,6 @@ public abstract class ConnectionConfiguration
         /// Use RESP3 to communicate with the server nodes.
         /// </summary>
         RESP3 = 1,
-    }
-
-    /// <summary>
-    /// Controls how the client discovers node roles and topology in standalone mode.
-    /// <para />
-    /// This option is only relevant for standalone clients; it is ignored in cluster mode, which
-    /// has its own topology discovery mechanism.
-    /// </summary>
-    public enum NodeDiscoveryMode : uint
-    {
-        /// <summary>
-        /// Default: verify node roles via <c>INFO REPLICATION</c>, use only the provided addresses.
-        /// This is the fully backward-compatible behavior.
-        /// </summary>
-        Standard = 0,
-        /// <summary>
-        /// Skip role detection entirely. Trust the provided addresses as-is; the first address is
-        /// treated as the primary. Use when connecting through a proxy (e.g., Envoy) or when the
-        /// topology is known and static.
-        /// <para />
-        /// <b>Note</b>: Do not set <see cref="ClientConfigurationBuilder{T}.ClientName"/> when using
-        /// this mode with a proxy, as the proxy may not support the <c>CLIENT SETNAME</c> command
-        /// sent during connection setup.
-        /// </summary>
-        Static = 1,
-        /// <summary>
-        /// Discover the full topology (primary + all replicas) from any starting node. Provide any
-        /// single node address (primary or replica) and the client will find and connect to all
-        /// other nodes.
-        /// <para />
-        /// Discovery happens only at client creation time; topology changes after creation are not
-        /// re-discovered until the client is recreated.
-        /// </summary>
-        DiscoverAll = 2,
     }
 
     #endregion
@@ -974,12 +940,7 @@ public abstract class ConnectionConfiguration
         /// <summary>
         /// Controls how the client discovers node roles and topology during connection
         /// initialization. If not set, defaults to <see cref="NodeDiscoveryMode.Standard" />.
-        /// <para />
-        /// <see cref="NodeDiscoveryMode.DiscoverAll" /> is mutually exclusive with read-only mode
-        /// (read-only skips the <c>INFO REPLICATION</c> call that discovery requires); this
-        /// combination is rejected at client creation time.
-        /// <para />
-        /// See also <seealso cref="NodeDiscoveryMode" />.
+        /// See <see cref="NodeDiscoveryMode" /> for the available modes and their details.
         /// </summary>
         public NodeDiscoveryMode NodeDiscoveryMode
         {

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -60,6 +60,7 @@ public abstract class ConnectionConfiguration
         public TimeSpan? PubSubReconciliationInterval;
         public CompressionConfig? CompressionConfig;
         public bool ReadOnly;
+        public NodeDiscoveryMode NodeDiscoveryMode;
         public ClientSideCacheConfig? ClientSideCacheConfig;
         public AddressResolverDelegate? AddressResolver;
 
@@ -83,6 +84,7 @@ public abstract class ConnectionConfiguration
                 (uint?)PubSubReconciliationInterval?.TotalMilliseconds,
                 CompressionConfig?.ToFfi(),
                 ReadOnly,
+                NodeDiscoveryMode,
                 ClientSideCacheConfig?.ToFfi()
             );
     }
@@ -221,6 +223,40 @@ public abstract class ConnectionConfiguration
         /// Use RESP3 to communicate with the server nodes.
         /// </summary>
         RESP3 = 1,
+    }
+
+    /// <summary>
+    /// Controls how the client discovers node roles and topology in standalone mode.
+    /// <para />
+    /// This option is only relevant for standalone clients; it is ignored in cluster mode, which
+    /// has its own topology discovery mechanism.
+    /// </summary>
+    public enum NodeDiscoveryMode : uint
+    {
+        /// <summary>
+        /// Default: verify node roles via <c>INFO REPLICATION</c>, use only the provided addresses.
+        /// This is the fully backward-compatible behavior.
+        /// </summary>
+        Standard = 0,
+        /// <summary>
+        /// Skip role detection entirely. Trust the provided addresses as-is; the first address is
+        /// treated as the primary. Use when connecting through a proxy (e.g., Envoy) or when the
+        /// topology is known and static.
+        /// <para />
+        /// <b>Note</b>: Do not set <see cref="ClientConfigurationBuilder{T}.ClientName"/> when using
+        /// this mode with a proxy, as the proxy may not support the <c>CLIENT SETNAME</c> command
+        /// sent during connection setup.
+        /// </summary>
+        Static = 1,
+        /// <summary>
+        /// Discover the full topology (primary + all replicas) from any starting node. Provide any
+        /// single node address (primary or replica) and the client will find and connect to all
+        /// other nodes.
+        /// <para />
+        /// Discovery happens only at client creation time; topology changes after creation are not
+        /// re-discovered until the client is recreated.
+        /// </summary>
+        DiscoverAll = 2,
     }
 
     #endregion
@@ -933,6 +969,31 @@ public abstract class ConnectionConfiguration
         /// Complete the configuration with given settings.
         /// </summary>
         public new StandaloneClientConfiguration Build() => new() { Request = base.Build() };
+
+        #region Node Discovery Mode
+        /// <summary>
+        /// Controls how the client discovers node roles and topology during connection
+        /// initialization. If not set, defaults to <see cref="NodeDiscoveryMode.Standard" />.
+        /// <para />
+        /// <see cref="NodeDiscoveryMode.DiscoverAll" /> is mutually exclusive with read-only mode
+        /// (read-only skips the <c>INFO REPLICATION</c> call that discovery requires); this
+        /// combination is rejected at client creation time.
+        /// <para />
+        /// See also <seealso cref="NodeDiscoveryMode" />.
+        /// </summary>
+        public NodeDiscoveryMode NodeDiscoveryMode
+        {
+            get => Config.NodeDiscoveryMode;
+            set => Config.NodeDiscoveryMode = value;
+        }
+
+        /// <inheritdoc cref="NodeDiscoveryMode" />
+        public StandaloneClientConfigurationBuilder WithNodeDiscoveryMode(NodeDiscoveryMode nodeDiscoveryMode)
+        {
+            NodeDiscoveryMode = nodeDiscoveryMode;
+            return this;
+        }
+        #endregion
 
         #region PubSub Subscriptions
         /// <summary>

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -219,6 +219,7 @@ internal partial class FFI
             uint? pubSubReconciliationIntervalMs,
             CompressionConfig? compressionConfig,
             bool readOnly,
+            ConnectionConfiguration.NodeDiscoveryMode nodeDiscoveryMode,
             ClientSideCacheConfig? clientSideCacheConfig)
         {
             _request = new()
@@ -253,6 +254,7 @@ internal partial class FFI
                 HasCompressionConfig = compressionConfig.HasValue,
                 CompressionConfig = compressionConfig ?? default,
                 ReadOnly = readOnly,
+                NodeDiscoveryMode = nodeDiscoveryMode,
                 HasClientSideCacheConfig = clientSideCacheConfig.HasValue,
                 ClientSideCacheConfig = clientSideCacheConfig ?? default,
             };
@@ -1129,6 +1131,8 @@ internal partial class FFI
         public CompressionConfig CompressionConfig;
         [MarshalAs(UnmanagedType.U1)]
         public bool ReadOnly;
+
+        public ConnectionConfiguration.NodeDiscoveryMode NodeDiscoveryMode;
 
         [MarshalAs(UnmanagedType.U1)]
         public bool HasClientSideCacheConfig;

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -200,6 +200,12 @@ internal partial class FFI
     {
         private ConnectionRequest _request;
 
+        /// <summary>
+        /// The node discovery mode marshalled into the underlying FFI request. Exposed for testing
+        /// that the value is correctly wired through to the FFI layer.
+        /// </summary>
+        internal NodeDiscoveryMode NodeDiscoveryMode => _request.NodeDiscoveryMode;
+
         public ConnectionConfig(
             List<NodeAddress> addresses,
             TlsMode tlsMode,
@@ -219,7 +225,7 @@ internal partial class FFI
             uint? pubSubReconciliationIntervalMs,
             CompressionConfig? compressionConfig,
             bool readOnly,
-            ConnectionConfiguration.NodeDiscoveryMode nodeDiscoveryMode,
+            NodeDiscoveryMode nodeDiscoveryMode,
             ClientSideCacheConfig? clientSideCacheConfig)
         {
             _request = new()
@@ -1129,10 +1135,11 @@ internal partial class FFI
         [MarshalAs(UnmanagedType.U1)]
         public bool HasCompressionConfig;
         public CompressionConfig CompressionConfig;
+
         [MarshalAs(UnmanagedType.U1)]
         public bool ReadOnly;
 
-        public ConnectionConfiguration.NodeDiscoveryMode NodeDiscoveryMode;
+        public NodeDiscoveryMode NodeDiscoveryMode;
 
         [MarshalAs(UnmanagedType.U1)]
         public bool HasClientSideCacheConfig;

--- a/sources/Valkey.Glide/abstract_Enums/NodeDiscoveryMode.cs
+++ b/sources/Valkey.Glide/abstract_Enums/NodeDiscoveryMode.cs
@@ -1,0 +1,40 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide;
+
+/// <summary>
+/// Controls how the client discovers node roles and topology in standalone mode.
+/// <para />
+/// This option is only relevant for standalone clients; it is ignored in cluster mode, which
+/// has its own topology discovery mechanism.
+/// </summary>
+/// <seealso href="https://glide.valkey.io/reference/connection-options/">Valkey GLIDE – Connection Options</seealso>
+public enum NodeDiscoveryMode : uint
+{
+    /// <summary>
+    /// Default: verify node roles via <c>INFO REPLICATION</c>, use only the provided addresses.
+    /// This is the fully backward-compatible behavior.
+    /// </summary>
+    Standard = 0,
+
+    /// <summary>
+    /// Skip role detection entirely. Trust the provided addresses as-is; the first address is
+    /// treated as the primary. Use when connecting through a proxy (e.g., Envoy) or when the
+    /// topology is known and static.
+    /// <para />
+    /// <b>Note</b>: Do not set a client name when using this mode with a proxy, as the proxy may
+    /// not support the <c>CLIENT SETNAME</c> command sent during connection setup.
+    /// </summary>
+    Static = 1,
+
+    /// <summary>
+    /// Discover the full topology (primary + all replicas) from any starting node. Provide any
+    /// single node address (primary or replica) and the client will find and connect to all
+    /// other nodes.
+    /// <para />
+    /// Discovery happens only at client creation time; topology changes after creation are not
+    /// re-discovered until the client is recreated. This mode is mutually exclusive with
+    /// read-only mode, which skips the <c>INFO REPLICATION</c> call that discovery requires.
+    /// </summary>
+    DiscoverAll = 2,
+}

--- a/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/StandaloneClientTests.cs
@@ -525,4 +525,19 @@ public class StandaloneClientTests(TestConfiguration config)
         await using var client = await GlideClient.CreateClient(builder.Build());
         await AssertConnected(client);
     }
+
+    [Theory]
+    [MemberData(nameof(NodeDiscoveryModes), MemberType = typeof(Data))]
+    public async Task Connect_WithNodeDiscoveryMode_Succeeds(NodeDiscoveryMode mode)
+    {
+        // Against a single-node standalone server, all modes should connect successfully:
+        // `Standard` verifies the role, `Static` trusts the address as primary, and
+        // `DiscoverAll` discovers the (replica-less) topology from the primary.
+        var config = TestConfiguration.DefaultClientConfig()
+            .WithNodeDiscoveryMode(mode)
+            .Build();
+
+        await using var client = await GlideClient.CreateClient(config);
+        await AssertConnected(client);
+    }
 }

--- a/tests/Valkey.Glide.TestUtils/Data.cs
+++ b/tests/Valkey.Glide.TestUtils/Data.cs
@@ -18,6 +18,12 @@ public static class Data
     public static TheoryData<bool> IsAtomic => [true, false];
 
     /// <summary>
+    /// All node discovery modes for testing.
+    /// </summary>
+    public static TheoryData<NodeDiscoveryMode> NodeDiscoveryModes
+        => new(Enum.GetValues<NodeDiscoveryMode>());
+
+    /// <summary>
     /// Server IP addresses for testing.
     /// </summary>
     public static TheoryData<string> IpAddresses => [

--- a/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
@@ -279,9 +279,7 @@ public class ConnectionConfigurationTests
     }
 
     [Theory]
-    [InlineData(NodeDiscoveryMode.Standard)]
-    [InlineData(NodeDiscoveryMode.Static)]
-    [InlineData(NodeDiscoveryMode.DiscoverAll)]
+    [MemberData(nameof(Data.NodeDiscoveryModes), MemberType = typeof(Data))]
     public void WithNodeDiscoveryMode_SetsMode(NodeDiscoveryMode mode)
     {
         var builder = new StandaloneClientConfigurationBuilder()
@@ -298,6 +296,18 @@ public class ConnectionConfigurationTests
         };
         Assert.Equal(NodeDiscoveryMode.DiscoverAll, builder.NodeDiscoveryMode);
         Assert.Equal(NodeDiscoveryMode.DiscoverAll, builder.Build().Request.NodeDiscoveryMode);
+    }
+
+    [Theory]
+    [MemberData(nameof(Data.NodeDiscoveryModes), MemberType = typeof(Data))]
+    public void WithNodeDiscoveryMode_ToFfi_PassesModeToFfiLayer(NodeDiscoveryMode mode)
+    {
+        var config = new StandaloneClientConfigurationBuilder()
+            .WithNodeDiscoveryMode(mode)
+            .Build();
+
+        using FFI.ConnectionConfig ffi = config.Request.ToFfi();
+        Assert.Equal(mode, ffi.NodeDiscoveryMode);
     }
 
     [Fact]

--- a/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
@@ -269,6 +269,48 @@ public class ConnectionConfigurationTests
     }
 
     #endregion
+    #region Node Discovery Mode Tests
+
+    [Fact]
+    public void NodeDiscoveryMode_Default_IsStandard()
+    {
+        var builder = new StandaloneClientConfigurationBuilder();
+        Assert.Equal(NodeDiscoveryMode.Standard, builder.Build().Request.NodeDiscoveryMode);
+    }
+
+    [Theory]
+    [InlineData(NodeDiscoveryMode.Standard)]
+    [InlineData(NodeDiscoveryMode.Static)]
+    [InlineData(NodeDiscoveryMode.DiscoverAll)]
+    public void WithNodeDiscoveryMode_SetsMode(NodeDiscoveryMode mode)
+    {
+        var builder = new StandaloneClientConfigurationBuilder()
+            .WithNodeDiscoveryMode(mode);
+        Assert.Equal(mode, builder.Build().Request.NodeDiscoveryMode);
+    }
+
+    [Fact]
+    public void NodeDiscoveryMode_Property_SetsMode()
+    {
+        var builder = new StandaloneClientConfigurationBuilder
+        {
+            NodeDiscoveryMode = NodeDiscoveryMode.DiscoverAll,
+        };
+        Assert.Equal(NodeDiscoveryMode.DiscoverAll, builder.NodeDiscoveryMode);
+        Assert.Equal(NodeDiscoveryMode.DiscoverAll, builder.Build().Request.NodeDiscoveryMode);
+    }
+
+    [Fact]
+    public void NodeDiscoveryMode_EnumValues_MatchFfiContract()
+    {
+        // These discriminants must stay aligned with the Rust FFI `NodeDiscoveryMode` enum and
+        // the glide-core protobuf values.
+        Assert.Equal(0u, (uint)NodeDiscoveryMode.Standard);
+        Assert.Equal(1u, (uint)NodeDiscoveryMode.Static);
+        Assert.Equal(2u, (uint)NodeDiscoveryMode.DiscoverAll);
+    }
+
+    #endregion
     #region TLS Configuration Tests
 
     [Fact]


### PR DESCRIPTION
## Summary

Adds a `NodeDiscoveryMode` configuration option for standalone clients, controlling how the client discovers node roles and topology during connection initialization. Three modes are supported:

- **`Standard`** (default): Verify node roles via `INFO REPLICATION`, use only the provided addresses. This is the current behavior — fully backward compatible.
- **`Static`**: Skip role detection entirely. Trust the provided addresses as-is; the first address is treated as the primary. Designed for proxy compatibility (e.g. Envoy/Twemproxy) or known-static topologies where `INFO` is unavailable.
- **`DiscoverAll`**: Discover the full topology (primary + all replicas) from any starting node. Provide any single node address and the client will find and connect to all other nodes.

This brings the C# binding in line with the other four language bindings (Rust core, Python, Java, Node.js, Go) implemented in the main valkey-glide repo.

## Issue Link

Closes #131.

## Features and Behaviour Changes

- New public `NodeDiscoveryMode` enum (`Standard = 0`, `Static = 1`, `DiscoverAll = 2`) on `ConnectionConfiguration`.
- New `NodeDiscoveryMode` property and `WithNodeDiscoveryMode(...)` fluent builder method on `StandaloneClientConfigurationBuilder`.
- **`Static` mode** skips `INFO REPLICATION` during connection setup and assumes the first provided address is the primary — enabling connectivity through proxies such as Envoy that don't support the `INFO` command (the original ask in #131).
- **`DiscoverAll` mode** discovers the full standalone topology from any starting node.
- **`Standard` mode** (default) maintains the current behavior with zero changes. Existing code continues to work without modification.
- The option is standalone-only; it is ignored in cluster mode, which has its own topology discovery mechanism.

## Implementation

Unlike the main valkey-glide repo (which edits the protobuf schema + glide-core), the C# repo consumes `glide-core` directly through its own thin Rust FFI shim, which was already hardcoding `node_discovery_mode: NodeDiscoveryMode::default()`. This PR wires the option through the existing FFI chain:

- **`sources/Valkey.Glide/ConnectionConfiguration.cs`**: public `NodeDiscoveryMode` enum, field on the internal `ConnectionConfig` record + `ToFfi()` wiring, and the standalone builder property/method.
- **`sources/Valkey.Glide/Internals/FFI.structs.cs`**: new parameter on the FFI `ConnectionConfig` constructor and a `NodeDiscoveryMode` field on the `ConnectionRequest` struct, placed right after `ReadOnly` to match the Rust layout.
- **`rust/src/ffi.rs`**: new `#[repr(u32)]` FFI `NodeDiscoveryMode` enum, a field on the FFI struct, and a match mapping it to `glide_core::client::NodeDiscoveryMode` (replacing the hardcoded `::default()`).

Reviewers may want to pay extra attention to the FFI struct layout alignment: the C# `enum : uint` (4 bytes) mirrors the Rust `#[repr(u32)]` enum, and the field is inserted at the same position on both sides (between `read_only` and `has_client_side_cache_config`), following the existing `TlsMode`/`Protocol` field pattern.

## Limitations

- **`Static` mode + `ClientName`**: Do not set `ClientName` when using `Static` mode with a proxy, as the proxy may not support the `CLIENT SETNAME` command sent during connection setup.
- **`DiscoverAll` mode**: Discovery happens only at client creation time — no periodic re-discovery. Replicas added after client creation are not discovered until the client is recreated.
- **`DiscoverAll` + read-only**: These modes are mutually exclusive (read-only skips the `INFO REPLICATION` call that discovery requires); rejected by glide-core at client creation time.
- **Standalone mode only**: `NodeDiscoveryMode` is ignored in cluster mode.

## Testing

- Added unit tests in `ConnectionConfigurationTests.cs` covering the default (`Standard`), each mode via the builder and via the property setter, and an enum-discriminant assertion that guards the `{0,1,2}` values against the Rust FFI / glide-core protobuf contract.
- `task build`, `task test:unit` (534/534 passing), `task lint:csharp`, and `task lint:rust` (fmt, clippy `-D warnings`, cargo-deny, cargo-doc) all pass locally.

## Related Issues

- Mirrors valkey-io/valkey-glide#5724 (NodeDiscoveryMode across the other bindings).

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.