### PR TITLE
Add inflight requests limit configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Inflight requests limit configuration (#484)
 - Mutual TLS (mTLS) support (#488)
 - Circuit breaker configuration (#474)
 - Support additional commands (#435):

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -190,6 +190,9 @@ pub struct ConnectionConfig {
     pub cert_reload_enabled: bool,
     pub has_cert_reload_interval_seconds: bool,
     pub cert_reload_interval_seconds: u32,
+
+    pub has_inflight_requests_limit: bool,
+    pub inflight_requests_limit: u32,
 }
 
 #[repr(C)]
@@ -432,15 +435,20 @@ pub(crate) unsafe fn create_connection_request(
                     .then_some(config.cert_reload_interval_seconds),
             }),
 
+        // Address resolver
         // Initialized to `None` because FFI clients pass the resolver as a function pointer
         // directly to `create_client`, which patches it onto the request after construction.
         address_resolver: None,
 
+        // Inflight requests limit
+        inflight_requests_limit: config
+            .has_inflight_requests_limit
+            .then_some(config.inflight_requests_limit),
+
         // Unimplemented configuration options
         // -----------------------------------
-        tcp_nodelay: false,            // TODO #490: Expose TCP_NODELAY.
-        periodic_checks: None,         // TODO #485: Expose cluster periodic checks.
-        inflight_requests_limit: None, // TODO #484: Expose request limiting.
+        tcp_nodelay: false,   // TODO #490: Expose TCP_NODELAY.
+        periodic_checks: None, // TODO #485: Expose cluster periodic checks.
         recovery_requests_queue_size: None,
     })
 }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -447,7 +447,7 @@ pub(crate) unsafe fn create_connection_request(
 
         // Unimplemented configuration options
         // -----------------------------------
-        tcp_nodelay: false,   // TODO #490: Expose TCP_NODELAY.
+        tcp_nodelay: false,    // TODO #490: Expose TCP_NODELAY.
         periodic_checks: None, // TODO #485: Expose cluster periodic checks.
         recovery_requests_queue_size: None,
     })

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -999,7 +999,6 @@ public abstract class ConnectionConfiguration
         /// <summary>
         /// The maximum number of concurrent requests allowed to be in-flight. When this limit is
         /// reached, new requests will immediately fail with a <see cref="Errors.RequestException"/>.
-        /// If not set, a default value of <c>1000</c> is used.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when value is zero.</exception>
         public uint? InflightRequestsLimit

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -1001,6 +1001,7 @@ public abstract class ConnectionConfiguration
         /// reached, new requests will immediately fail with a <see cref="Errors.RequestException"/>.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when value is zero.</exception>
+        /// <seealso href="https://glide.valkey.io/how-to/connections/limit-inflight-requests/">Valkey GLIDE – Limit Inflight Requests</seealso>
         public uint? InflightRequestsLimit
         {
             get => Config.InflightRequestsLimit;

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -62,6 +62,7 @@ public abstract class ConnectionConfiguration
         public ClientSideCacheConfig? ClientSideCacheConfig;
         public CircuitBreakerConfig? CircuitBreakerConfig;
         public AddressResolverDelegate? AddressResolver;
+        public uint? InflightRequestsLimit;
 
         // TLS configuration
         public TlsMode TlsMode = TlsMode.NoTls;
@@ -95,6 +96,7 @@ public abstract class ConnectionConfiguration
             NodeDiscoveryMode,
             ClientSideCacheConfig?.ToFfi(),
             CircuitBreakerConfig?.ToFfi(),
+            InflightRequestsLimit,
 
             // TLS configuration
             TlsMode,
@@ -988,6 +990,35 @@ public abstract class ConnectionConfiguration
         {
             ArgumentNullException.ThrowIfNull(circuitBreakerConfig, nameof(circuitBreakerConfig));
             CircuitBreakerConfig = circuitBreakerConfig;
+            return (T)this;
+        }
+
+        #endregion
+        #region Inflight Requests Limit
+
+        /// <summary>
+        /// The maximum number of concurrent requests allowed to be in-flight. When this limit is
+        /// reached, new requests will immediately fail with a <see cref="Errors.RequestException"/>.
+        /// If not set, a default value of <c>1000</c> is used.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when value is zero.</exception>
+        public uint? InflightRequestsLimit
+        {
+            get => Config.InflightRequestsLimit;
+            set
+            {
+                if (value.HasValue)
+                {
+                    ArgumentOutOfRangeException.ThrowIfZero(value.Value, nameof(value));
+                }
+                Config.InflightRequestsLimit = value;
+            }
+        }
+
+        /// <inheritdoc cref="InflightRequestsLimit" />
+        public T WithInflightRequestsLimit(uint inflightRequestsLimit)
+        {
+            InflightRequestsLimit = inflightRequestsLimit;
             return (T)this;
         }
 

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -96,7 +96,6 @@ public abstract class ConnectionConfiguration
             NodeDiscoveryMode,
             ClientSideCacheConfig?.ToFfi(),
             CircuitBreakerConfig?.ToFfi(),
-            InflightRequestsLimit,
 
             // TLS configuration
             TlsMode,
@@ -108,7 +107,10 @@ public abstract class ConnectionConfiguration
             ClientCertificatePath,
             ClientKeyPath,
             CertReloadEnabled,
-            CertReloadIntervalSeconds
+            CertReloadIntervalSeconds,
+
+            // Inflight requests limit
+            InflightRequestsLimit
         );
     }
 

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -226,7 +226,6 @@ internal partial class FFI
             NodeDiscoveryMode nodeDiscoveryMode,
             ClientSideCacheConfig? clientSideCacheConfig,
             CircuitBreakerConfig? circuitBreakerConfig,
