### PR TITLE
Fix flaky TestClientPause integration tests

### DIFF
--- a/dev/conf/coverage-baseline.json
+++ b/dev/conf/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "server_type": "valkey",
   "server_version": "9.0",
-  "line_coverage": 71.4,
+  "line_coverage": 71.6,
   "branch_coverage": 51.9
 }

--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -155,14 +155,24 @@ public class ConnectionManagementCommandTests(ServerFixture fixture) : IClassFix
     [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task TestClientPause_ReadsPausedUntilExpires(bool clusterMode)
     {
-        await using var client = await fixture.GetServer(clusterMode).CreateClientAsync();
+        // Request timeout must be longer than the pause duration.
+        var pauseFor = TimeSpan.FromSeconds(1);
+        var requestTimeout = 2 * pauseFor;
+
+        await using BaseClient client = clusterMode
+            ? await GlideClusterClient.CreateClient(
+                fixture.ClusterServer.CreateConfigBuilder()
+                    .WithRequestTimeout(requestTimeout)
+                    .Build())
+            : await GlideClient.CreateClient(
+                fixture.StandaloneServer.CreateConfigBuilder()
+                    .WithRequestTimeout(requestTimeout)
+                    .Build());
 
         var key = Guid.NewGuid().ToString();
         await client.SetAsync(key, "value");
 
         var sw = Stopwatch.StartNew();
-
-        var pauseFor = TimeSpan.FromSeconds(2);
         await client.ClientPauseAsync(pauseFor);
 
         // Verify that read commands are blocked until the pause expires.
@@ -176,14 +186,24 @@ public class ConnectionManagementCommandTests(ServerFixture fixture) : IClassFix
     [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
     public async Task TestClientPause_WritesPausedUntilExpires(bool clusterMode)
     {
-        await using var client = await fixture.GetServer(clusterMode).CreateClientAsync();
+        // Request timeout must be longer than the pause duration.
+        var pauseFor = TimeSpan.FromSeconds(1);
+        var requestTimeout = 2 * pauseFor;
+
+        await using BaseClient client = clusterMode
+            ? await GlideClusterClient.CreateClient(
+                fixture.ClusterServer.CreateConfigBuilder()
+                    .WithRequestTimeout(requestTimeout)
+                    .Build())
+            : await GlideClient.CreateClient(
+                fixture.StandaloneServer.CreateConfigBuilder()
+                    .WithRequestTimeout(requestTimeout)
+                    .Build());
 
         var key = Guid.NewGuid().ToString();
         await client.SetAsync(key, "before");
 
         var sw = Stopwatch.StartNew();
-
-        var pauseFor = TimeSpan.FromSeconds(2);
         await client.ClientPauseAsync(pauseFor);
 
         // Verify that write commands are blocked until the pause expires.

--- a/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ConnectionManagementCommandTests.cs
@@ -157,7 +157,7 @@ public class ConnectionManagementCommandTests(ServerFixture fixture) : IClassFix
     {
         // Request timeout must be longer than the pause duration.
         var pauseFor = TimeSpan.FromSeconds(1);
-        var requestTimeout = 2 * pauseFor;
+        var requestTimeout = pauseFor + TimeSpan.FromSeconds(1);
 
         await using BaseClient client = clusterMode
             ? await GlideClusterClient.CreateClient(
@@ -188,7 +188,7 @@ public class ConnectionManagementCommandTests(ServerFixture fixture) : IClassFix
     {
         // Request timeout must be longer than the pause duration.
         var pauseFor = TimeSpan.FromSeconds(1);
-        var requestTimeout = 2 * pauseFor;
+        var requestTimeout = pauseFor + TimeSpan.FromSeconds(1);
 
         await using BaseClient client = clusterMode
             ? await GlideClusterClient.CreateClient(


### PR DESCRIPTION
## Summary

Fix flaky `TestClientPause_ReadsPausedUntilExpires` and `TestClientPause_WritesPausedUntilExpires` integration tests by configuring an explicit request timeout that exceeds the pause duration.

## Issue Link

:white_circle: None

## Features and Behaviour Changes

:white_circle: None — test-only change

## Implementation

The tests pause the client for a duration and then assert that a read/write command completes after the pause expires. The default request timeout was shorter than or close to the pause duration, causing sporadic `TimeoutException` failures when the paused command couldn't complete within the timeout window.

Changes:

- Reduce pause duration from 2s to 1s to minimize test execution time.
- Configure an explicit request timeout of 2x the pause duration (2s), giving the blocked command sufficient headroom to complete after the pause expires.
- Construct clients directly via `GlideClusterClient.CreateClient()`/`GlideClient.CreateClient()` to pass the custom timeout configuration.

## Limitations

:white_circle: None

## Testing

- Build passes (`task build`).
- All unit tests pass (`task test:unit`).
- Format, lint, and checks all pass.

## Related Issues

:white_circle: None

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~ (Not applicable — test-only change.)
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
- [x] ~~All TODOs referencing issue(s) closed by this PR have been resolved.~~ (Not applicable.)