### PR TITLE
Add periodic topology checks configuration for cluster client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Inflight requests limit configuration (#484)
-- Mutual TLS (mTLS) support (#488)
-- Circuit breaker configuration (#474)
+- Support additional configuration options:
+  - Circuit breaker (#474)
+  - Inflight requests limit (#484)
+  - Mutual TLS (#488)
+  - Periodic topology checks (#485)
 - Support additional commands (#435):
   - `BGREWRITEAOF` (#444)
   - `BGSAVE CANCEL` (#436)

--- a/rust/src/enums.rs
+++ b/rust/src/enums.rs
@@ -44,7 +44,7 @@ pub enum PushKind {
 
 /// The command routing type for cluster clients.
 /// Must match [`redis::cluster_routing::RoutingInfo`] in glide-core.
-#[repr(C)]
+#[repr(u32)]
 #[derive(Clone, Copy)]
 pub enum RouteType {
     Random = 0,
@@ -57,7 +57,7 @@ pub enum RouteType {
 
 /// The AWS service type for IAM authentication.
 /// Must match [`glide_core::iam::ServiceType`] in glide-core.
-#[repr(C)]
+#[repr(u32)]
 #[derive(Clone, Copy)]
 pub enum ServiceType {
     ElastiCache = 0,

--- a/rust/src/enums.rs
+++ b/rust/src/enums.rs
@@ -1,0 +1,65 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+/// The cache metric to retrieve from the client-side cache.
+/// Must match the C# `FFI.CacheMetricsType` enum.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub enum CacheMetricsType {
+    HitRate = 0,
+    MissRate = 1,
+    EntryCount = 2,
+    Evictions = 3,
+    Expirations = 4,
+    TotalLookups = 5,
+}
+
+/// The periodic topology checks mode for cluster clients.
+/// Must match [`glide_core::client::PeriodicCheck`] in glide-core.
+#[repr(u32)]
+#[derive(Clone, Copy)]
+pub enum PeriodicChecksMode {
+    Enabled = 0,
+    Disabled = 1,
+    ManualInterval = 2,
+}
+
+/// The push notification kind received from the server.
+/// Must match [`redis::PushKind`] in glide-core.
+#[repr(u32)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum PushKind {
+    Disconnection = 0,
+    Other = 1,
+    Invalidate = 2,
+    Message = 3,
+    PMessage = 4,
+    SMessage = 5,
+    Unsubscribe = 6,
+    PUnsubscribe = 7,
+    SUnsubscribe = 8,
+    Subscribe = 9,
+    PSubscribe = 10,
+    SSubscribe = 11,
+}
+
+/// The command routing type for cluster clients.
+/// Must match [`redis::cluster_routing::RoutingInfo`] in glide-core.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum RouteType {
+    Random = 0,
+    AllNodes = 1,
+    AllPrimaries = 2,
+    SlotId = 3,
+    SlotKey = 4,
+    ByAddress = 5,
+}
+
+/// The AWS service type for IAM authentication.
+/// Must match [`glide_core::iam::ServiceType`] in glide-core.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum ServiceType {
+    ElastiCache = 0,
+    MemoryDB = 1,
+}

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -197,6 +197,7 @@ pub struct ConnectionConfig {
     pub inflight_requests_limit: u32,
 
     // Periodic checks
+    pub has_periodic_checks_config: bool,
     pub periodic_checks_mode: PeriodicChecksMode,
     pub periodic_checks_interval_sec: u32,
 }
@@ -447,15 +448,17 @@ pub(crate) unsafe fn create_connection_request(
             .then_some(config.inflight_requests_limit),
 
         // Periodic checks configuration
-        periodic_checks: Some(match config.periodic_checks_mode {
-            PeriodicChecksMode::Enabled => glide_core::client::PeriodicCheck::Enabled,
-            PeriodicChecksMode::Disabled => glide_core::client::PeriodicCheck::Disabled,
-            PeriodicChecksMode::ManualInterval => {
-                glide_core::client::PeriodicCheck::ManualInterval(std::time::Duration::from_secs(
-                    config.periodic_checks_interval_sec as u64,
-                ))
-            }
-        }),
+        periodic_checks: config.has_periodic_checks_config.then_some(
+            match config.periodic_checks_mode {
+                PeriodicChecksMode::Enabled => glide_core::client::PeriodicCheck::Enabled,
+                PeriodicChecksMode::Disabled => glide_core::client::PeriodicCheck::Disabled,
+                PeriodicChecksMode::ManualInterval => {
+                    glide_core::client::PeriodicCheck::ManualInterval(
+                        std::time::Duration::from_secs(config.periodic_checks_interval_sec as u64),
+                    )
+                }
+            },
+        ),
 
         // Address resolver
         // Initialized to `None` because FFI clients pass the resolver as a function pointer

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,5 +1,6 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+use crate::enums::{PeriodicChecksMode, PushKind, RouteType, ServiceType};
 use std::{
     ffi::{CStr, c_char},
     slice::from_raw_parts,
@@ -190,6 +191,10 @@ pub struct ConnectionConfig {
     pub cert_reload_enabled: bool,
     pub has_cert_reload_interval_seconds: bool,
     pub cert_reload_interval_seconds: u32,
+
+    // Periodic checks configuration
+    pub periodic_checks_mode: PeriodicChecksMode,
+    pub periodic_checks_interval_sec: u32,
 }
 
 #[repr(C)]
@@ -432,6 +437,17 @@ pub(crate) unsafe fn create_connection_request(
                     .then_some(config.cert_reload_interval_seconds),
             }),
 
+        // Periodic checks configuration
+        periodic_checks: Some(match config.periodic_checks_mode {
+            PeriodicChecksMode::Enabled => glide_core::client::PeriodicCheck::Enabled,
+            PeriodicChecksMode::Disabled => glide_core::client::PeriodicCheck::Disabled,
+            PeriodicChecksMode::ManualInterval => {
+                glide_core::client::PeriodicCheck::ManualInterval(std::time::Duration::from_secs(
+                    config.periodic_checks_interval_sec as u64,
+                ))
+            }
+        }),
+
         // Initialized to `None` because FFI clients pass the resolver as a function pointer
         // directly to `create_client`, which patches it onto the request after construction.
         address_resolver: None,
@@ -439,7 +455,6 @@ pub(crate) unsafe fn create_connection_request(
         // Unimplemented configuration options
         // -----------------------------------
         tcp_nodelay: false,            // TODO #490: Expose TCP_NODELAY.
-        periodic_checks: None,         // TODO #485: Expose cluster periodic checks.
         inflight_requests_limit: None, // TODO #484: Expose request limiting.
         recovery_requests_queue_size: None,
     })
@@ -511,24 +526,6 @@ pub struct IamCredentials {
     pub service_type: ServiceType,
     pub has_refresh_interval_seconds: bool,
     pub refresh_interval_seconds: u32,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub enum ServiceType {
-    ElastiCache = 0,
-    MemoryDB = 1,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub enum RouteType {
-    Random,
-    AllNodes,
-    AllPrimaries,
-    SlotId,
-    SlotKey,
-    ByAddress,
 }
 
 /// A mirror of [`SlotAddr`]
@@ -1013,40 +1010,6 @@ pub(crate) unsafe fn get_pipeline_options(
         timeout,
         PipelineRetryStrategy::new(info.retry_server_error, info.retry_connection_error),
     ))
-}
-
-/// FFI-safe version of [`redis::PushKind`] for C# interop.
-/// This enum maps to the `PushKind` enum in `sources/Valkey.Glide/Internals/FFI.structs.cs`.
-///
-/// The `#[repr(u32)]` attribute ensures a stable memory layout compatible with C# marshaling.
-/// Each variant corresponds to a specific Redis/Valkey PubSub notification type.
-#[repr(u32)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum PushKind {
-    /// Disconnection notification sent from the library when connection is closed.
-    Disconnection = 0,
-    /// Other/unknown push notification type.
-    Other = 1,
-    /// Cache invalidation notification received when a key is changed/deleted.
-    Invalidate = 2,
-    /// Regular channel message received via SUBSCRIBE.
-    Message = 3,
-    /// Pattern-based message received via PSUBSCRIBE.
-    PMessage = 4,
-    /// Sharded channel message received via SSUBSCRIBE.
-    SMessage = 5,
-    /// Unsubscribe confirmation.
-    Unsubscribe = 6,
-    /// Pattern unsubscribe confirmation.
-    PUnsubscribe = 7,
-    /// Sharded unsubscribe confirmation.
-    SUnsubscribe = 8,
-    /// Subscribe confirmation.
-    Subscribe = 9,
-    /// Pattern subscribe confirmation.
-    PSubscribe = 10,
-    /// Sharded subscribe confirmation.
-    SSubscribe = 11,
 }
 
 impl From<&redis::PushKind> for PushKind {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,9 +1,11 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 
+mod enums;
+use enums::{CacheMetricsType, PushKind};
 mod ffi;
 use ffi::{
-    BatchInfo, BatchOptionsInfo, CmdInfo, ConnectionConfig, PubSubCallback, PushKind,
-    ResponseValue, RouteInfo, create_cmd, create_connection_request, create_pipeline, create_route,
+    BatchInfo, BatchOptionsInfo, CmdInfo, ConnectionConfig, PubSubCallback, ResponseValue,
+    RouteInfo, create_cmd, create_connection_request, create_pipeline, create_route,
     get_pipeline_options,
 };
 use glide_core::{
@@ -1939,18 +1941,6 @@ fn create_span(command_name: &str) -> *const c_void {
 // ========================================================================================
 // Client-Side Cache Metrics
 // ========================================================================================
-
-/// Cache metrics type enum matching the Rust core's cache metric methods.
-#[repr(u32)]
-#[derive(Debug, Clone, Copy)]
-pub enum CacheMetricsType {
-    HitRate = 0,
-    MissRate = 1,
-    EntryCount = 2,
-    Evictions = 3,
-    Expirations = 4,
-    TotalLookups = 5,
-}
 
 /// Get a cache metric from the client.
 ///

--- a/sources/Valkey.Glide/ClientSideCacheConfig.cs
+++ b/sources/Valkey.Glide/ClientSideCacheConfig.cs
@@ -92,10 +92,10 @@ public sealed class ClientSideCacheConfig
     /// <summary>
     /// Creates a new <see cref="ClientSideCacheConfig"/> with an auto-generated unique cache ID.
     /// </summary>
-    /// <param name="maxCacheKb">Maximum size of the cache in kilobytes (KB). Must be positive.</param>
+    /// <param name="maxCacheKb">Maximum size of the cache in kilobytes (KB).</param>
     /// <param name="entryTtl">Time-To-Live for cached entries. Use <see cref="TimeSpan.Zero"/> to disable expiration.</param>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxCacheKb"/> is zero.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="entryTtl"/> is negative.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="maxCacheKb"/> is zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="entryTtl"/> is negative.</exception>
     /// <example>
     /// <code>
     /// var cache = new ClientSideCacheConfig(1024, TimeSpan.FromMinutes(1))

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -79,8 +79,8 @@ public abstract class ConnectionConfiguration
         public uint? InflightRequestsLimit;
 
         // Periodic checks
-        public PeriodicChecksMode PeriodicChecksMode;
-        public uint PeriodicChecksIntervalSecs;
+        public PeriodicChecksMode? PeriodicChecksMode;
+        public uint? PeriodicChecksIntervalSecs;
 
         internal FFI.ConnectionConfig ToFfi() => new(
             Addresses,
@@ -1123,16 +1123,17 @@ public abstract class ConnectionConfiguration
         /// </summary>
         public ClusterClientConfigurationBuilder() : base(true) { }
 
+        /// <summary>
+        /// Complete the configuration with given settings.
+        /// </summary>
+        public new ClusterClientConfiguration Build() => new() { Request = base.Build() };
+
         #region Refresh Topology
+
         /// <summary>
         /// Enables refreshing the cluster topology using only the initial nodes.
-        /// <para />
-        /// When this option is enabled, all topology updates (both the periodic checks and on-demand
-        /// refreshes triggered by topology changes) will query only the initial nodes provided when
-        /// creating the client, rather than using the internal cluster view.
-        /// <para />
-        /// If not set, defaults to <c>false</c> (uses internal cluster view for topology refresh).
         /// </summary>
+        /// <seealso href="https://glide.valkey.io/how-to/connections/periodic-checks/">Valkey GLIDE – Configure Periodic Checks</seealso>
         public bool RefreshTopologyFromInitialNodes
         {
             get => Config.RefreshTopologyFromInitialNodes;
@@ -1145,67 +1146,51 @@ public abstract class ConnectionConfiguration
             RefreshTopologyFromInitialNodes = refreshTopologyFromInitialNodes;
             return this;
         }
+
         #endregion
         #region Periodic Checks
 
-        // TODO #485: refactor after mTLS merge
-
         /// <summary>
-        /// The maximum supported periodic checks interval. The Rust core uses <c>u32</c> seconds,
-        /// so values exceeding this limit will throw an exception during configuration.
+        /// Enables periodic topology checks.
         /// </summary>
-        public static readonly TimeSpan MaxPeriodicChecksInterval = TimeSpan.FromSeconds(uint.MaxValue);
-
-        /// <summary>
-        /// Configures periodic topology checks to run at a custom interval.
-        /// <para/>
-        /// These checks evaluate changes in the cluster's topology at regular intervals,
-        /// triggering a slot refresh when a change is detected. They query a limited number of nodes
-        /// to remain quick and efficient.
-        /// <para/>
-        /// By default, periodic checks are enabled with a 60-second interval.
-        /// Sub-second precision is truncated because the Rust core operates in whole seconds.
-        /// </summary>
-        /// <param name="interval">The interval between periodic topology checks. Must be positive
-        /// and not exceed <see cref="MaxPeriodicChecksInterval"/>.</param>
+        /// <seealso href="https://glide.valkey.io/how-to/connections/periodic-checks/">Valkey GLIDE – Configure Periodic Checks</seealso>
         /// <returns>This configuration builder instance for method chaining.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// Thrown if <paramref name="interval"/> is not positive or exceeds <see cref="MaxPeriodicChecksInterval"/>.
-        /// </exception>
+        public ClusterClientConfigurationBuilder WithPeriodicChecks()
+        {
+            Config.PeriodicChecksMode = PeriodicChecksMode.Enabled;
+            Config.PeriodicChecksIntervalSecs = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables periodic topology checks at the specified interval.
+        /// </summary>
+        /// <seealso href="https://glide.valkey.io/how-to/connections/periodic-checks/">Valkey GLIDE – Configure Periodic Checks</seealso>
+        /// <param name="interval">The interval between periodic topology checks. Must be positive.</param>
+        /// <returns>This configuration builder instance for method chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="interval"/> is not positive or exceeds <see cref="uint.MaxValue"/> seconds.</exception>
         public ClusterClientConfigurationBuilder WithPeriodicChecks(TimeSpan interval)
         {
-            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero, nameof(interval));
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(interval, MaxPeriodicChecksInterval, nameof(interval));
-
-            Config.PeriodicChecksMode = FFI.PeriodicChecksMode.ManualInterval;
-            Config.PeriodicChecksIntervalSecs = (uint)interval.TotalSeconds;
+            Config.PeriodicChecksMode = PeriodicChecksMode.ManualInterval;
+            Config.PeriodicChecksIntervalSecs = TimeUtils.ToPositiveUintSecs(interval, nameof(interval));
             return this;
         }
 
         /// <summary>
         /// Disables periodic topology checks.
-        /// <para/>
-        /// When disabled, the client will not periodically query the cluster to detect topology changes.
-        /// Topology refreshes will only occur in response to moved/ask redirections.
-        /// <para/>
-        /// By default, periodic checks are enabled with a 60-second interval.
         /// </summary>
+        /// <seealso href="https://glide.valkey.io/how-to/connections/periodic-checks/">Valkey GLIDE – Configure Periodic Checks</seealso>
         /// <returns>This configuration builder instance for method chaining.</returns>
         public ClusterClientConfigurationBuilder WithoutPeriodicChecks()
         {
-            Config.PeriodicChecksMode = FFI.PeriodicChecksMode.Disabled;
-            Config.PeriodicChecksIntervalSecs = 0;
+            Config.PeriodicChecksMode = PeriodicChecksMode.Disabled;
+            Config.PeriodicChecksIntervalSecs = null;
             return this;
         }
 
         #endregion
-
-        /// <summary>
-        /// Complete the configuration with given settings.
-        /// </summary>
-        public new ClusterClientConfiguration Build() => new() { Request = base.Build() };
-
         #region PubSub Subscriptions
+
         /// <summary>
         /// Configure PubSub subscriptions for the cluster client.
         /// </summary>
@@ -1219,6 +1204,7 @@ public abstract class ConnectionConfiguration
             Config.PubSubSubscriptions = config;
             return this;
         }
+
         #endregion
     }
 }

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -1170,7 +1170,7 @@ public abstract class ConnectionConfiguration
         /// Enables periodic topology checks at the specified interval.
         /// </summary>
         /// <seealso href="https://glide.valkey.io/how-to/connections/periodic-checks/">Valkey GLIDE – Configure Periodic Checks</seealso>
-        /// <param name="interval">The interval between periodic topology checks. Must be positive.</param>
+        /// <param name="interval">The interval between periodic topology checks.</param>
         /// <returns>This configuration builder instance for method chaining.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="interval"/> is not positive or exceeds <see cref="uint.MaxValue"/> seconds.</exception>
         public ClusterClientConfigurationBuilder WithPeriodicChecks(TimeSpan interval)

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -75,6 +75,10 @@ public abstract class ConnectionConfiguration
         public bool CertReloadEnabled;
         public uint? CertReloadIntervalSeconds;
 
+        // Periodic checks
+        public PeriodicChecksMode PeriodicChecksMode;
+        public uint PeriodicChecksIntervalSecs;
+
         internal FFI.ConnectionConfig ToFfi() => new(
             Addresses,
             ClusterMode,
@@ -106,7 +110,11 @@ public abstract class ConnectionConfiguration
             ClientCertificatePath,
             ClientKeyPath,
             CertReloadEnabled,
-            CertReloadIntervalSeconds
+            CertReloadIntervalSeconds,
+
+            // Periodic checks configuration
+            PeriodicChecksMode,
+            PeriodicChecksIntervalSecs
         );
     }
 
@@ -1102,6 +1110,59 @@ public abstract class ConnectionConfiguration
             RefreshTopologyFromInitialNodes = refreshTopologyFromInitialNodes;
             return this;
         }
+        #endregion
+        #region Periodic Checks
+
+        // TODO #485: refactor after mTLS merge
+
+        /// <summary>
+        /// The maximum supported periodic checks interval. The Rust core uses <c>u32</c> seconds,
+        /// so values exceeding this limit will throw an exception during configuration.
+        /// </summary>
+        public static readonly TimeSpan MaxPeriodicChecksInterval = TimeSpan.FromSeconds(uint.MaxValue);
+
+        /// <summary>
+        /// Configures periodic topology checks to run at a custom interval.
+        /// <para/>
+        /// These checks evaluate changes in the cluster's topology at regular intervals,
+        /// triggering a slot refresh when a change is detected. They query a limited number of nodes
+        /// to remain quick and efficient.
+        /// <para/>
+        /// By default, periodic checks are enabled with a 60-second interval.
+        /// Sub-second precision is truncated because the Rust core operates in whole seconds.
+        /// </summary>
+        /// <param name="interval">The interval between periodic topology checks. Must be positive
+        /// and not exceed <see cref="MaxPeriodicChecksInterval"/>.</param>
+        /// <returns>This configuration builder instance for method chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if <paramref name="interval"/> is not positive or exceeds <see cref="MaxPeriodicChecksInterval"/>.
+        /// </exception>
+        public ClusterClientConfigurationBuilder WithPeriodicChecks(TimeSpan interval)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero, nameof(interval));
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(interval, MaxPeriodicChecksInterval, nameof(interval));
+
+            Config.PeriodicChecksMode = FFI.PeriodicChecksMode.ManualInterval;
+            Config.PeriodicChecksIntervalSecs = (uint)interval.TotalSeconds;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables periodic topology checks.
+        /// <para/>
+        /// When disabled, the client will not periodically query the cluster to detect topology changes.
+        /// Topology refreshes will only occur in response to moved/ask redirections.
+        /// <para/>
+        /// By default, periodic checks are enabled with a 60-second interval.
+        /// </summary>
+        /// <returns>This configuration builder instance for method chaining.</returns>
+        public ClusterClientConfigurationBuilder WithoutPeriodicChecks()
+        {
+            Config.PeriodicChecksMode = FFI.PeriodicChecksMode.Disabled;
+            Config.PeriodicChecksIntervalSecs = 0;
+            return this;
+        }
+
         #endregion
 
         /// <summary>

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -1129,11 +1129,15 @@ public abstract class ConnectionConfiguration
         public new ClusterClientConfiguration Build() => new() { Request = base.Build() };
 
         #region Refresh Topology
-
         /// <summary>
         /// Enables refreshing the cluster topology using only the initial nodes.
+        /// <para />
+        /// When this option is enabled, all topology updates (both the periodic checks and on-demand
+        /// refreshes triggered by topology changes) will query only the initial nodes provided when
+        /// creating the client, rather than using the internal cluster view.
+        /// <para />
+        /// If not set, defaults to <c>false</c> (uses internal cluster view for topology refresh).
         /// </summary>
-        /// <seealso href="https://glide.valkey.io/how-to/connections/periodic-checks/">Valkey GLIDE – Configure Periodic Checks</seealso>
         public bool RefreshTopologyFromInitialNodes
         {
             get => Config.RefreshTopologyFromInitialNodes;

--- a/sources/Valkey.Glide/Internals/FFI.enums.cs
+++ b/sources/Valkey.Glide/Internals/FFI.enums.cs
@@ -1,0 +1,533 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide.Internals;
+
+/// <summary>
+/// Internal enum definitions for the FFI layer.
+/// </summary>
+/// <seealso href="https://github.com/valkey-io/valkey-glide/blob/main/glide-core/redis-rs/redis/src/types.rs">glide-core</seealso>
+internal partial class FFI
+{
+    /// <summary>
+    /// The cache metric to retrieve from the client-side cache.<p/>
+    /// Must match the glide-core cache metric methods.
+    /// </summary>
+    internal enum CacheMetricsType : uint
+    {
+        HitRate = 0,
+        MissRate = 1,
+        EntryCount = 2,
+        Evictions = 3,
+        Expirations = 4,
+        TotalLookups = 5,
+    }
+
+    /// <summary>
+    /// The periodic topology checks mode for cluster clients.<p/>
+    /// Must match <c>glide_core::client::PeriodicCheck</c> in glide-core.
+    /// </summary>
+    internal enum PeriodicChecksMode : uint
+    {
+        Enabled = 0,
+        Disabled = 1,
+        ManualInterval = 2,
+    }
+
+    /// <summary>
+    /// The push notification kind received from the server.<p/>
+    /// Must match <c>redis::PushKind</c> in glide-core.
+    /// </summary>
+    internal enum PushKind
+    {
+        PushDisconnection = 0,
+        PushOther = 1,
+        PushInvalidate = 2,
+        PushMessage = 3,
+        PushPMessage = 4,
+        PushSMessage = 5,
+        PushUnsubscribe = 6,
+        PushPUnsubscribe = 7,
+        PushSUnsubscribe = 8,
+        PushSubscribe = 9,
+        PushPSubscribe = 10,
+        PushSSubscribe = 11,
+    }
+
+    /// <summary>
+    /// The Valkey command request type.<p/>
+    /// Must match <c>glide_core::request_type::RequestType</c> in glide-core.
+    /// </summary>
+    // TODO #472: Auto-generate this enum
+    internal enum RequestType : int
+    {
+        /// Invalid request type
+        InvalidRequest = 0,
+
+        /// An unknown command, where all arguments are defined by the user.
+        CustomCommand = 1,
+
+        //// Bitmap commands
+        BitCount = 101,
+        BitField = 102,
+        BitFieldReadOnly = 103,
+        BitOp = 104,
+        BitPos = 105,
+        GetBit = 106,
+        SetBit = 107,
+
+        //// Cluster commands
+        Asking = 201,
+        ClusterAddSlots = 202,
+        ClusterAddSlotsRange = 203,
+        ClusterBumpEpoch = 204,
+        ClusterCountFailureReports = 205,
+        ClusterCountKeysInSlot = 206,
+        ClusterDelSlots = 207,
+        ClusterDelSlotsRange = 208,
+        ClusterFailover = 209,
+        ClusterFlushSlots = 210,
+        ClusterForget = 211,
+        ClusterGetKeysInSlot = 212,
+        ClusterInfo = 213,
+        ClusterKeySlot = 214,
+        ClusterLinks = 215,
+        ClusterMeet = 216,
+        ClusterMyId = 217,
+        ClusterMyShardId = 218,
+        ClusterNodes = 219,
+        ClusterReplicas = 220,
+        ClusterReplicate = 221,
+        ClusterReset = 222,
+        ClusterSaveConfig = 223,
+        ClusterSetConfigEpoch = 224,
+        ClusterSetslot = 225,
+        ClusterShards = 226,
+        ClusterSlaves = 227,
+        ClusterSlots = 228,
+        ReadOnly = 229,
+        ReadWrite = 230,
+
+        //// Connection Management commands
+        Auth = 301,
+        ClientCaching = 302,
+        ClientGetName = 303,
+        ClientGetRedir = 304,
+        ClientId = 305,
+        ClientInfo = 306,
+        ClientKillSimple = 307,
+        ClientKill = 308,
+        ClientList = 309,
+        ClientNoEvict = 310,
+        ClientNoTouch = 311,
+        ClientPause = 312,
+        ClientReply = 313,
+        ClientSetInfo = 314,
+        ClientSetName = 315,
+        ClientTracking = 316,
+        ClientTrackingInfo = 317,
+        ClientUnblock = 318,
+        ClientUnpause = 319,
+        Echo = 320,
+        Hello = 321,
+        Ping = 322,
+        Quit = 323, // deprecated in 7.2.0
+        Reset = 324,
+        Select = 325,
+
+        //// Generic commands
+        Copy = 401,
+        Del = 402,
+        Dump = 403,
+        Exists = 404,
+        Expire = 405,
+        ExpireAt = 406,
+        ExpireTime = 407,
+        Keys = 408,
+        Migrate = 409,
+        Move = 410,
+        ObjectEncoding = 411,
+        ObjectFreq = 412,
+        ObjectIdleTime = 413,
+        ObjectRefCount = 414,
+        Persist = 415,
+        PExpire = 416,
+        PExpireAt = 417,
+        PExpireTime = 418,
+        PTTL = 419,
+        RandomKey = 420,
+        Rename = 421,
+        RenameNX = 422,
+        Restore = 423,
+        Scan = 424,
+        Sort = 425,
+        SortReadOnly = 426,
+        Touch = 427,
+        TTL = 428,
+        Type = 429,
+        Unlink = 430,
+        Wait = 431,
+        WaitAof = 432,
+
+        //// Geospatial indices commands
+        GeoAdd = 501,
+        GeoDist = 502,
+        GeoHash = 503,
+        GeoPos = 504,
+        GeoRadius = 505,
+        GeoRadiusReadOnly = 506, // deprecated in 6.2.0
+        GeoRadiusByMember = 507,
+        GeoRadiusByMemberReadOnly = 508, // deprecated in 6.2.0
+        GeoSearch = 509,
+        GeoSearchStore = 510,
+
+        //// Hash commands
+        HDel = 601,
+        HExists = 602,
+        HGet = 603,
+        HGetAll = 604,
+        HIncrBy = 605,
+        HIncrByFloat = 606,
+        HKeys = 607,
+        HLen = 608,
+        HMGet = 609,
+        HMSet = 610,
+        HRandField = 611,
+        HScan = 612,
+        HSet = 613,
+        HSetNX = 614,
+        HStrlen = 615,
+        HVals = 616,
+        HSetEx = 617,
+        HGetEx = 618,
+        HExpire = 619,
+        HExpireAt = 620,
+        HPExpire = 621,
+        HPExpireAt = 622,
+        HPersist = 623,
+        HTtl = 624,
+        HPTtl = 625,
+        HExpireTime = 626,
+        HPExpireTime = 627,
+
+        //// HyperLogLog commands
+        PfAdd = 701,
+        PfCount = 702,
+        PfMerge = 703,
+
+        //// List commands
+        BLMove = 801,
+        BLMPop = 802,
+        BLPop = 803,
+        BRPop = 804,
+        BRPopLPush = 805, // deprecated in 6.2.0
+        LIndex = 806,
+        LInsert = 807,
+        LLen = 808,
+        LMove = 809,
+        LMPop = 810,
+        LPop = 811,
+        LPos = 812,
+        LPush = 813,
+        LPushX = 814,
+        LRange = 815,
+        LRem = 816,
+        LSet = 817,
+        LTrim = 818,
+        RPop = 819,
+        RPopLPush = 820, // deprecated in 6.2.0
+        RPush = 821,
+        RPushX = 822,
+
+        //// Pub/Sub commands
+        PSubscribe = 901,
+        Publish = 902,
+        PubSubChannels = 903,
+        PubSubNumPat = 904,
+        PubSubNumSub = 905,
+        PubSubShardChannels = 906,
+        PubSubShardNumSub = 907,
+        PUnsubscribe = 908,
+        SPublish = 909,
+        SSubscribe = 910,
+        Subscribe = 911,
+        SUnsubscribe = 912,
+        Unsubscribe = 913,
+        SubscribeBlocking = 914,
+        UnsubscribeBlocking = 915,
+        PSubscribeBlocking = 916,
+        PUnsubscribeBlocking = 917,
+        SSubscribeBlocking = 918,
+        SUnsubscribeBlocking = 919,
+        GetSubscriptions = 920,
+
+        //// Scripting and Functions commands
+        Eval = 1001,
+        EvalReadOnly = 1002,
+        EvalSha = 1003,
+        EvalShaReadOnly = 1004,
+        FCall = 1005,
+        FCallReadOnly = 1006,
+        FunctionDelete = 1007,
+        FunctionDump = 1008,
+        FunctionFlush = 1009,
+        FunctionKill = 1010,
+        FunctionList = 1011,
+        FunctionLoad = 1012,
+        FunctionRestore = 1013,
+        FunctionStats = 1014,
+        ScriptDebug = 1015,
+        ScriptExists = 1016,
+        ScriptFlush = 1017,
+        ScriptKill = 1018,
+        ScriptLoad = 1019,
+        ScriptShow = 1020,
+
+        //// Server management commands
+        AclCat = 1101,
+        AclDelUser = 1102,
+        AclDryRun = 1103,
+        AclGenPass = 1104,
+        AclGetUser = 1105,
+        AclList = 1106,
+        AclLoad = 1107,
+        AclLog = 1108,
+        AclSave = 1109,
+        AclSetSser = 1110,
+        AclUsers = 1111,
+        AclWhoami = 1112,
+        BgRewriteAof = 1113,
+        BgSave = 1114,
+        Command_ = 1115, // Command - renamed to avoid collisions
+        CommandCount = 1116,
+        CommandDocs = 1117,
+        CommandGetKeys = 1118,
+        CommandGetKeysAndFlags = 1119,
+        CommandInfo = 1120,
+        CommandList = 1121,
+        ConfigGet = 1122,
+        ConfigResetStat = 1123,
+        ConfigRewrite = 1124,
+        ConfigSet = 1125,
+        DBSize = 1126,
+        FailOver = 1127,
+        FlushAll = 1128,
+        FlushDB = 1129,
+        Info = 1130,
+        LastSave = 1131,
+        LatencyDoctor = 1132,
+        LatencyGraph = 1133,
+        LatencyHistogram = 1134,
+        LatencyHistory = 1135,
+        LatencyLatest = 1136,
+        LatencyReset = 1137,
+        Lolwut = 1138,
+        MemoryDoctor = 1139,
+        MemoryMallocStats = 1140,
+        MemoryPurge = 1141,
+        MemoryStats = 1142,
+        MemoryUsage = 1143,
+        ModuleList = 1144,
+        ModuleLoad = 1145,
+        ModuleLoadEx = 1146,
+        ModuleUnload = 1147,
+        Monitor = 1148,
+        PSync = 1149,
+        ReplConf = 1150,
+        ReplicaOf = 1151,
+        RestoreAsking = 1152,
+        Role = 1153,
+        Save = 1154,
+        ShutDown = 1155,
+        SlaveOf = 1156,
+        SlowLogGet = 1157,
+        SlowLogLen = 1158,
+        SlowLogReset = 1159,
+        SwapDb = 1160,
+        Sync = 1161,
+        Time = 1162,
+
+        //// Set commands
+        SAdd = 1201,
+        SCard = 1202,
+        SDiff = 1203,
+        SDiffStore = 1204,
+        SInter = 1205,
+        SInterCard = 1206,
+        SInterStore = 1207,
+        SIsMember = 1208,
+        SMembers = 1209,
+        SMIsMember = 1210,
+        SMove = 1211,
+        SPop = 1212,
+        SRandMember = 1213,
+        SRem = 1214,
+        SScan = 1215,
+        SUnion = 1216,
+        SUnionStore = 1217,
+
+        //// Sorted set commands
+        BZMPop = 1301,
+        BZPopMax = 1302,
+        BZPopMin = 1303,
+        ZAdd = 1304,
+        ZCard = 1305,
+        ZCount = 1306,
+        ZDiff = 1307,
+        ZDiffStore = 1308,
+        ZIncrBy = 1309,
+        ZInter = 1310,
+        ZInterCard = 1311,
+        ZInterStore = 1312,
+        ZLexCount = 1313,
+        ZMPop = 1314,
+        ZMScore = 1315,
+        ZPopMax = 1316,
+        ZPopMin = 1317,
+        ZRandMember = 1318,
+        ZRange = 1319,
+        ZRangeByLex = 1320,
+        ZRangeByScore = 1321,
+        ZRangeStore = 1322,
+        ZRank = 1323,
+        ZRem = 1324,
+        ZRemRangeByLex = 1325,
+        ZRemRangeByRank = 1326,
+        ZRemRangeByScore = 1327,
+        ZRevRange = 1328,
+        ZRevRangeByLex = 1329,
+        ZRevRangeByScore = 1330,
+        ZRevRank = 1331,
+        ZScan = 1332,
+        ZScore = 1333,
+        ZUnion = 1334,
+        ZUnionStore = 1335,
+
+        //// Stream commands
+        XAck = 1401,
+        XAdd = 1402,
+        XAutoClaim = 1403,
+        XClaim = 1404,
+        XDel = 1405,
+        XGroupCreate = 1406,
+        XGroupCreateConsumer = 1407,
+        XGroupDelConsumer = 1408,
+        XGroupDestroy = 1409,
+        XGroupSetId = 1410,
+        XInfoConsumers = 1411,
+        XInfoGroups = 1412,
+        XInfoStream = 1413,
+        XLen = 1414,
+        XPending = 1415,
+        XRange = 1416,
+        XRead = 1417,
+        XReadGroup = 1418,
+        XRevRange = 1419,
+        XSetId = 1420,
+        XTrim = 1421,
+
+        //// String commands
+        Append = 1501,
+        Decr = 1502,
+        DecrBy = 1503,
+        Get = 1504,
+        GetDel = 1505,
+        GetEx = 1506,
+        GetRange = 1507,
+        GetSet = 1508, // deprecated in 6.2.0
+        Incr = 1509,
+        IncrBy = 1510,
+        IncrByFloat = 1511,
+        LCS = 1512,
+        MGet = 1513,
+        MSet = 1514,
+        MSetNX = 1515,
+        PSetEx = 1516, // deprecated in 2.6.12
+        Set = 1517,
+        SetEx = 1518, // deprecated in 2.6.12
+        SetNX = 1519, // deprecated in 2.6.12
+        SetRange = 1520,
+        Strlen = 1521,
+        Substr = 1522,
+
+        //// Transaction commands
+        Discard = 1601,
+        Exec = 1602,
+        Multi = 1603,
+        UnWatch = 1604,
+        Watch = 1605,
+
+        //// JSON commands
+        JsonArrAppend = 2001,
+        JsonArrIndex = 2002,
+        JsonArrInsert = 2003,
+        JsonArrLen = 2004,
+        JsonArrPop = 2005,
+        JsonArrTrim = 2006,
+        JsonClear = 2007,
+        JsonDebug = 2008,
+        JsonDel = 2009,
+        JsonForget = 2010,
+        JsonGet = 2011,
+        JsonMGet = 2012,
+        JsonNumIncrBy = 2013,
+        JsonNumMultBy = 2014,
+        JsonObjKeys = 2015,
+        JsonObjLen = 2016,
+        JsonResp = 2017,
+        JsonSet = 2018,
+        JsonStrAppend = 2019,
+        JsonStrLen = 2020,
+        JsonToggle = 2021,
+        JsonType = 2022,
+
+        //// Vector Search commands
+        FtList = 2101,
+        FtAggregate = 2102,
+        FtAliasAdd = 2103,
+        FtAliasDel = 2104,
+        FtAliasList = 2105,
+        FtAliasUpdate = 2106,
+        FtCreate = 2107,
+        FtDropIndex = 2108,
+        FtExplain = 2109,
+        FtExplainCli = 2110,
+        FtInfo = 2111,
+        FtProfile = 2112,
+        FtSearch = 2113,
+    }
+
+    /// <summary>
+    /// The command routing type for cluster clients.<p/>
+    /// Must match <c>redis::cluster_routing::RoutingInfo</c> in glide-core.
+    /// </summary>
+    internal enum RouteType : uint
+    {
+        Random = 0,
+        AllNodes = 1,
+        AllPrimaries = 2,
+        SlotId = 3,
+        SlotKey = 4,
+        ByAddress = 5,
+    }
+
+    /// <summary>
+    /// The AWS service type for IAM authentication.<p/>
+    /// Must match <c>glide_core::iam::ServiceType</c> in glide-core.
+    /// </summary>
+    internal enum ServiceType : uint
+    {
+        ElastiCache = 0,
+        MemoryDB = 1,
+    }
+
+    /// <summary>
+    /// The TLS mode for server connections.<p/>
+    /// Must match <c>glide_core::client::TlsMode</c> in glide-core.
+    /// </summary>
+    internal enum TlsMode : uint
+    {
+        NoTls = 0,
+        InsecureTls = 1,
+        SecureTls = 2,
+    }
+}

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -243,8 +243,8 @@ internal partial class FFI
             uint? inflightRequestsLimit,
 
             // Periodic checks
-            PeriodicChecksMode periodicChecksMode,
-            uint periodicChecksIntervalSec)
+            PeriodicChecksMode? periodicChecksMode,
+            uint? periodicChecksIntervalSec)
         {
             _request = new()
             {
@@ -303,8 +303,9 @@ internal partial class FFI
                 InflightRequestsLimit = inflightRequestsLimit ?? default,
 
                 // Periodic checks configuration
-                PeriodicChecksMode = periodicChecksMode,
-                PeriodicChecksIntervalSec = periodicChecksIntervalSec,
+                HasPeriodicChecksConfig = periodicChecksMode.HasValue,
+                PeriodicChecksMode = periodicChecksMode ?? default,
+                PeriodicChecksIntervalSec = periodicChecksIntervalSec ?? 0,
             };
         }
 
@@ -805,6 +806,8 @@ internal partial class FFI
         #endregion
         #region Periodic Checks
 
+        [MarshalAs(UnmanagedType.U1)]
+        public bool HasPeriodicChecksConfig;
         public PeriodicChecksMode PeriodicChecksMode;
         public uint PeriodicChecksIntervalSec;
 

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -237,7 +237,11 @@ internal partial class FFI
             string? clientCertificatePath,
             string? clientKeyPath,
             bool certReloadEnabled,
-            uint? certReloadIntervalSeconds)
+            uint? certReloadIntervalSeconds,
+
+            // Periodic checks configuration
+            PeriodicChecksMode periodicChecksMode,
+            uint periodicChecksIntervalSec)
         {
             _request = new()
             {
@@ -290,6 +294,10 @@ internal partial class FFI
                 CertReloadEnabled = certReloadEnabled,
                 HasCertReloadIntervalSeconds = certReloadIntervalSeconds.HasValue,
                 CertReloadIntervalSeconds = certReloadIntervalSeconds ?? 0,
+
+                // Periodic checks configuration
+                PeriodicChecksMode = periodicChecksMode,
+                PeriodicChecksIntervalSec = periodicChecksIntervalSec,
             };
         }
 
@@ -660,454 +668,7 @@ internal partial class FFI
         public IntPtr Route;
     }
 
-    // TODO #472: Auto-generate this enum
-    internal enum RequestType : int
-    {
-        /// Invalid request type
-        InvalidRequest = 0,
 
-        /// An unknown command, where all arguments are defined by the user.
-        CustomCommand = 1,
-
-        //// Bitmap commands
-        BitCount = 101,
-        BitField = 102,
-        BitFieldReadOnly = 103,
-        BitOp = 104,
-        BitPos = 105,
-        GetBit = 106,
-        SetBit = 107,
-
-        //// Cluster commands
-        Asking = 201,
-        ClusterAddSlots = 202,
-        ClusterAddSlotsRange = 203,
-        ClusterBumpEpoch = 204,
-        ClusterCountFailureReports = 205,
-        ClusterCountKeysInSlot = 206,
-        ClusterDelSlots = 207,
-        ClusterDelSlotsRange = 208,
-        ClusterFailover = 209,
-        ClusterFlushSlots = 210,
-        ClusterForget = 211,
-        ClusterGetKeysInSlot = 212,
-        ClusterInfo = 213,
-        ClusterKeySlot = 214,
-        ClusterLinks = 215,
-        ClusterMeet = 216,
-        ClusterMyId = 217,
-        ClusterMyShardId = 218,
-        ClusterNodes = 219,
-        ClusterReplicas = 220,
-        ClusterReplicate = 221,
-        ClusterReset = 222,
-        ClusterSaveConfig = 223,
-        ClusterSetConfigEpoch = 224,
-        ClusterSetslot = 225,
-        ClusterShards = 226,
-        ClusterSlaves = 227,
-        ClusterSlots = 228,
-        ReadOnly = 229,
-        ReadWrite = 230,
-
-        //// Connection Management commands
-        Auth = 301,
-        ClientCaching = 302,
-        ClientGetName = 303,
-        ClientGetRedir = 304,
-        ClientId = 305,
-        ClientInfo = 306,
-        ClientKillSimple = 307,
-        ClientKill = 308,
-        ClientList = 309,
-        ClientNoEvict = 310,
-        ClientNoTouch = 311,
-        ClientPause = 312,
-        ClientReply = 313,
-        ClientSetInfo = 314,
-        ClientSetName = 315,
-        ClientTracking = 316,
-        ClientTrackingInfo = 317,
-        ClientUnblock = 318,
-        ClientUnpause = 319,
-        Echo = 320,
-        Hello = 321,
-        Ping = 322,
-        Quit = 323, // deprecated in 7.2.0
-        Reset = 324,
-        Select = 325,
-
-        //// Generic commands
-        Copy = 401,
-        Del = 402,
-        Dump = 403,
-        Exists = 404,
-        Expire = 405,
-        ExpireAt = 406,
-        ExpireTime = 407,
-        Keys = 408,
-        Migrate = 409,
-        Move = 410,
-        ObjectEncoding = 411,
-        ObjectFreq = 412,
-        ObjectIdleTime = 413,
-        ObjectRefCount = 414,
-        Persist = 415,
-        PExpire = 416,
-        PExpireAt = 417,
-        PExpireTime = 418,
-        PTTL = 419,
-        RandomKey = 420,
-        Rename = 421,
-        RenameNX = 422,
-        Restore = 423,
-        Scan = 424,
-        Sort = 425,
-        SortReadOnly = 426,
-        Touch = 427,
-        TTL = 428,
-        Type = 429,
-        Unlink = 430,
-        Wait = 431,
-        WaitAof = 432,
-
-        //// Geospatial indices commands
-        GeoAdd = 501,
-        GeoDist = 502,
-        GeoHash = 503,
-        GeoPos = 504,
-        GeoRadius = 505,
-        GeoRadiusReadOnly = 506, // deprecated in 6.2.0
-        GeoRadiusByMember = 507,
-        GeoRadiusByMemberReadOnly = 508, // deprecated in 6.2.0
-        GeoSearch = 509,
-        GeoSearchStore = 510,
-
-        //// Hash commands
-        HDel = 601,
-        HExists = 602,
-        HGet = 603,
-        HGetAll = 604,
-        HIncrBy = 605,
-        HIncrByFloat = 606,
-        HKeys = 607,
-        HLen = 608,
-        HMGet = 609,
-        HMSet = 610,
-        HRandField = 611,
-        HScan = 612,
-        HSet = 613,
-        HSetNX = 614,
-        HStrlen = 615,
-        HVals = 616,
-        HSetEx = 617,
-        HGetEx = 618,
-        HExpire = 619,
-        HExpireAt = 620,
-        HPExpire = 621,
-        HPExpireAt = 622,
-        HPersist = 623,
-        HTtl = 624,
-        HPTtl = 625,
-        HExpireTime = 626,
-        HPExpireTime = 627,
-
-        //// HyperLogLog commands
-        PfAdd = 701,
-        PfCount = 702,
-        PfMerge = 703,
-
-        //// List commands
-        BLMove = 801,
-        BLMPop = 802,
-        BLPop = 803,
-        BRPop = 804,
-        BRPopLPush = 805, // deprecated in 6.2.0
-        LIndex = 806,
-        LInsert = 807,
-        LLen = 808,
-        LMove = 809,
-        LMPop = 810,
-        LPop = 811,
-        LPos = 812,
-        LPush = 813,
-        LPushX = 814,
-        LRange = 815,
-        LRem = 816,
-        LSet = 817,
-        LTrim = 818,
-        RPop = 819,
-        RPopLPush = 820, // deprecated in 6.2.0
-        RPush = 821,
-        RPushX = 822,
-
-        //// Pub/Sub commands
-        PSubscribe = 901,
-        Publish = 902,
-        PubSubChannels = 903,
-        PubSubNumPat = 904,
-        PubSubNumSub = 905,
-        PubSubShardChannels = 906,
-        PubSubShardNumSub = 907,
-        PUnsubscribe = 908,
-        SPublish = 909,
-        SSubscribe = 910,
-        Subscribe = 911,
-        SUnsubscribe = 912,
-        Unsubscribe = 913,
-        SubscribeBlocking = 914,
-        UnsubscribeBlocking = 915,
-        PSubscribeBlocking = 916,
-        PUnsubscribeBlocking = 917,
-        SSubscribeBlocking = 918,
-        SUnsubscribeBlocking = 919,
-        GetSubscriptions = 920,
-
-        //// Scripting and Functions commands
-        Eval = 1001,
-        EvalReadOnly = 1002,
-        EvalSha = 1003,
-        EvalShaReadOnly = 1004,
-        FCall = 1005,
-        FCallReadOnly = 1006,
-        FunctionDelete = 1007,
-        FunctionDump = 1008,
-        FunctionFlush = 1009,
-        FunctionKill = 1010,
-        FunctionList = 1011,
-        FunctionLoad = 1012,
-        FunctionRestore = 1013,
-        FunctionStats = 1014,
-        ScriptDebug = 1015,
-        ScriptExists = 1016,
-        ScriptFlush = 1017,
-        ScriptKill = 1018,
-        ScriptLoad = 1019,
-        ScriptShow = 1020,
-
-        //// Server management commands
-        AclCat = 1101,
-        AclDelUser = 1102,
-        AclDryRun = 1103,
-        AclGenPass = 1104,
-        AclGetUser = 1105,
-        AclList = 1106,
-        AclLoad = 1107,
-        AclLog = 1108,
-        AclSave = 1109,
-        AclSetSser = 1110,
-        AclUsers = 1111,
-        AclWhoami = 1112,
-        BgRewriteAof = 1113,
-        BgSave = 1114,
-        Command_ = 1115, // Command - renamed to avoid collisions
-        CommandCount = 1116,
-        CommandDocs = 1117,
-        CommandGetKeys = 1118,
-        CommandGetKeysAndFlags = 1119,
-        CommandInfo = 1120,
-        CommandList = 1121,
-        ConfigGet = 1122,
-        ConfigResetStat = 1123,
-        ConfigRewrite = 1124,
-        ConfigSet = 1125,
-        DBSize = 1126,
-        FailOver = 1127,
-        FlushAll = 1128,
-        FlushDB = 1129,
-        Info = 1130,
-        LastSave = 1131,
-        LatencyDoctor = 1132,
-        LatencyGraph = 1133,
-        LatencyHistogram = 1134,
-        LatencyHistory = 1135,
-        LatencyLatest = 1136,
-        LatencyReset = 1137,
-        Lolwut = 1138,
-        MemoryDoctor = 1139,
-        MemoryMallocStats = 1140,
-        MemoryPurge = 1141,
-        MemoryStats = 1142,
-        MemoryUsage = 1143,
-        ModuleList = 1144,
-        ModuleLoad = 1145,
-        ModuleLoadEx = 1146,
-        ModuleUnload = 1147,
-        Monitor = 1148,
-        PSync = 1149,
-        ReplConf = 1150,
-        ReplicaOf = 1151,
-        RestoreAsking = 1152,
-        Role = 1153,
-        Save = 1154,
-        ShutDown = 1155,
-        SlaveOf = 1156,
-        SlowLogGet = 1157,
-        SlowLogLen = 1158,
-        SlowLogReset = 1159,
-        SwapDb = 1160,
-        Sync = 1161,
-        Time = 1162,
-
-        //// Set commands
-        SAdd = 1201,
-        SCard = 1202,
-        SDiff = 1203,
-        SDiffStore = 1204,
-        SInter = 1205,
-        SInterCard = 1206,
-        SInterStore = 1207,
-        SIsMember = 1208,
-        SMembers = 1209,
-        SMIsMember = 1210,
-        SMove = 1211,
-        SPop = 1212,
-        SRandMember = 1213,
-        SRem = 1214,
-        SScan = 1215,
-        SUnion = 1216,
-        SUnionStore = 1217,
-
-        //// Sorted set commands
-        BZMPop = 1301,
-        BZPopMax = 1302,
-        BZPopMin = 1303,
-        ZAdd = 1304,
-        ZCard = 1305,
-        ZCount = 1306,
-        ZDiff = 1307,
-        ZDiffStore = 1308,
-        ZIncrBy = 1309,
-        ZInter = 1310,
-        ZInterCard = 1311,
-        ZInterStore = 1312,
-        ZLexCount = 1313,
-        ZMPop = 1314,
-        ZMScore = 1315,
-        ZPopMax = 1316,
-        ZPopMin = 1317,
-        ZRandMember = 1318,
-        ZRange = 1319,
-        ZRangeByLex = 1320,
-        ZRangeByScore = 1321,
-        ZRangeStore = 1322,
-        ZRank = 1323,
-        ZRem = 1324,
-        ZRemRangeByLex = 1325,
-        ZRemRangeByRank = 1326,
-        ZRemRangeByScore = 1327,
-        ZRevRange = 1328,
-        ZRevRangeByLex = 1329,
-        ZRevRangeByScore = 1330,
-        ZRevRank = 1331,
-        ZScan = 1332,
-        ZScore = 1333,
-        ZUnion = 1334,
-        ZUnionStore = 1335,
-
-        //// Stream commands
-        XAck = 1401,
-        XAdd = 1402,
-        XAutoClaim = 1403,
-        XClaim = 1404,
-        XDel = 1405,
-        XGroupCreate = 1406,
-        XGroupCreateConsumer = 1407,
-        XGroupDelConsumer = 1408,
-        XGroupDestroy = 1409,
-        XGroupSetId = 1410,
-        XInfoConsumers = 1411,
-        XInfoGroups = 1412,
-        XInfoStream = 1413,
-        XLen = 1414,
-        XPending = 1415,
-        XRange = 1416,
-        XRead = 1417,
-        XReadGroup = 1418,
-        XRevRange = 1419,
-        XSetId = 1420,
-        XTrim = 1421,
-
-        //// String commands
-        Append = 1501,
-        Decr = 1502,
-        DecrBy = 1503,
-        Get = 1504,
-        GetDel = 1505,
-        GetEx = 1506,
-        GetRange = 1507,
-        GetSet = 1508, // deprecated in 6.2.0
-        Incr = 1509,
-        IncrBy = 1510,
-        IncrByFloat = 1511,
-        LCS = 1512,
-        MGet = 1513,
-        MSet = 1514,
-        MSetNX = 1515,
-        PSetEx = 1516, // deprecated in 2.6.12
-        Set = 1517,
-        SetEx = 1518, // deprecated in 2.6.12
-        SetNX = 1519, // deprecated in 2.6.12
-        SetRange = 1520,
-        Strlen = 1521,
-        Substr = 1522,
-
-        //// Transaction commands
-        Discard = 1601,
-        Exec = 1602,
-        Multi = 1603,
-        UnWatch = 1604,
-        Watch = 1605,
-
-        //// JSON commands
-        JsonArrAppend = 2001,
-        JsonArrIndex = 2002,
-        JsonArrInsert = 2003,
-        JsonArrLen = 2004,
-        JsonArrPop = 2005,
-        JsonArrTrim = 2006,
-        JsonClear = 2007,
-        JsonDebug = 2008,
-        JsonDel = 2009,
-        JsonForget = 2010,
-        JsonGet = 2011,
-        JsonMGet = 2012,
-        JsonNumIncrBy = 2013,
-        JsonNumMultBy = 2014,
-        JsonObjKeys = 2015,
-        JsonObjLen = 2016,
-        JsonResp = 2017,
-        JsonSet = 2018,
-        JsonStrAppend = 2019,
-        JsonStrLen = 2020,
-        JsonToggle = 2021,
-        JsonType = 2022,
-
-        //// Vector Search commands
-        FtList = 2101,
-        FtAggregate = 2102,
-        FtAliasAdd = 2103,
-        FtAliasDel = 2104,
-        FtAliasList = 2105,
-        FtAliasUpdate = 2106,
-        FtCreate = 2107,
-        FtDropIndex = 2108,
-        FtExplain = 2109,
-        FtExplainCli = 2110,
-        FtInfo = 2111,
-        FtProfile = 2112,
-        FtSearch = 2113,
-    }
-
-    internal enum RouteType : uint
-    {
-        Random,
-        AllNodes,
-        AllPrimaries,
-        SlotId,
-        SlotKey,
-        ByAddress,
-    }
 
     [StructLayout(LayoutKind.Sequential)]
     private struct RouteInfo
@@ -1228,6 +789,12 @@ internal partial class FFI
         public uint CertReloadIntervalSeconds;
 
         #endregion
+        #region Periodic Checks
+
+        public PeriodicChecksMode PeriodicChecksMode;
+        public uint PeriodicChecksIntervalSec;
+
+        #endregion
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -1249,12 +816,6 @@ internal partial class FFI
         public readonly ushort Port = port;
     }
 
-    internal enum TlsMode : uint
-    {
-        NoTls = 0,
-        InsecureTls = 1,
-        SecureTls = 2,
-    }
 
     [StructLayout(LayoutKind.Sequential)]
     private readonly struct ScriptHashBuffer
@@ -1543,53 +1104,6 @@ internal partial class FFI
         }
     }
 