-            uint? inflightRequestsLimit,
 
             // TLS configuration
             TlsMode tlsMode,
@@ -238,7 +237,10 @@ internal partial class FFI
             string? clientCertificatePath,
             string? clientKeyPath,
             bool certReloadEnabled,
-            uint? certReloadIntervalSeconds)
+            uint? certReloadIntervalSeconds,
+
+            // Inflight requests limit
+            uint? inflightRequestsLimit)
         {
             _request = new()
             {
@@ -281,9 +283,6 @@ internal partial class FFI
                 RootCertsPtr = MarshallRootCertificates(rootCertificates),
                 RootCertsLensPtr = MarshallRootCertificatesLengths(rootCertificates),
 
-                HasInflightRequestsLimit = inflightRequestsLimit.HasValue,
-                InflightRequestsLimit = inflightRequestsLimit ?? default,
-
                 // Mutual TLS configuration
                 ClientCertLen = (nuint)(clientCertificate?.Length ?? 0),
                 ClientCertPtr = MarshalBytes(clientCertificate),
@@ -294,6 +293,10 @@ internal partial class FFI
                 CertReloadEnabled = certReloadEnabled,
                 HasCertReloadIntervalSeconds = certReloadIntervalSeconds.HasValue,
                 CertReloadIntervalSeconds = certReloadIntervalSeconds ?? 0,
+
+                // Inflight requests limit
+                HasInflightRequestsLimit = inflightRequestsLimit.HasValue,
+                InflightRequestsLimit = inflightRequestsLimit ?? default,
             };
         }
 
@@ -1201,10 +1204,6 @@ internal partial class FFI
         public CircuitBreakerConfig CircuitBreakerConfig;
 
         #endregion
-        [MarshalAs(UnmanagedType.U1)]
-        public bool HasInflightRequestsLimit;
-        public uint InflightRequestsLimit;
-
         #region TLS
 
         public TlsMode TlsMode;
@@ -1234,6 +1233,13 @@ internal partial class FFI
         [MarshalAs(UnmanagedType.U1)]
         public bool HasCertReloadIntervalSeconds;
         public uint CertReloadIntervalSeconds;
+
+        #endregion
+        #region Inflight Requests Limit
+
+        [MarshalAs(UnmanagedType.U1)]
+        public bool HasInflightRequestsLimit;
+        public uint InflightRequestsLimit;
 
         #endregion
     }

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -226,6 +226,7 @@ internal partial class FFI
             NodeDiscoveryMode nodeDiscoveryMode,
             ClientSideCacheConfig? clientSideCacheConfig,
             CircuitBreakerConfig? circuitBreakerConfig,
+            uint? inflightRequestsLimit,
 
             // TLS configuration
             TlsMode tlsMode,
@@ -279,6 +280,9 @@ internal partial class FFI
                 RootCertsCount = (nuint)rootCertificates.Count,
                 RootCertsPtr = MarshallRootCertificates(rootCertificates),
                 RootCertsLensPtr = MarshallRootCertificatesLengths(rootCertificates),
+
+                HasInflightRequestsLimit = inflightRequestsLimit.HasValue,
+                InflightRequestsLimit = inflightRequestsLimit ?? default,
 
                 // Mutual TLS configuration
                 ClientCertLen = (nuint)(clientCertificate?.Length ?? 0),
@@ -1197,6 +1201,10 @@ internal partial class FFI
         public CircuitBreakerConfig CircuitBreakerConfig;
 
         #endregion
+        [MarshalAs(UnmanagedType.U1)]
+        public bool HasInflightRequestsLimit;
+        public uint InflightRequestsLimit;
+
         #region TLS
 
         public TlsMode TlsMode;

