### PR TITLE
feat: add LibName and ClientInfoTag to client configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support additional configuration options:
   - All nodes read-from strategy (#207)
   - Circuit breaker (#474)
+  - Client library name and info tag (#514)
   - Inflight requests limit (#484)
   - Mutual TLS (#488)
   - Periodic topology checks (#485)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -799,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1026,6 +1026,7 @@ dependencies = [
  "protobuf-codegen",
  "rand 0.8.7",
  "redis",
+ "regex",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -1627,7 +1628,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2122,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2232,7 +2233,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2289,7 +2290,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2640,7 +2641,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3203,7 +3204,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -28,7 +28,7 @@ use redis::{
 /// # Safety
 ///
 /// * `ptr` must be able to be safely casted to a valid [`CStr`] via [`CStr::from_ptr`]. See the safety documentation of [`std::ffi::CStr::from_ptr`].
-unsafe fn ptr_to_str(ptr: *const c_char) -> Result<String, String> {
+pub(crate) unsafe fn ptr_to_str(ptr: *const c_char) -> Result<String, String> {
     if !ptr.is_null() {
         unsafe { CStr::from_ptr(ptr) }
             .to_str()
@@ -155,6 +155,9 @@ pub struct ConnectionConfig {
     pub protocol: redis::ProtocolVersion,
     /// zero pointer is valid, means no client name is given (`None`)
     pub client_name: *const c_char,
+    /// Library name override for CLIENT SETINFO LIB-NAME. Always provided by the C# layer
+    /// (defaults to "GlideC#"); must be non-null.
+    pub lib_name: *const c_char,
     pub lazy_connect: bool,
     pub refresh_topology_from_initial_nodes: bool,
     pub pubsub_config: PubSubConfigInfo,
@@ -311,7 +314,7 @@ pub(crate) unsafe fn create_connection_request(
             None
         },
         client_name: unsafe { ptr_to_opt_str(config.client_name) }?,
-        lib_name: Some(env!("GLIDE_NAME").to_string()),
+        lib_name: Some(unsafe { ptr_to_str(config.lib_name) }?),
         authentication_info: if config.has_authentication_info {
             let auth_info = config.authentication_info;
             let iam_config = if auth_info.has_iam_credentials {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2039,6 +2039,7 @@ pub struct MonitorConfig {
     pub database: u16,
     pub username: *const c_char,
     pub password: *const c_char,
+    pub lib_name: *const c_char,
 }
 
 struct MonitorAdapter {
@@ -2074,16 +2075,26 @@ pub unsafe extern "C-unwind" fn create_monitor_client(
 ) -> *const MonitorConnectionResponse {
     let config = unsafe { &*config };
 
-    let host = match unsafe { CStr::from_ptr(config.host) }.to_str() {
-        Ok(s) => s.to_owned(),
-        Err(e) => {
-            let err_msg = CString::new(format!("Invalid UTF-8 in host: {e}")).unwrap_or_default();
-            return Box::into_raw(Box::new(MonitorConnectionResponse {
-                conn_ptr: std::ptr::null(),
-                connection_error_message: err_msg.into_raw(),
-            }));
-        }
-    };
+    // Converts a required C string field to a Rust `String`, or returns an error response
+    // immediately if it is not valid UTF-8. Shared by `host` and `lib_name`, which are the two
+    // required (non-optional) string fields on `MonitorConfig`.
+    macro_rules! required_field {
+        ($ptr:expr, $field_name:literal) => {
+            match unsafe { crate::ffi::ptr_to_str($ptr) } {
+                Ok(s) => s,
+                Err(e) => {
+                    let err_msg = CString::new(format!("Invalid UTF-8 in {}: {e}", $field_name))
+                        .unwrap_or_default();
+                    return Box::into_raw(Box::new(MonitorConnectionResponse {
+                        conn_ptr: std::ptr::null(),
+                        connection_error_message: err_msg.into_raw(),
+                    }));
+                }
+            }
+        };
+    }
+
+    let host = required_field!(config.host, "host");
 
     let address = NodeAddress {
         host,
@@ -2114,13 +2125,15 @@ pub unsafe extern "C-unwind" fn create_monitor_client(
         }
     };
 
+    let lib_name = required_field!(config.lib_name, "lib_name");
+
     let redis_conn_info = redis::RedisConnectionInfo {
         db: config.database as i64,
         username,
         password,
         protocol: redis::ProtocolVersion::RESP2,
         client_name: None,
-        lib_name: Some(env!("GLIDE_NAME").to_string()),
+        lib_name: Some(lib_name),
         server_assisted_cache: false,
         cache: None,
     };

--- a/sources/Valkey.Glide/ConnectionConfiguration.cs
+++ b/sources/Valkey.Glide/ConnectionConfiguration.cs
@@ -52,6 +52,8 @@ public abstract class ConnectionConfiguration
         public uint DatabaseId;
         public Protocol? Protocol;
         public string? ClientName;
+        public string? LibName;
+        public string? ClientInfoTag;
         public bool LazyConnect;
         public bool RefreshTopologyFromInitialNodes;
         public BasePubSubSubscriptionConfig? PubSubSubscriptions;
@@ -82,6 +84,9 @@ public abstract class ConnectionConfiguration
         public PeriodicChecksMode? PeriodicChecksMode;
         public uint? PeriodicChecksIntervalSecs;
 
+        /// <summary>
+        /// Computes the resolved library name to send via CLIENT SETINFO LIB-NAME.
+        /// </summary>
         internal FFI.ConnectionConfig ToFfi() => new(
             Addresses,
             ClusterMode,
@@ -120,7 +125,10 @@ public abstract class ConnectionConfiguration
 
             // Periodic checks
             PeriodicChecksMode,
-            PeriodicChecksIntervalSecs
+            PeriodicChecksIntervalSecs,
+
+            // CLIENT SETINFO LIB-NAME
+            Internals.Utils.ResolveLibraryName(LibName, ClientInfoTag)
         );
     }
 
@@ -866,6 +874,60 @@ public abstract class ConnectionConfiguration
         public T WithClientName(string? clientName)
         {
             ClientName = clientName;
+            return (T)this;
+        }
+
+        #endregion
+        #region Library Name
+
+        /// <summary>
+        /// Full override for the library name reported via <c>CLIENT SETINFO LIB-NAME</c> during connection establishment.
+        /// Defaults to <c>GlideC#</c>. When set, this replaces the default identifier entirely.
+        /// <para/>
+        /// Use <see cref="ClientInfoTag"/> instead if you want to preserve the GLIDE identity while adding a framework tag.
+        /// </summary>
+        /// <seealso cref="ClientInfoTag"/>
+        public string? LibraryName
+        {
+            get => Config.LibName ?? Internals.Utils.DefaultLibraryName;
+            set => Config.LibName = value;
+        }
+
+        /// <inheritdoc cref="LibraryName" />
+        public T WithLibraryName(string? libraryName)
+        {
+            LibraryName = libraryName;
+            return (T)this;
+        }
+
+        #endregion
+        #region Client Info Tag
+
+        /// <summary>
+        /// A tag appended to the library name reported via <c>CLIENT SETINFO LIB-NAME</c>.
+        /// The tag is appended in parentheses to preserve the underlying GLIDE identity for adoption tracking.
+        /// <para/>
+        /// For example, setting <c>ClientInfoTag = "my-framework:1.0"</c> produces <c>GlideC#(my-framework:1.0)</c>.
+        /// <para/>
+        /// A <see langword="null"/> value is treated as absent: the base library name is reported
+        /// unchanged, with no <c>()</c> suffix. Any other value — including empty or
+        /// whitespace-only — is passed through as supplied. Character validation is performed
+        /// entirely by the GLIDE core, which permits only printable ASCII from <c>!</c> through
+        /// <c>~</c> (excluding space) plus at most one matched, non-empty trailing <c>(tag)</c>
+        /// group; a malformed value fails client creation with a configuration error rather than
+        /// being silently dropped.
+        /// </summary>
+        /// <seealso cref="LibraryName"/>
+        public string? ClientInfoTag
+        {
+            get => Config.ClientInfoTag;
+            set => Config.ClientInfoTag = value;
+        }
+
+        /// <inheritdoc cref="ClientInfoTag" />
+        public T WithClientInfoTag(string? clientInfoTag)
+        {
+            ClientInfoTag = clientInfoTag;
             return (T)this;
         }
 

--- a/sources/Valkey.Glide/Internals/FFI.structs.cs
+++ b/sources/Valkey.Glide/Internals/FFI.structs.cs
@@ -34,6 +34,7 @@ internal partial class FFI
             if (_ptr != IntPtr.Zero)
             {
                 FreeMemory();
+                DestroyStruct(_ptr);
                 FreeStructPtr(_ptr);
                 _ptr = IntPtr.Zero;
             }
@@ -43,6 +44,15 @@ internal partial class FFI
         protected abstract IntPtr AllocateAndCopy();
 
         protected abstract void FreeMemory();
+
+        /// <summary>
+        /// Releases unmanaged memory the runtime marshaller allocated for reference-typed struct
+        /// fields (e.g. <see cref="UnmanagedType.LPUTF8Str"/> strings), which <see cref="FreeMemory"/>
+        /// (manual <see cref="IntPtr"/> frees) does not cover. No-op by default; override for structs
+        /// that contain such fields. Called after <see cref="FreeMemory"/> and before the block is freed.
+        /// </summary>
+        /// <param name="ptr">Pointer to the marshalled struct whose reference-typed fields are released.</param>
+        protected virtual void DestroyStruct(IntPtr ptr) { }
     }
 
     // A wrapper for a command, resposible for marshalling (allocating and freeing) the required data
@@ -213,6 +223,12 @@ internal partial class FFI
         /// </summary>
         internal NodeDiscoveryMode NodeDiscoveryMode => _request.NodeDiscoveryMode;
 
+        /// <summary>
+        /// The resolved library name marshalled into the underlying FFI request. Exposed for testing
+        /// that <see cref="Utils.ResolveLibraryName"/> is correctly wired through to the FFI layer.
+        /// </summary>
+        internal string ResolvedLibName => _request.ResolvedLibName;
+
         public ConnectionConfig(
             List<NodeAddress> addresses,
             bool clusterMode,
@@ -251,7 +267,10 @@ internal partial class FFI
 
             // Periodic checks
             PeriodicChecksMode? periodicChecksMode,
-            uint? periodicChecksIntervalSec)
+            uint? periodicChecksIntervalSec,
+
+            // Resolved library name
+            string resolvedLibName)
         {
             _request = new()
             {
@@ -313,6 +332,9 @@ internal partial class FFI
                 HasPeriodicChecksConfig = periodicChecksMode.HasValue,
                 PeriodicChecksMode = periodicChecksMode ?? default,
                 PeriodicChecksIntervalSec = periodicChecksIntervalSec ?? 0,
+
+                // CLIENT SETINFO LIB-NAME
+                ResolvedLibName = resolvedLibName,
             };
         }
 
@@ -380,6 +402,9 @@ internal partial class FFI
 
         protected override IntPtr AllocateAndCopy()
             => StructToPtr(_request);
+
+        protected override void DestroyStruct(IntPtr ptr)
+            => Marshal.DestroyStructure(ptr, typeof(ConnectionRequest));
 
         /// <summary>
         /// Marshals the node addresses.
@@ -739,6 +764,13 @@ internal partial class FFI
 
         [MarshalAs(UnmanagedType.LPUTF8Str)]
         public string? ClientName;
+
+        /// <summary>
+        /// The fully composed value sent to <c>CLIENT SETINFO LIB-NAME</c> (already includes any
+        /// <c>ClientInfoTag</c>). Named distinctly from the raw <c>LibName</c> to avoid re-composing.
+        /// </summary>
+        [MarshalAs(UnmanagedType.LPUTF8Str)]
+        public string ResolvedLibName;
 
         [MarshalAs(UnmanagedType.U1)]
         public bool LazyConnect;
@@ -1281,6 +1313,12 @@ internal partial class FFI
         /// or <see langword="null"/> if not set.</summary>
         [MarshalAs(UnmanagedType.LPUTF8Str)]
         public string? Password;
+
+        /// <summary>
+        /// The resolved library name reported via CLIENT SETINFO LIB-NAME for the MONITOR connection.
+        /// </summary>
+        [MarshalAs(UnmanagedType.LPUTF8Str)]
+        public string LibName;
     }
 
     /// <summary>

--- a/sources/Valkey.Glide/Internals/Utils.cs
+++ b/sources/Valkey.Glide/Internals/Utils.cs
@@ -68,4 +68,31 @@ internal static class Utils
 
         return list;
     }
+
+    /// <summary>
+    /// The default library name reported via <c>CLIENT SETINFO LIB-NAME</c> when no override is supplied.
+    /// </summary>
+    public const string DefaultLibraryName = "GlideC#";
+
+    /// <summary>
+    /// Composes the value reported via <c>CLIENT SETINFO LIB-NAME</c> from an optional library-name
+    /// override and an optional client-info tag. Used by every connection type (standard, cluster,
+    /// and MONITOR) so the composition stays identical across them.
+    /// </summary>
+    /// <param name="libraryName">Full override for the library name, or <see langword="null"/> to use <see cref="DefaultLibraryName"/>.</param>
+    /// <param name="clientInfoTag">
+    /// Tag appended in parentheses, e.g. <c>GlideC#(tag)</c>, or <see langword="null"/> for none.
+    /// A non-null value — including an empty or whitespace-only one — is passed through as
+    /// supplied. GLIDE core validates the effective library name before client creation and fails
+    /// creation with a configuration error if it is malformed; validation is deliberately not
+    /// duplicated here, per the standing rule that the client defers to the server.
+    /// </param>
+    /// <returns>The resolved library name to send to the server.</returns>
+    public static string ResolveLibraryName(string? libraryName, string? clientInfoTag)
+    {
+        string baseName = libraryName ?? DefaultLibraryName;
+        return clientInfoTag is null
+            ? baseName
+            : $"{baseName}({clientInfoTag})";
+    }
 }

--- a/sources/Valkey.Glide/MonitorClient.cs
+++ b/sources/Valkey.Glide/MonitorClient.cs
@@ -63,6 +63,7 @@ public sealed class MonitorClient : IAsyncDisposable, IDisposable
             Database = config.Database,
             Username = config.Username,
             Password = config.Password is not null ? new string(config.Password) : null,
+            LibName = Internals.Utils.ResolveLibraryName(config.LibraryName, config.ClientInfoTag),
         };
 
         IntPtr configPtr = Marshal.AllocHGlobal(Marshal.SizeOf<MonitorConfigFfi>());

--- a/sources/Valkey.Glide/MonitorConfig.cs
+++ b/sources/Valkey.Glide/MonitorConfig.cs
@@ -46,6 +46,31 @@ public sealed class MonitorConfig(string host, ushort port) : IDisposable
         private set;
     } = null;
 
+    /// <summary>
+    /// Full override for the library name reported via <c>CLIENT SETINFO LIB-NAME</c> for the
+    /// MONITOR connection. Defaults to <c>GlideC#</c>. When set, this replaces the default entirely.
+    /// </summary>
+    /// <seealso cref="ClientInfoTag"/>
+    public string? LibraryName
+    {
+        get => field ?? Internals.Utils.DefaultLibraryName;
+        private set;
+    } = null;
+
+    /// <summary>
+    /// A tag appended in parentheses to the library name reported via <c>CLIENT SETINFO LIB-NAME</c>
+    /// for the MONITOR connection, e.g. <c>GlideC#(my-framework:1.0)</c>, preserving the GLIDE identity.
+    /// <para/>
+    /// A <see langword="null"/> value is treated as absent: the base library name is reported
+    /// unchanged, with no <c>()</c> suffix. Any other value — including empty or whitespace-only —
+    /// is passed through as supplied. Character validation is performed entirely by the GLIDE
+    /// core, which permits only printable ASCII from <c>!</c> through <c>~</c> (excluding space)
+    /// plus at most one matched, non-empty trailing <c>(tag)</c> group; a malformed value fails
+    /// client creation with a configuration error.
+    /// </summary>
+    /// <seealso cref="LibraryName"/>
+    public string? ClientInfoTag { get; private set; } = null;
+
     #endregion
     #region Internal Properties
 
@@ -118,7 +143,32 @@ public sealed class MonitorConfig(string host, ushort port) : IDisposable
     /// <returns>This instance for method chaining.</returns>
     public MonitorConfig WithDatabase(ushort database)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
         Database = database;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a full override for the library name reported via <c>CLIENT SETINFO LIB-NAME</c>.
+    /// </summary>
+    /// <param name="libraryName">The library name, or <see langword="null"/> to use the default (<c>GlideC#</c>).</param>
+    /// <returns>This instance for method chaining.</returns>
+    public MonitorConfig WithLibraryName(string? libraryName)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        LibraryName = libraryName;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets a tag appended in parentheses to the library name reported via <c>CLIENT SETINFO LIB-NAME</c>.
+    /// </summary>
+    /// <param name="clientInfoTag">The tag, or <see langword="null"/> for none.</param>
+    /// <returns>This instance for method chaining.</returns>
+    public MonitorConfig WithClientInfoTag(string? clientInfoTag)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ClientInfoTag = clientInfoTag;
         return this;
     }
 

--- a/tests/Valkey.Glide.IntegrationTests/ClientInfoTagTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/ClientInfoTagTests.cs
@@ -1,0 +1,171 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+using Valkey.Glide.TestUtils;
+
+namespace Valkey.Glide.IntegrationTests;
+
+/// <summary>
+/// Integration tests verifying CLIENT INFO reports the correct lib-name
+/// when LibraryName and/or ClientInfoTag are configured.
+/// Requires Valkey server >= 7.2.0 (CLIENT SETINFO support).
+/// </summary>
+[Collection("GlideTests")]
+public class ClientInfoTagTests(TestConfiguration config)
+{
+    public TestConfiguration Config { get; } = config;
+
+    /// <summary>
+    /// LibraryName override only → CLIENT INFO contains lib-name=custom-client
+    /// </summary>
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
+    public async Task TestClientInfo_WithLibNameOnly_ReportsCustomLibName(bool useCluster)
+    {
+        Skip.IfClientSetInfoNotSupported();
+
+        const string customLibName = "custom-client";
+
+        using BaseClient client = useCluster
+            ? await GlideClusterClient.CreateClient(
+                TestConfiguration.DefaultClusterClientConfig()
+                    .WithLibraryName(customLibName)
+                    .Build())
+            : await GlideClient.CreateClient(
+                TestConfiguration.DefaultClientConfig()
+                    .WithLibraryName(customLibName)
+                    .Build());
+
+        string info = await Client.GetClientInfo(client);
+
+        Assert.Contains($"lib-name={customLibName}", info);
+        // Should NOT have parenthesized tag when no ClientInfoTag is set
+        Assert.DoesNotContain($"lib-name={customLibName}(", info);
+    }
+
+    /// <summary>
+    /// ClientInfoTag only → CLIENT INFO contains lib-name=GlideC#(tag)
+    /// </summary>
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
+    public async Task TestClientInfo_WithClientInfoTagOnly_ReportsDefaultLibNameWithTag(bool useCluster)
+    {
+        Skip.IfClientSetInfoNotSupported();
+
+        const string tag = "my-framework:1.0";
+
+        using BaseClient client = useCluster
+            ? await GlideClusterClient.CreateClient(
+                TestConfiguration.DefaultClusterClientConfig()
+                    .WithClientInfoTag(tag)
+                    .Build())
+            : await GlideClient.CreateClient(
+                TestConfiguration.DefaultClientConfig()
+                    .WithClientInfoTag(tag)
+                    .Build());
+
+        string info = await Client.GetClientInfo(client);
+
+        Assert.Contains($"lib-name=GlideC#({tag})", info);
+    }
+
+    /// <summary>
+    /// Both LibraryName and ClientInfoTag → CLIENT INFO contains lib-name=custom-client(tag)
+    /// </summary>
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [MemberData(nameof(Data.ClusterMode), MemberType = typeof(Data))]
+    public async Task TestClientInfo_WithLibNameAndClientInfoTag_ReportsCombined(bool useCluster)
+    {
+        Skip.IfClientSetInfoNotSupported();
+
+        const string customLibName = "custom-client";
+        const string tag = "my-framework:1.0";
+
+        using BaseClient client = useCluster
+            ? await GlideClusterClient.CreateClient(
+                TestConfiguration.DefaultClusterClientConfig()
+                    .WithLibraryName(customLibName)
+                    .WithClientInfoTag(tag)
+                    .Build())
+            : await GlideClient.CreateClient(
+                TestConfiguration.DefaultClientConfig()
+                    .WithLibraryName(customLibName)
+                    .WithClientInfoTag(tag)
+                    .Build());
+
+        string info = await Client.GetClientInfo(client);
+
+        Assert.Contains($"lib-name={customLibName}({tag})", info);
+    }
+
+    /// <summary>
+    /// A malformed library name is rejected by glide-core before any network activity, so client
+    /// creation fails rather than silently dropping the lib-name.
+    /// <para/>
+    /// This pins the boundary the binding deliberately delegates: C# performs structural
+    /// composition only and leaves character validation to core. If core's grammar changed, C#
+    /// behaviour would change with it — this test fails loudly instead of drifting silently.
+    /// <para/>
+    /// Note a single matched trailing <c>(tag)</c> group is VALID (that is what makes the
+    /// binding's own <c>base(tag)</c> composition legal), so the invalid paren cases below are
+    /// unmatched, doubled and empty groups rather than parens as such.
+    /// </summary>
+    [Theory(DisableDiscoveryEnumeration = true)]
+    [InlineData("Glide C#")]        // interior space
+    [InlineData("GlideC#(")]        // unmatched open paren
+    [InlineData("GlideC#()")]       // empty tag group
+    [InlineData("GlideC#(a)(b)")]   // more than one group
+    [InlineData("caf\u00e9")]       // non-ASCII
+    public async Task TestClientCreation_WithMalformedLibraryName_IsRejectedByCore(string invalidLibName)
+    {
+        Skip.IfClientSetInfoNotSupported();
+
+        _ = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using BaseClient client = await GlideClient.CreateClient(
+                TestConfiguration.DefaultClientConfig()
+                    .WithLibraryName(invalidLibName)
+                    .Build());
+        });
+    }
+
+    /// <summary>
+    /// A tag containing interior whitespace composes a value core rejects, so client creation fails.
+    /// </summary>
+    [Fact]
+    public async Task TestClientCreation_WithInteriorWhitespaceTag_IsRejectedByCore()
+    {
+        Skip.IfClientSetInfoNotSupported();
+
+        _ = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using BaseClient client = await GlideClient.CreateClient(
+                TestConfiguration.DefaultClientConfig()
+                    .WithClientInfoTag("foo bar")
+                    .Build());
+        });
+    }
+
+    /// <summary>
+    /// A whitespace-only tag is composed and passed through, not folded to absent, so core rejects
+    /// it and client creation fails. The client defers all validation — whitespace, empty, or
+    /// otherwise — to the server; a whitespace-only tag is a caller mistake and must surface loudly
+    /// rather than being silently ignored.
+    /// </summary>
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("")]
+    public async Task TestClientCreation_WithWhitespaceOrEmptyTag_IsRejectedByCore(string tag)
+    {
+        Skip.IfClientSetInfoNotSupported();
+
+        _ = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using BaseClient client = await GlideClient.CreateClient(
+                TestConfiguration.DefaultClientConfig()
+                    .WithClientInfoTag(tag)
+                    .Build());
+        });
+    }
+}