-    /// <summary>
-    /// Enum representing the type of push notification received from the server.
-    /// This matches the <c>PushKind</c> enum in <c>rust/src/ffi.rs</c>, which is an FFI-safe
-    /// version of the <c>redis::PushKind</c> enum from glide-core.
-    /// </summary>
-    /// <remarks>
-    /// The numeric values must remain stable as they are part of the FFI contract between
-    /// C# and Rust. Each variant corresponds to a specific Redis/Valkey PubSub notification type.
-    /// </remarks>
-    internal enum PushKind
-    {
-        /// <summary>Disconnection notification sent from the library when connection is closed.</summary>
-        PushDisconnection = 0,
-
-        /// <summary>Other/unknown push notification type.</summary>
-        PushOther = 1,
-
-        /// <summary>Cache invalidation notification received when a key is changed/deleted.</summary>
-        PushInvalidate = 2,
-
-        /// <summary>Regular channel message received via SUBSCRIBE.</summary>
-        PushMessage = 3,
-
-        /// <summary>Pattern-based message received via PSUBSCRIBE.</summary>
-        PushPMessage = 4,
-
-        /// <summary>Sharded channel message received via SSUBSCRIBE.</summary>
-        PushSMessage = 5,
-
-        /// <summary>Unsubscribe confirmation.</summary>
-        PushUnsubscribe = 6,
-
-        /// <summary>Pattern unsubscribe confirmation.</summary>
-        PushPUnsubscribe = 7,
-
-        /// <summary>Sharded unsubscribe confirmation.</summary>
-        PushSUnsubscribe = 8,
-
-        /// <summary>Subscribe confirmation.</summary>
-        PushSubscribe = 9,
-
-        /// <summary>Pattern subscribe confirmation.</summary>
-        PushPSubscribe = 10,
-
-        /// <summary>Sharded subscribe confirmation.</summary>
-        PushSSubscribe = 11,
-    }
 
     // ========================================================================================
     // OpenTelemetry
