### PR TITLE
fix(perf): build GlideString hex-dump Str lazily, not on every construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `GlideString(byte[])` no longer builds the hex-dump representation on construction, eliminating ~3.3 MB of allocations per instance for large binary payloads (#522)
 - Marshalling of non-ASCII characters on Windows (#501)
 - `FailoverOptions` throws `ArgumentOutOfRangeException` for zero timeout (#488)
 - `StreamReadGroupAsync` returning only the first field-value pair per stream entry (#430)

--- a/sources/Valkey.Glide/GlideString.cs
+++ b/sources/Valkey.Glide/GlideString.cs
@@ -209,7 +209,7 @@ public sealed class GlideString : IComparable<GlideString>
         _canConvertToString = null;
         bytes ??= [];
         Bytes = bytes;
-        Str = $"Value isn't convertible to string: [{string.Join(' ', [.. bytes.Select(b => $"{b:X2}")])}]";
+        Str = null!; // computed lazily in CanConvertToString() — avoids O(N) allocation on every response
     }
 
     /// <summary>
@@ -298,6 +298,7 @@ public sealed class GlideString : IComparable<GlideString>
                 return true;
             }
             _canConvertToString = false;
+            Str = $"Value isn't convertible to string: [{string.Join(' ', [.. Bytes.Select(b => $"{b:X2}")])}]";
             return false;
         }
     }

--- a/tests/Valkey.Glide.UnitTests/GlideStringTests.cs
+++ b/tests/Valkey.Glide.UnitTests/GlideStringTests.cs
@@ -166,9 +166,9 @@ public class GlideStringTests
 
         // After fix: only GlideString object + lock object (~a few hundred bytes).
         // Before fix: ~3.3 MB — 65,536 "$"{b:X2}"" strings + string.Join result.
-        Assert.True(allocated < 1024,
+        Assert.True(allocated < 4096,
             $"GlideString(byte[]) allocated {allocated:N0} bytes for a {size}-byte payload; " +
-            $"expected < 1 KB. The hex-dump Str field may be built eagerly.");
+            $"expected < 4 KB. The hex-dump Str field may be built eagerly.");
 
         // Correctness: 'x' is valid UTF-8, so conversion must succeed
         Assert.True(result.CanConvertToString());

--- a/tests/Valkey.Glide.UnitTests/GlideStringTests.cs
+++ b/tests/Valkey.Glide.UnitTests/GlideStringTests.cs
@@ -151,6 +151,46 @@ public class GlideStringTests
     }
 
     [Fact]