--- a/tests/Valkey.Glide.IntegrationTests/MonitorClientTests.cs
+++ b/tests/Valkey.Glide.IntegrationTests/MonitorClientTests.cs
@@ -96,6 +96,20 @@ public class MonitorClientTests(StandaloneClientFixture fixture) : IClassFixture
         await monitor.DisposeAsync(); // Should not throw
     }
 
+    [Fact]
+    public async Task Monitor_ReportsConfiguredLibNameAndTag()
+    {
+        Skip.IfClientSetInfoNotSupported();
+
+        const string tag = "monitor-tag:1.0";
+        var addr = fixture.Server.Address;
+        using var config = BuildMonitorConfig(addr.Host, addr.Port).WithClientInfoTag(tag);
+        await using var monitor = await MonitorClient.CreateClient(config);
+
+        string? monitorLibName = await PollMonitorLibNameAsync();
+        Assert.Equal($"GlideC#({tag})", monitorLibName);
+    }
+
     #endregion
     #region Helpers
 
@@ -104,6 +118,39 @@ public class MonitorClientTests(StandaloneClientFixture fixture) : IClassFixture
         var addr = fixture.Server.Address;
         using var config = BuildMonitorConfig(addr.Host, addr.Port);
         return await MonitorClient.CreateClient(config);