@@ -1701,24 +1215,6 @@ internal partial class FFI
         public readonly uint? RefreshIntervalSeconds = refreshIntervalSeconds ?? default;
     }
 
-    internal enum ServiceType : uint
-    {
-        ElastiCache = 0,
-        MemoryDB = 1,
-    }
-
-    /// <summary>
-    /// Cache metrics type enum matching the Rust core's cache metric methods.
-    /// </summary>
-    internal enum CacheMetricsType : uint
-    {
-        HitRate = 0,
-        MissRate = 1,
-        EntryCount = 2,
-        Evictions = 3,
-        Expirations = 4,
-        TotalLookups = 5,
-    }
 
     #region Monitor
 

--- a/sources/Valkey.Glide/OpenTelemetry.cs
+++ b/sources/Valkey.Glide/OpenTelemetry.cs
@@ -144,7 +144,7 @@ public static class OpenTelemetry
         var ffiConfig = new FFI.OpenTelemetryConfig(
             config.Traces != null ? new FFI.TracesConfig(config.Traces.Endpoint, config.Traces.SamplePercentage) : null,
             config.Metrics != null ? new FFI.MetricsConfig(config.Metrics.Endpoint) : null,
-            config.FlushInterval.HasValue ? (uint)config.FlushInterval.Value.TotalMilliseconds : null
+            config.FlushIntervalMs
         );
 
         // Marshal the config to unmanaged memory

