### PR TITLE
ci(fix): dependabot gitsubmodule cooldown crash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
 # Dependabot version updates configuration.
 #
 # - All updates run weekly on Monday at 09:00 UTC.
-# - All updates use a 7-day cooldown period. This delays proposing updates to
-#   newly published package versions, reducing exposure to malicious or unstable
-#   releases. See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown
-# - Open pull requests are limited to 10 per ecosystem to avoid flooding the
-#   repository with dependency update PRs.
+# - Uses a 7-day cooldown period. This delays proposing updates
+#   to newly published package versions, reducing exposure to malicious or
+#   unstable releases. The gitsubmodule ecosystem is excluded because the
+#   submodule is a first-party repo in the same organization.
+# - Open pull requests are limited per ecosystem to avoid flooding the
+#   repository with dependency update PRs (10 for most, 1 for gitsubmodule).
 
 version: 2
 
@@ -52,14 +53,13 @@ updates:
           - "rust"
 
     # Enable version updates for git submodules
+    # nosemgrep: package_managers.dependabot.dependabot-missing-cooldown.dependabot-missing-cooldown
     - package-ecosystem: "gitsubmodule"
       directory: "/"
       schedule:
           interval: "weekly"
           day: "monday"
           time: "09:00"
-      cooldown:
-          default-days: 7
       open-pull-requests-limit: 1 # Only one submodule to track.
       labels:
           - "dependencies"


### PR DESCRIPTION
## Summary

Remove the `cooldown` configuration from the Dependabot `gitsubmodule` entry. The cooldown period is unnecessary because the submodule (`valkey-glide`) is a first-party repo in the same organization — commits are already reviewed and CI-gated before landing on main.

## Issue Link

Fix bug related to #449. Verify behaviour before closing issue.

## Features and Behaviour Changes

- Dependabot submodule updates will no longer crash due to the cooldown feature trying to parse commit SHAs as semver versions.
- Cooldown is intentionally excluded for the gitsubmodule ecosystem since the submodule is first-party and does not benefit from the protection cooldown provides against malicious or unstable third-party releases.

## Implementation

- Removed the `cooldown: default-days: 7` block from the `gitsubmodule` entry in `.github/dependabot.yml`.
- Added a `nosemgrep` comment to suppress the `dependabot-missing-cooldown` lint rule for this entry.
- Updated the file header comment to explain why cooldown is excluded for gitsubmodule and clarify the per-ecosystem PR limits.

## Limitations

:white_circle: None.

## Testing

- Validated YAML formatting passes (`task lint:yaml`).
- The fix will be verified when Dependabot next runs (Monday 09:00 UTC) or via a manual trigger from the Dependabot Insights page.

## Related Issues

- PR #450 — added Dependabot submodule update configuration (introduced the `cooldown` that causes this crash).
- [dependabot/dependabot-core#15631](https://github.com/dependabot/dependabot-core/issues/15631) — upstream bug report for the crash.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.