+    }
+
+    /// <summary>
+    /// Polls <c>CLIENT LIST</c> (via a normal client) for the MONITOR connection (flag <c>O</c>)
+    /// and returns its reported <c>lib-name</c>.
+    /// </summary>
+    private async Task<string?> PollMonitorLibNameAsync()
+    {
+        string? libName = null;
+        await Polling.WaitForAsync(
+            async () =>
+            {
+                GlideString[] clientListCommand = ["CLIENT", "LIST"];
+                object? result = await Client.CustomCommand(clientListCommand);
+                foreach (string line in result!.ToString()!.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    string[] fields = line.Split(' ');
+                    string? flags = fields.FirstOrDefault(f => f.StartsWith("flags=", StringComparison.Ordinal));
+                    if (flags is null || !flags["flags=".Length..].Contains('O'))
+                    {
+                        continue;
+                    }
+
+                    string? found = fields.FirstOrDefault(f => f.StartsWith("lib-name=", StringComparison.Ordinal));
+                    libName = found?["lib-name=".Length..];
+                    return true;
+                }
+
+                return false;
+            },
+            "MONITOR connection did not appear in CLIENT LIST in time.");
+
+        return libName;
     }
 
     #endregion

--- a/tests/Valkey.Glide.IntegrationTests/Skip.cs
+++ b/tests/Valkey.Glide.IntegrationTests/Skip.cs
@@ -12,8 +12,17 @@ internal static class Skip
     #region Version Checks
 
     private static readonly Version Valkey7_0 = new("7.0.0");