--- a/sources/Valkey.Glide/OpenTelemetryConfig.cs
+++ b/sources/Valkey.Glide/OpenTelemetryConfig.cs
@@ -22,16 +22,18 @@ public sealed class OpenTelemetryConfig
     /// <summary>
     /// Interval for flushing telemetry data to the collector.
     /// </summary>
-    public TimeSpan? FlushInterval { get; }
+    public TimeSpan? FlushInterval => FlushIntervalMs.HasValue
+        ? TimeSpan.FromMilliseconds(FlushIntervalMs.Value)
+        : null;
 
     #endregion
     #region Constructors & Builders
 
-    private OpenTelemetryConfig(TracesConfig? traces, MetricsConfig? metrics, TimeSpan? flushInterval)
+    private OpenTelemetryConfig(TracesConfig? traces, MetricsConfig? metrics, uint? flushIntervalMs)
     {
         Traces = traces;
         Metrics = metrics;
-        FlushInterval = flushInterval;
+        FlushIntervalMs = flushIntervalMs;
     }
 
     #endregion
@@ -43,6 +45,11 @@ public sealed class OpenTelemetryConfig
     public static Builder CreateBuilder() => new();
 
     #endregion
+    #region Internal Fields
+
+    internal readonly uint? FlushIntervalMs;
+
+    #endregion
 
     /// <summary>
     /// Builder for OpenTelemetryConfig.
