### PR TITLE
Remove Windows from standard CI profile

### DIFF
--- a/.github/json_matrices/os-matrix.json
+++ b/.github/json_matrices/os-matrix.json
@@ -34,7 +34,7 @@
         "os": "windows",
         "runner": "windows-2025",
         "target": "x86_64-pc-windows-msvc",
-        "profiles": [ "standard", "full"]
+        "profiles": ["full"]
     },
     {
         "os": "windows",


### PR DESCRIPTION
## Summary

Remove the Windows x86_64 runner (`windows-2025`) from the `standard` CI test profile to prevent flaky Windows tests from blocking pull requests. Windows test coverage is retained in the `full` profile, which runs nightly.

## Issue Link

:white_circle: None.

## Features and Behaviour Changes

- The `standard` CI profile (triggered on every PR) no longer includes the Windows x86_64 runner.
- The `full` profile (nightly full matrix tests) continues to include both Windows runners (x86_64 and ARM64).

## Implementation

Removed `"standard"` from the `profiles` array of the Windows x86_64 entry in `.github/json_matrices/os-matrix.json`.

## Limitations

:white_circle: None.

## Testing

- Verified that `load_matrices.py standard` no longer includes Windows in its output.
- Verified that `load_matrices.py full` still includes both Windows entries.

## Related Issues

:white_circle: None.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.