+    private static readonly Version Valkey7_2 = new("7.2.0");
     private static readonly Version Valkey8_1 = new("8.1.0");
     private static readonly Version Valkey9_0 = new("9.0.0");
+
+    /// <summary>
+    /// Skips the test if <c>CLIENT SETINFO</c> (lib-name / lib-ver reporting) is not supported.
+    /// </summary>
+    public static void IfClientSetInfoNotSupported()
+        => Assert.SkipWhen(
+            TestConfiguration.SERVER_VERSION < Valkey7_2,
+            "CLIENT SETINFO requires Valkey 7.2+");
 
     /// <summary>
     /// Skips the test if background save cancel commands are not supported.

--- a/tests/Valkey.Glide.TestUtils/Client.cs
+++ b/tests/Valkey.Glide.TestUtils/Client.cs
@@ -35,6 +35,20 @@ public static class Client
     }
 
     /// <summary>
+    /// Returns the output of the <c>CLIENT INFO</c> command for the given client.
+    /// </summary>
+    /// <param name="client">A client that is connected to the server.</param>
+    /// <returns>A task that resolves to the raw <c>CLIENT INFO</c> string.</returns>
+    public static async Task<string> GetClientInfo(BaseClient client)
+    {
+        GlideString[] infoCommand = ["CLIENT", "INFO"];
+        object? result = client is GlideClusterClient clusterClient
+            ? (await clusterClient.CustomCommand(infoCommand, Route.Random)).SingleValue
+            : await ((GlideClient)client).CustomCommand(infoCommand);
+        return result!.ToString()!;
+    }
+
+    /// <summary>
     /// Returns the Valkey server version.
     /// </summary>
     /// <param name="client">A client that is connected to the server.</param>