@@ -51,7 +58,7 @@ public sealed class OpenTelemetryConfig
     {
         private TracesConfig? _traces;
         private MetricsConfig? _metrics;
-        private TimeSpan? _flushInterval;
+        private uint? _flushIntervalMs;
 
         /// <summary>
         /// Sets the traces configuration.
@@ -74,13 +81,10 @@ public sealed class OpenTelemetryConfig
         /// <summary>
         /// Sets the flush interval.
         /// </summary>
-        /// <exception cref="ArgumentException">Thrown if flushInterval is not positive.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="flushInterval"/> is not positive or exceeds <see cref="uint.MaxValue"/> milliseconds.</exception>
         public Builder WithFlushInterval(TimeSpan flushInterval)
         {
-            if (flushInterval <= TimeSpan.Zero)
-                throw new ArgumentException("Flush interval must be positive", nameof(flushInterval));
-
-            _flushInterval = flushInterval;
+            _flushIntervalMs = Internals.TimeUtils.ToPositiveUintMs(flushInterval, nameof(flushInterval));
             return this;
         }
 
@@ -91,9 +95,11 @@ public sealed class OpenTelemetryConfig
         public OpenTelemetryConfig Build()
         {
             if (_traces == null && _metrics == null)
+            {
                 throw new InvalidOperationException("At least one of traces or metrics must be configured");
+            }
 
-            return new OpenTelemetryConfig(_traces, _metrics, _flushInterval);
+            return new OpenTelemetryConfig(_traces, _metrics, _flushIntervalMs);
         }
     }
 }