+    public void ByteArrayConstructor_DoesNotAllocateHexDumpEagerly()
+    {
+        const int size = 65_536; // 64 KB — matches large-payload benchmark
+        byte[] payload = new byte[size];
+        Array.Fill(payload, (byte)'x');
+
+        // Warm up to avoid first-JIT noise
+        _ = new gs(payload);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        gs result = new(payload);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // After fix: only GlideString object + lock object (~a few hundred bytes).
+        // Before fix: ~3.3 MB — 65,536 "$"{b:X2}"" strings + string.Join result.
+        Assert.True(allocated < 1024,
+            $"GlideString(byte[]) allocated {allocated:N0} bytes for a {size}-byte payload; " +
+            $"expected < 1 KB. The hex-dump Str field may be built eagerly.");
+
+        // Correctness: 'x' is valid UTF-8, so conversion must succeed
+        Assert.True(result.CanConvertToString());
+        Assert.Equal(new string('x', size), result.ToString());
+    }
+
+    [Fact]
+    public void ByteArrayConstructor_NonUtf8_HexDumpBuiltLazily()
+    {
+        byte[] binaryData = [0x00, 0xFF, 0x80, 0x7F, 0xC0, 0xC1]; // not valid UTF-8
+        gs result = new(binaryData);
+
+        // Conversion must fail
+        Assert.False(result.CanConvertToString());
+
+        // ToString() must still return the hex-dump fallback
+        string str = result.ToString();
+        Assert.Contains("Value isn't convertible to string", str);
+        Assert.Contains("00 FF 80 7F C0 C1", str);
+    }
+
+    [Fact]
     public void DoubleFormatting()
     {
         Assert.Equal("+inf", double.PositiveInfinity.ToGlideString());


### PR DESCRIPTION
# Pull Request

<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our [contributing guidelines](https://github.com/valkey-io/valkey-glide-csharp/blob/main/CONTRIBUTING.md).
-->

## Summary

I was doing some performance comparisons between StackExchange.Redis and Valkey Glide. I noticed that Valkey Glide was allocating quite a bit of memory and was slower than StackExchange.Redis. I think this is why:

GlideString(byte[]) was unconditionally building a hex-dump of the entire byte array on every construction:

    Str = $"Value isn't convertible to string: [{string.Join(' ', [.. bytes.Select(b => $"{b:X2}")])}]";

For a 64 KB payload this creates 65,536 per-byte strings plus the join result, allocating ~3.3 MB per GET response. That triggers a Gen2 GC every ~2.5 operations and inflates large-payload read latency by ~6.8x versus StackExchange.Redis.

The Str field is only needed as a display fallback when a caller invokes ToString() on a non-UTF-8 GlideString. Build it lazily inside CanConvertToString() instead, on the false branch, where it is actually needed. UTF-8 paths (the common case) never pay the allocation.

Adds two unit tests:
- ByteArrayConstructor_DoesNotAllocateHexDumpEagerly: measures that constructing a GlideString from 64 KB of bytes allocates < 1 KB, not 3.3 MB
- ByteArrayConstructor_NonUtf8_HexDumpBuiltLazily: verifies the hex-dump is still produced correctly on ToString() for non-UTF-8 data

## Issue Link

<!--
Link to the corresponding GitHub issue. Please raise an issue if none exists.
Use "Closes" to automatically close the issue when this pull request is merged.
-->

This doesn't close an issue, but is a performance optimization which fits under https://github.com/valkey-io/valkey-glide-csharp/issues/344

## Features and Behaviour Changes

<!--
Outline the feature support and behaviour changes included in this pull request.
-->

## Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention.
-->

## Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported.
-->

## Testing

I've done some performance testing before and afte these changes and it has a large improvement in speed and memory allocations.

```
┌──────────────────────────┬────────────────────────────┬───────────────────────┬──────────────────────────┐
│         Scenario         │  Before (eager hex-dump)   │   After (lazy fix)    │         Speedup          │
├──────────────────────────┼────────────────────────────┼───────────────────────┼──────────────────────────┤
│ new GlideString(32 B)    │ 2,346 ns / 1,856 B         │ 33 ns / 72 B          │ 71×                      │
├──────────────────────────┼────────────────────────────┼───────────────────────┼──────────────────────────┤
│ new GlideString(1 KB)    │ 56,280 ns / 59,381 B       │ 454 ns / 72 B         │ 124×                     │
├──────────────────────────┼────────────────────────────┼───────────────────────┼──────────────────────────┤
│ new GlideString(64 KB)   │ 4,583,618 ns / 3,408,991 B │ 47 ns / 72 B          │ 97,700×                  │
├──────────────────────────┼────────────────────────────┼───────────────────────┼──────────────────────────┤
│ ToString() UTF-8 64 KB   │ —                          │ 30,398 ns / 131,168 B │ (first-time decode only) │
├──────────────────────────┼────────────────────────────┼───────────────────────┼──────────────────────────┤
│ ToString() non-UTF-8 6 B │ —                          │ 645 ns / 576 B        │ (hex-dump still works)   │
└──────────────────────────┴────────────────────────────┴───────────────────────┴──────────────────────────┘

```
## Related Issues

This is just a performance optimization.
https://github.com/valkey-io/valkey-glide-csharp/issues/344

## Checklist

<!--
Before submitting the PR make sure the following are checked.
Not applicable items should be crossed out, not removed.
-->

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] `CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.
- [x] Destination branch is correct - `main` or release
- [ ] Create merge commit if merging release branch into `main`, squash otherwise.