--- a/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ConnectionConfigurationTests.cs
@@ -1002,6 +1002,109 @@ public class ConnectionConfigurationTests
         => Assert.Null(new ClusterClientConfigurationBuilder { AddressResolver = null }.Build().Request.AddressResolver);
 
     #endregion
+    #region LibName and ClientInfoTag Tests
+
+    [Fact]
+    public void LibName_NotSet_DefaultsToGlideCSharp()
+        => Assert.Null(new StandaloneClientConfigurationBuilder().Build().Request.LibName);
+
+    [Fact]
+    public void LibName_Set_OverridesDefault()
+    {
+        var config = new StandaloneClientConfigurationBuilder()
+            .WithLibraryName("custom-lib")
+            .Build();
+        Assert.Equal("custom-lib", config.Request.LibName);
+    }
+
+    [Fact]
+    public void LibName_SetNull_FallsBackToDefault()
+    {
+        var config = new StandaloneClientConfigurationBuilder()
+            .WithLibraryName(null)
+            .Build();
+        Assert.Null(config.Request.LibName);
+    }
+
+    [Fact]
+    public void ClientInfoTag_Set_StoresTag()
+    {
+        var config = new StandaloneClientConfigurationBuilder()
+            .WithClientInfoTag("my-framework:1.0")
+            .Build();
+        Assert.Equal("my-framework:1.0", config.Request.ClientInfoTag);
+    }
+
+    [Fact]
+    public void ClientInfoTag_Null_ClearsTag()
+    {
+        var config = new StandaloneClientConfigurationBuilder()
+            .WithClientInfoTag(null)
+            .Build();
+        Assert.Null(config.Request.ClientInfoTag);
+    }
+
+    [Fact]
+    public void LibName_Cluster_Set_OverridesDefault()
+    {
+        var config = new ClusterClientConfigurationBuilder()
+            .WithLibraryName("cluster-lib")
+            .Build();
+        Assert.Equal("cluster-lib", config.Request.LibName);
+    }
+
+    [Fact]
+    public void LibraryName_NotSet_ExposesDefaultGlideCSharp()
+    {
+        var builder = new StandaloneClientConfigurationBuilder();
+        Assert.Equal("GlideC#", builder.LibraryName);
+    }
+
+    [Fact]
+    public void LibraryName_Cluster_NotSet_ExposesDefaultGlideCSharp()
+    {
+        var builder = new ClusterClientConfigurationBuilder();
+        Assert.Equal("GlideC#", builder.LibraryName);
+    }
+
+    /// <summary>
+    /// Composition itself (base name + tag folding rules) is covered by
+    /// <see cref="UtilsTests"/>; these pin only that <c>ToFfi()</c> wires the resolved value
+    /// through to the FFI layer correctly.
+    /// </summary>
+    [Fact]
+    public void LibraryNameAndTag_ToFfi_PassesResolvedLibNameToFfiLayer()
+    {
+        var config = new StandaloneClientConfigurationBuilder()
+            .WithLibraryName("custom")
+            .WithClientInfoTag("tag:1")
+            .Build();
+
+        using FFI.ConnectionConfig ffi = config.Request.ToFfi();
+        Assert.Equal("custom(tag:1)", ffi.ResolvedLibName);
+    }
+
+    [Fact]
+    public void ClientInfoTag_ToFfi_PassesComposedDefaultLibNameToFfiLayer()
+    {
+        var config = new StandaloneClientConfigurationBuilder()
+            .WithClientInfoTag("lmcache:1.2")
+            .Build();
+
+        using FFI.ConnectionConfig ffi = config.Request.ToFfi();
+        Assert.Equal("GlideC#(lmcache:1.2)", ffi.ResolvedLibName);
+    }
+
+    [Fact]
+    public void LibraryName_Default_ToFfi_PassesGlideCSharpToFfiLayer()
+    {
+        var config = new StandaloneClientConfigurationBuilder().Build();
+
+        using FFI.ConnectionConfig ffi = config.Request.ToFfi();
+        Assert.Equal("GlideC#", ffi.ResolvedLibName);
+    }
+
+    #endregion
     #region Helpers
 
     private static dynamic GetConfigurationBuilder(bool clusterMode)