--- a/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
@@ -908,6 +908,64 @@ public class ConnectionConfigurationTests
     }
 
     #endregion
+    #region Periodic Checks Tests
+
+    [Fact]
+    public void PeriodicChecks_Default()
+    {
+        var request = new ClusterClientConfigurationBuilder()
+            .Build().Request;
+        Assert.Null(request.PeriodicChecksMode);
+        Assert.Null(request.PeriodicChecksIntervalSecs);
+    }
+
+    [Fact]
+    public void WithPeriodicChecks_NoArgs()
+    {
+        var request = new ClusterClientConfigurationBuilder()
+            .WithPeriodicChecks()
+            .Build().Request;
+        Assert.Equal(FFI.PeriodicChecksMode.Enabled, request.PeriodicChecksMode);
+        Assert.Null(request.PeriodicChecksIntervalSecs);
+    }
+
+    [Fact]
+    public void WithPeriodicChecks_Interval()
+    {
+        var request = new ClusterClientConfigurationBuilder()
+            .WithPeriodicChecks(TimeSpan.FromSeconds(30))
+            .Build().Request;
+        Assert.Equal(FFI.PeriodicChecksMode.ManualInterval, request.PeriodicChecksMode);
+        Assert.Equal(30u, request.PeriodicChecksIntervalSecs);
+    }
+
+    [Fact]
+    public void WithoutPeriodicChecks()
+    {
+        var request = new ClusterClientConfigurationBuilder()
+            .WithoutPeriodicChecks()
+            .Build().Request;
+        Assert.Equal(FFI.PeriodicChecksMode.Disabled, request.PeriodicChecksMode);
+        Assert.Null(request.PeriodicChecksIntervalSecs);
+    }
+
+    [Fact]
+    public void WithPeriodicChecks_Zero_Throws()
+        => _ = Assert.Throws<ArgumentOutOfRangeException>(()
+            => new ClusterClientConfigurationBuilder().WithPeriodicChecks(TimeSpan.Zero));
+
+    [Fact]
+    public void WithPeriodicChecks_Negative_Throws()
+        => _ = Assert.Throws<ArgumentOutOfRangeException>(()
+            => new ClusterClientConfigurationBuilder().WithPeriodicChecks(TimeSpan.FromSeconds(-1)));
+
+    [Fact]
+    public void WithPeriodicChecks_ExceedsMax_Throws()
+        => _ = Assert.Throws<ArgumentOutOfRangeException>(()
+            => new ClusterClientConfigurationBuilder().WithPeriodicChecks(
+                TimeSpan.FromSeconds(uint.MaxValue + 1.0)));
+
+    #endregion
     #region Address Resolver Tests
 
     [Fact]

