### PR TITLE
Fix flaky `TestClientPauseWrite_ReadsNotPaused` test

### DIFF
--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -197,7 +197,7 @@ public class ConnectionManagementCommandTests(TestConfiguration config)
         var key = Guid.NewGuid().ToString();
         await client.SetAsync(key, "before");
 
-        var pauseFor = TimeSpan.FromSeconds(2);
+        var pauseFor = TimeSpan.FromMinutes(1);
         await client.ClientPauseWriteAsync(pauseFor);
 
         var sw = Stopwatch.StartNew();


### PR DESCRIPTION
## Summary

Fix flaky `TestClientPauseWrite_ReadsNotPaused` integration test by increasing the write-pause duration from 2 seconds to 1 minute. The test verifies that read commands are *not blocked* during a write-only pause by asserting the read completes faster than the pause duration. With only 2 seconds of headroom, CI runners under load can exceed this threshold — causing spurious failures.

## Issue Link

:white_circle: None (no open issue for this flake).

## Features and Behaviour Changes

:white_circle: None — test-only change with no behaviour changes.

## Implementation

Changed `pauseFor` from `TimeSpan.FromSeconds(2)` to `TimeSpan.FromMinutes(1)` in `TestClientPauseWrite_ReadsNotPaused`. This matches the pattern already used by the sibling test `TestClientPauseWrite_ThenUnpause`, which uses a 1-minute pause for the same reason. The existing `ClientUnpauseAsync()` cleanup call ensures the server isn't left paused.

## Limitations

:white_circle: None.

## Testing

- C# lint passes (`task lint:csharp`).
- The test logic is unchanged — only the timing threshold is relaxed.

## Related Issues

:white_circle: None.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] ~~Tests are added or updated and all checks pass.~~
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.