--- a/tests/Valkey.Glide.UnitTests/MonitorConfigTests.cs
+++ b/tests/Valkey.Glide.UnitTests/MonitorConfigTests.cs
@@ -80,6 +80,9 @@ public class MonitorConfigTests
         _ = Assert.Throws<ObjectDisposedException>(() => config.WithAuth(Password));
         _ = Assert.Throws<ObjectDisposedException>(() => config.WithAuth(Username, Password));
         _ = Assert.Throws<ObjectDisposedException>(() => config.WithTls());
+        // WithDatabase previously lacked the guard its sibling mutators all have, so it silently
+        // mutated a disposed config instead of throwing.
+        _ = Assert.Throws<ObjectDisposedException>(() => config.WithDatabase(1));
     }
 
     [Fact]
@@ -100,6 +103,32 @@ public class MonitorConfigTests
         config.Dispose();
 
         Assert.All(passwordRef, c => Assert.Equal('\0', c));
+    }
+
+    [Fact]
+    public void LibraryName_NotSet_DefaultsToGlideCSharp()
+    {
+        using var config = BuildMonitorConfig();
+        Assert.Equal("GlideC#", config.LibraryName);
+    }
+
+    [Fact]
+    public void WithLibraryName_OverridesDefault()
+    {
+        using var config = BuildMonitorConfig().WithLibraryName("custom-mon");
+        Assert.Equal("custom-mon", config.LibraryName);
+    }
+
+    /// <summary>
+    /// Composition itself (base name + tag folding rules) is covered by
+    /// <see cref="UtilsTests"/>, which <see cref="MonitorConfig"/> shares via
+    /// <see cref="Utils.ResolveLibraryName"/>; this pins only that the tag is stored.
+    /// </summary>
+    [Fact]
+    public void WithClientInfoTag_StoresTag()
+    {
+        using var config = BuildMonitorConfig().WithClientInfoTag("svc:1.0");
+        Assert.Equal("svc:1.0", config.ClientInfoTag);
     }
 
     #endregion