--- a/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
@@ -881,6 +881,29 @@ public class ConnectionConfigurationTests
     }
 
     #endregion
+    #region Inflight Requests Limit Tests
+
+    [Fact]
+    public void InflightRequestsLimit_Default_IsNull()
+    {
+        var builder = new StandaloneClientConfigurationBuilder();
+        Assert.Null(builder.Build().Request.InflightRequestsLimit);
+    }
+
+    [Fact]
+    public void WithInflightRequestsLimit_SetsValue()
+    {
+        var builder = new StandaloneClientConfigurationBuilder()
+            .WithInflightRequestsLimit(500);
+        Assert.Equal(500u, builder.Build().Request.InflightRequestsLimit);
+    }
+
+    [Fact]
+    public void WithInflightRequestsLimit_ZeroThrows()
+        => _ = Assert.Throws<ArgumentOutOfRangeException>(()
+            => new StandaloneClientConfigurationBuilder().WithInflightRequestsLimit(0));
+
+    #endregion
     #region Address Resolver Tests
 
     [Fact]

--- a/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
@@ -883,25 +883,29 @@ public class ConnectionConfigurationTests
     #endregion
     #region Inflight Requests Limit Tests
 
-    [Fact]
-    public void InflightRequestsLimit_Default_IsNull()
+    [Theory]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
+    public void InflightRequestsLimit_Default_IsNull(bool clusterMode)
     {
-        var builder = new StandaloneClientConfigurationBuilder();
+        var builder = GetConfigurationBuilder(clusterMode);
         Assert.Null(builder.Build().Request.InflightRequestsLimit);
     }
 
-    [Fact]
-    public void WithInflightRequestsLimit_SetsValue()
+    [Theory]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
+    public void WithInflightRequestsLimit_SetsValue(bool clusterMode)
     {
-        var builder = new StandaloneClientConfigurationBuilder()
-            .WithInflightRequestsLimit(500);
+        var builder = GetConfigurationBuilder(clusterMode).WithInflightRequestsLimit(500);
         Assert.Equal(500u, builder.Build().Request.InflightRequestsLimit);
     }
 
-    [Fact]
-    public void WithInflightRequestsLimit_ZeroThrows()
-        => _ = Assert.Throws<ArgumentOutOfRangeException>(()
-            => new StandaloneClientConfigurationBuilder().WithInflightRequestsLimit(0));
+    [Theory]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
+    public void WithInflightRequestsLimit_ZeroThrows(bool clusterMode)
+    {
+        var builder = GetConfigurationBuilder(clusterMode);
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => builder.WithInflightRequestsLimit(0));
+    }
 
     #endregion
     #region Address Resolver Tests
@@ -940,6 +944,11 @@ public class ConnectionConfigurationTests
 
     #endregion
     #region Helpers
+
+    private static dynamic GetConfigurationBuilder(bool clusterMode)
+        => clusterMode
+            ? new ClusterClientConfigurationBuilder()
+            : new StandaloneClientConfigurationBuilder();
 
     /// <summary>
     /// Builds and returns a new IAM authentication configuration for testing.


### PR DESCRIPTION
## Summary

Expose the glide-core `inflight_requests_limit` configuration option through the C# client's connection configuration builder, allowing users to control the maximum number of concurrent in-flight requests before new requests are rejected.

## Issue Link

Closes #484.

## Features and Behaviour Changes

- New `InflightRequestsLimit` property on `ClientConfigurationBuilder<T>` (both standalone and cluster).
- New `WithInflightRequestsLimit(uint)` fluent builder method.
- If not set, the glide-core default is used.
- Setting the value to `0` throws `ArgumentOutOfRangeException`.

## Implementation

Changes across 4 layers to wire the option from C# through FFI to glide-core:

1. **Rust FFI** (`rust/src/ffi.rs`): Added `has_inflight_requests_limit` and `inflight_requests_limit` fields to the `ConnectionConfig` struct; updated `create_connection_request()` to pass the value through.
2. **C# FFI structs** (`sources/Valkey.Glide/Internals/FFI.structs.cs`): Added matching fields to the `ConnectionRequest` struct and constructor parameter.
3. **C# public API** (`sources/Valkey.Glide/ConnectionConfiguration.cs`): Added `InflightRequestsLimit` to `ConnectionConfig` record, `ToFfi()`, and the builder property/method with zero-validation.
4. **Unit tests** (`tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs`): Added tests for default (null), set value, and zero-throws.

## Limitations

:white_circle: None.

## Testing

- 3 unit tests added covering default value, explicit value, and zero-validation.

## Related Issues

:white_circle: None.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
- [ ] All TODOs referencing issue(s) closed by this PR have been resolved.