--- a/tests/Valkey.Glide.UnitTests/OpenTelemetryConfigTests.cs
+++ b/tests/Valkey.Glide.UnitTests/OpenTelemetryConfigTests.cs
@@ -13,11 +13,11 @@ public class OpenTelemetryConfigTests
     #region Tests
 
     [Fact]
-    public void WithFlushInterval_WithInvalidInterval_ThrowsArgumentException()
+    public void WithFlushInterval_WithInvalidInterval_ThrowsArgumentOutOfRangeException()
     {
         var builder = OpenTelemetryConfig.CreateBuilder();
-        _ = Assert.Throws<ArgumentException>(() => builder.WithFlushInterval(TimeSpan.FromSeconds(-1)));
-        _ = Assert.Throws<ArgumentException>(() => builder.WithFlushInterval(TimeSpan.Zero));
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => builder.WithFlushInterval(TimeSpan.FromSeconds(-1)));
+        _ = Assert.Throws<ArgumentOutOfRangeException>(() => builder.WithFlushInterval(TimeSpan.Zero));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Add periodic topology checks configuration for the cluster client, allowing users to control how frequently the client polls the cluster for topology changes.

## Issue Link

Closes #485.

## Features and Behaviour Changes

- **`WithPeriodicChecks()`** — explicitly enables periodic checks with the default 60-second interval.
- **`WithPeriodicChecks(TimeSpan)`** — enables periodic checks with a custom interval.
- **`WithoutPeriodicChecks()`** — disables periodic checks entirely.
- Default behavior is implemented by glide-core: periodic checks are enabled at 60 seconds, matching all other GLIDE language clients.

## Implementation

- Added `PeriodicChecksMode` FFI enum and `has_periodic_checks_config` / `periodic_checks_mode` / `periodic_checks_interval_sec` fields to the FFI boundary.
- Uses `TimeUtils.ToPositiveUintSecs` for interval validation and conversion.
- Extracted all FFI enums into dedicated files (`FFI.enums.cs` and `rust/src/enums.rs`) for maintainability, ordered alphabetically with consistent documentation linking to their glide-core counterparts.

## Limitations

:white_circle: None

## Testing

- 7 unit tests added to `ConnectionConfigurationTests.cs` covering: default state, enabled, custom interval, disabled, and validation (zero, negative, exceeds max).

## Related Issues

- [valkey-io/valkey-glide-docs#314](https://github.com/valkey-io/valkey-glide-docs/pull/314) — docs page for this feature.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] `CHANGELOG.md`, ~~`README.md`, `DEVELOPER.md`,~~ and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.