--- a/tests/Valkey.Glide.UnitTests/UtilsTests.cs
+++ b/tests/Valkey.Glide.UnitTests/UtilsTests.cs
@@ -12,4 +12,62 @@ public class UtilsTests
         Assert.Equal("[::1]:6379", Utils.FormatAddress("::1", 6379));
         Assert.Equal("[2001:db8::1]:8080", Utils.FormatAddress("2001:db8::1", 8080));
     }
+
+    [Fact]
+    public void ResolveLibraryName_NoOverrides_ReturnsDefault()
+        => Assert.Equal("GlideC#", Utils.ResolveLibraryName(null, null));
+
+    [Fact]
+    public void ResolveLibraryName_LibraryNameOverride_ReplacesDefault()
+        => Assert.Equal("custom-lib", Utils.ResolveLibraryName("custom-lib", null));
+
+    [Fact]
+    public void ResolveLibraryName_Tag_AppendsToDefault()
+        => Assert.Equal("GlideC#(my-framework:1.0)", Utils.ResolveLibraryName(null, "my-framework:1.0"));
+
+    [Fact]
+    public void ResolveLibraryName_LibraryNameAndTag_AppendsToOverride()
+        => Assert.Equal("custom(lmcache:1.2)", Utils.ResolveLibraryName("custom", "lmcache:1.2"));
+
+    [Fact]
+    public void ResolveLibraryName_NullTag_LeavesDefaultUnchanged()
+        => Assert.Equal("GlideC#", Utils.ResolveLibraryName(null, null));
+
+    /// <summary>
+    /// An empty tag is composed and passed through, not folded to absent — the client defers all
+    /// validation, whitespace or otherwise, to the server. Contrast with <see langword="null"/>,
+    /// which is the only value treated as "no tag" (<see cref="ResolveLibraryName_NullTag_LeavesDefaultUnchanged"/>).
+    /// <c>GlideC#()</c> fails GLIDE core's grammar (a matched trailing group must be non-empty), so
+    /// this composes a value the server will reject, by design.
+    /// </summary>
+    [Fact]
+    public void ResolveLibraryName_EmptyTag_IsComposedAndLeftToCore()
+        => Assert.Equal("GlideC#()", Utils.ResolveLibraryName(null, ""));
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    [InlineData(" \t \n ")]
+    public void ResolveLibraryName_WhitespaceOnlyTag_IsComposedAndLeftToCore(string tag) =>
+        // Whitespace-only tags are NOT folded away. Per the maintainer directive that bindings
+        // compose and core validates, the tag is composed as-is and passed through; glide-core's
+        // library-name grammar then rejects it (space is 0x20, below the \x21 floor), failing
+        // client creation with a configuration error. That rejection is the intended outcome —
+        // a whitespace-only tag is a caller mistake and the caller is told so.
+        // Only null/empty are treated as absent, which is what keeps "GlideC#()" unreachable.
+        Assert.Equal($"GlideC#({tag})", Utils.ResolveLibraryName(null, tag));
+
+    [Fact]
+    public void ResolveLibraryName_WhitespaceOnlyTag_WithLibraryName_IsComposed()
+        => Assert.Equal("custom(   )", Utils.ResolveLibraryName("custom", "   "));
+
+    [Fact]
+    public void ResolveLibraryName_LibraryNameOnly_Cluster_OverridesDefault()
+        => Assert.Equal("cluster-lib", Utils.ResolveLibraryName("cluster-lib", null));
+
+    [Fact]
+    public void ResolveLibraryName_TagOnly_Cluster_AppendsToDefault()
+        => Assert.Equal("GlideC#(my-svc:2.0)", Utils.ResolveLibraryName(null, "my-svc:2.0"));
 }


### PR DESCRIPTION
## Summary

Adds two client-identification options — reported via `CLIENT SETINFO LIB-NAME` — to the standalone, cluster, **and MONITOR** clients:

1. **`LibraryName`** — full override for the lib-name value. Defaults to `GlideC#`; when set, replaces that identifier entirely.
2. **`ClientInfoTag`** — appends a parenthesized tag to the resolved library name while preserving the underlying GLIDE identity, e.g. `GlideC#(my-framework:1.0)`.

Available on `ConnectionConfiguration` (standalone/cluster) and on `MonitorConfig` (MONITOR connection).

## Motivation

Libraries and frameworks embedding GLIDE need to identify themselves to the server for adoption tracking, observability, and debugging. `ClientInfoTag` is the recommended option: it keeps the `GlideC#` token intact for GLIDE-level dashboards while adding per-framework attribution.

## Behavior matrix

| Config | Resulting `lib-name` |
|---|---|
| _(none)_ | `GlideC#` |
| `ClientInfoTag="lmcache:1.2"` | `GlideC#(lmcache:1.2)` |
| `ClientInfoTag="   "` _(whitespace-only)_ | `GlideC#` |
| `LibraryName="custom"` | `custom` |
| `LibraryName="custom"`, `ClientInfoTag="lmcache:1.2"` | `custom(lmcache:1.2)` |

## What changed

- **`ConnectionConfiguration.cs`** — Add `LibraryName` and `ClientInfoTag` builder options (`WithLibraryName`, `WithClientInfoTag`), backed by the `ConnectionConfig` record with a `ResolvedLibName` computed property. No client-side validation is performed on the tag — validation is deferred to the server. As output-composition hygiene, a whitespace-only tag degrades to the base lib-name (so `CLIENT SETINFO LIB-NAME`, which rejects spaces/newlines/special characters, never receives a broken value). `LibraryName` exposes the `GlideC#` default via its getter.
- **`MonitorConfig.cs` / `MonitorClient.cs`** — Add the same `LibraryName` / `ClientInfoTag` options (+ `WithLibraryName` / `WithClientInfoTag`) to the MONITOR client, and send the resolved lib-name for the monitor connection instead of the hard-coded `GLIDE_NAME`.
- **`Internals/LibNameResolver.cs`** (new) — Shared composition (base name + optional tag, incl. whitespace-only handling) used by both `ConnectionConfiguration` and `MonitorConfig`, so all connection types stay consistent.
- **`Internals/FFI.structs.cs`** — Add the non-optional `LibName` field (`LPUTF8Str`) to the `ConnectionRequest` struct and to `MonitorConfigFfi`. The resolved lib-name is always provided.
- **`rust/src/ffi.rs` / `rust/src/lib.rs`** — Add required `lib_name` to the connection and monitor FFI structs; always send the C#-resolved value (no compile-time `GLIDE_NAME` fallback — glide-core honors the request `lib_name`). glide-core is untouched.
- **Tests** — Unit tests for `ConnectionConfiguration` and `MonitorConfig` (defaults, overrides, tag composition, whitespace-only, cluster); integration tests asserting `CLIENT INFO` (standard/cluster) and `CLIENT LIST` (monitor connection) report the expected lib-name.

## Testing

- Unit tests green (671 total).
- Integration tests (standalone + cluster) verify `CLIENT INFO` reports the expected `lib-name`; a MONITOR integration test verifies the monitor connection's `lib-name` via `CLIENT LIST` (gated to Valkey 7.2+ for `CLIENT SETINFO`).
- Follows the same pattern as the merged Python PR (valkey-io/valkey-glide#6389).

## Notes

- **LIB-NAME only.** `LIB-VER` remains core-controlled via `GLIDE_VERSION`.
- **No client-level tag validation** — deferred to the server per review discussion; only whitespace-only tags are normalized away at composition.
- The `lib_name` field already exists in the shared `ConnectionRequest` (used by other language clients). This change wires C# (including the MONITOR connection) to use it.
