### PR TITLE
fix(core): `ClusterValue.HasSingleData` always true for value-type `T`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CONFIG RESETSTAT` routed to AllPrimaries instead of AllNodes in cluster mode (#493)
   - `FUNCTION KILL` routed to AllPrimaries instead of AllNodes in cluster mode (#494)
 - `GlideString(byte[])` no longer builds the hex-dump representation on construction (#522)
-- `ClusterValue<T>.HasSingleData` always true for value-type `T` (#547)
+- `ClusterValue<T>.HasSingleData` returns expected result for value-type `T` (#547)
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CONFIG RESETSTAT` routed to AllPrimaries instead of AllNodes in cluster mode (#493)
   - `FUNCTION KILL` routed to AllPrimaries instead of AllNodes in cluster mode (#494)
 - `GlideString(byte[])` no longer builds the hex-dump representation on construction (#522)
+- `ClusterValue<T>.HasSingleData` always true for value-type `T` (#547)
 
 ## 1.1.0
 

--- a/sources/Valkey.Glide/ClusterValue.cs
+++ b/sources/Valkey.Glide/ClusterValue.cs
@@ -20,13 +20,18 @@ namespace Valkey.Glide;
 /// <typeparam name="T">The wrapped response type</typeparam>
 public class ClusterValue<T>
 {
-    private Dictionary<string, T>? _multiValue = default;
+    #region Private Fields
+
     private T? _singleValue = default;
+    private Dictionary<string, T>? _multiValue = default;
+
+    #endregion
+    #region Constructors & Builders
 
     private ClusterValue() { }
 
     /// <summary>
-    /// A constructor for the value with type auto-detection.
+    /// Builds a cluster value from the given object.
     /// </summary>
     internal static ClusterValue<T> Of(object obj)
     {
@@ -41,36 +46,54 @@ public class ClusterValue<T>
         return OfSingleValue((T)obj);
     }
 
+    /// <summary>
+    /// Builds a cluster value from the given value.
+    /// </summary>
     internal static ClusterValue<T> OfSingleValue(T obj)
         => new() { _singleValue = obj };
 
+    /// <summary>
+    /// Builds a cluster value from the given values, indexed by node address.
+    /// </summary>
     internal static ClusterValue<T> OfMultiValue(Dictionary<string, T> obj)
         => new() { _multiValue = obj };
 
+    /// <summary>
+    /// Builds a cluster value from the given values, indexed by node address.
+    /// </summary>
     internal static ClusterValue<T> OfMultiValue(Dictionary<GlideString, T> obj)
         => new() { _multiValue = obj.DownCastKeys() };
 
-    /// <summary>
-    /// Get per-node value.<br />
-    /// Asserts if <see cref="HasMultiData" /> is <see langword="false" />.
-    /// </summary>
-    public Dictionary<string, T> MultiValue
-        => _multiValue ?? throw new Exception("No multi value stored");
+    #endregion
+    #region Public Methods
 
     /// <summary>
-    /// Get the single value.<br />
-    /// Asserts if <see cref="HasSingleData" /> is <see langword="false" />.
-    /// </summary>
-    public T SingleValue
-        => HasSingleData ? _singleValue! : throw new Exception("No single value stored");
-
-    /// <summary>
-    /// Check that multi-value is stored in this object. Should be called prior to <see cref="MultiValue" />.
+    /// Returns whether multiple values are stored in this object.
+    /// Should be called prior to <see cref="MultiValue" />.
     /// </summary>
     public bool HasMultiData => _multiValue != null;
 
     /// <summary>
-    /// Check that single-value is stored in this object. Should be called prior to <see cref="SingleValue" />.
+    /// Returns multiple value if they are stored in this object.
+    /// Values are indexed by node address.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="HasMultiData" /> is <see langword="false" />.</exception>
+    public Dictionary<string, T> MultiValue
+        => HasMultiData ? _multiValue! : throw new Exception("No multi value stored");
+
+    /// <summary>
+    /// Returns whether a single value is stored in this object.
+    /// Should be called prior to <see cref="SingleValue" />.
     /// </summary>
     public bool HasSingleData => _multiValue == null;
+
+    /// <summary>
+    /// Returns a single value if one is stored in this object.
+    /// </summary>
+    /// <returns>The single value response</returns>
+    /// <exception cref="Exception">Thrown when <see cref="HasSingleData" /> is <see langword="false" />.</exception>
+    public T SingleValue
+        => HasSingleData ? _singleValue! : throw new Exception("No single value stored");
+
+    #endregion
 }

--- a/sources/Valkey.Glide/ClusterValue.cs
+++ b/sources/Valkey.Glide/ClusterValue.cs
@@ -72,5 +72,5 @@ public class ClusterValue<T>
     /// <summary>
     /// Check that single-value is stored in this object. Should be called prior to <see cref="SingleValue" />.
     /// </summary>
-    public bool HasSingleData => _singleValue != null;
+    public bool HasSingleData => _multiValue == null;
 }

--- a/sources/Valkey.Glide/ClusterValue.cs
+++ b/sources/Valkey.Glide/ClusterValue.cs
@@ -85,7 +85,7 @@ public class ClusterValue<T>
     /// Returns whether a single value is stored in this object.
     /// Should be called prior to <see cref="SingleValue" />.
     /// </summary>
-    public bool HasSingleData => _multiValue == null;
+    public bool HasSingleData => !HasMultiData;
 
     /// <summary>
     /// Returns a single value if one is stored in this object.

--- a/sources/Valkey.Glide/ClusterValue.cs
+++ b/sources/Valkey.Glide/ClusterValue.cs
@@ -33,18 +33,18 @@ public class ClusterValue<T>
     /// <summary>
     /// Builds a cluster value from the given object.
     /// </summary>
+    /// <param name="obj">The response to wrap.</param>
+    /// <exception cref="ArgumentException">Thrown if type is not supported.</exception>
     internal static ClusterValue<T> Of(object obj)
-    {
-        if (obj is Dictionary<string, T> dict)
+        => obj switch
         {
-            return OfMultiValue(dict);
-        }
-        else if (obj is Dictionary<GlideString, T> dictGs)
-        {
-            return OfMultiValue(dictGs);
-        }
-        return OfSingleValue((T)obj);
-    }
+            Dictionary<string, T> dict => OfMultiValue(dict),
+            Dictionary<GlideString, T> dictGs => OfMultiValue(dictGs),
+            T value => OfSingleValue(value),
+            _ => throw new ArgumentException(
+                $"Cannot build {nameof(ClusterValue<>)}<{typeof(T).Name}> from a value of type '{obj?.GetType().Name ?? "null"}'.",
+                nameof(obj)),
+        };
 
     /// <summary>
     /// Builds a cluster value from the given value.

--- a/sources/Valkey.Glide/ClusterValue.cs
+++ b/sources/Valkey.Glide/ClusterValue.cs
@@ -23,7 +23,7 @@ public class ClusterValue<T>
     #region Private Fields
 
     private T? _singleValue = default;
-    private Dictionary<string, T>? _multiValue = default;
+    private Dictionary<string, T>? _multiValue = null;
 
     #endregion
     #region Constructors & Builders

--- a/tests/Valkey.Glide.UnitTests/ClusterValueTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ClusterValueTests.cs
@@ -75,6 +75,8 @@ public class ClusterValueTests
         AssertSingleValue(ClusterValue<int>.Of(SingleValue), SingleValue);
         AssertMultiValue(ClusterValue<int>.Of(ValueStrings), ValueStrings);
         AssertMultiValue(ClusterValue<int>.Of(ValueGlideStrings), ValueStrings);
+
+        _ = Assert.Throws<ArgumentException>(() => ClusterValue<int>.Of(SingleReference));
     }
 
     #endregion

--- a/tests/Valkey.Glide.UnitTests/ClusterValueTests.cs
+++ b/tests/Valkey.Glide.UnitTests/ClusterValueTests.cs
@@ -1,0 +1,98 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+namespace Valkey.Glide.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="ClusterValue{T}" />.
+/// </summary>
+public class ClusterValueTests
+{
+    #region Test Data
+
+    // Single-value
+    private const int SingleValue = 1;
+    private const string SingleReference = "REFERENCE";
+
+    // Multi-value
+    private static readonly Dictionary<string, int> ValueEmpty = [];
+    private static readonly Dictionary<string, int> ValueString = new() { ["node1"] = 1 };
+    private static readonly Dictionary<string, int> ValueStrings = new() { ["node1"] = 1, ["node2"] = 2 };
+    private static readonly Dictionary<gs, int> ValueGlideStrings = new() { ["node1"] = 1, ["node2"] = 2 };
+
+    private static readonly Dictionary<string, string> ReferenceEmpty = [];
+    private static readonly Dictionary<string, string> ReferenceString = new() { ["node1"] = "value1" };
+    private static readonly Dictionary<string, string> ReferenceStrings = new() { ["node1"] = "value1", ["node2"] = "value2" };
+    private static readonly Dictionary<gs, string> ReferenceGlideStrings = new() { ["node1"] = "value1", ["node2"] = "value2" };
+
+    #endregion
+    #region Tests
+
+    [Fact]
+    public void OfMultiValue_ValueType()
+    {
+        // Values
+        AssertMultiValue(ClusterValue<int>.OfMultiValue(ValueEmpty), ValueEmpty);
+        AssertMultiValue(ClusterValue<int>.OfMultiValue(ValueString), ValueString);
+        AssertMultiValue(ClusterValue<int>.OfMultiValue(ValueStrings), ValueStrings);
+        AssertMultiValue(ClusterValue<int>.OfMultiValue(ValueGlideStrings), ValueStrings);
+
+        // References
+        AssertMultiValue(ClusterValue<string>.OfMultiValue(ReferenceEmpty), ReferenceEmpty);
+        AssertMultiValue(ClusterValue<string>.OfMultiValue(ReferenceString), ReferenceString);
+        AssertMultiValue(ClusterValue<string>.OfMultiValue(ReferenceStrings), ReferenceStrings);
+        AssertMultiValue(ClusterValue<string>.OfMultiValue(ReferenceGlideStrings), ReferenceStrings);
+    }
+
+    [Fact]
+    public void OfSingleValue_ValueType()
+    {
+        // Values
+        AssertSingleValue(ClusterValue<int>.OfSingleValue(SingleValue), SingleValue);
+        AssertSingleValue(ClusterValue<int>.OfSingleValue(default), default);
+
+        // References
+        AssertSingleValue(ClusterValue<string?>.OfSingleValue(SingleReference), SingleReference);
+        AssertSingleValue(ClusterValue<string?>.OfSingleValue(null), null);
+    }
+
+    [Fact]
+    public void SingleValue_OnMultiValue_Throws()
+    {
+        _ = Assert.Throws<Exception>(() => _ = ClusterValue<int>.OfMultiValue(ValueStrings).SingleValue);
+        _ = Assert.Throws<Exception>(() => _ = ClusterValue<string>.OfMultiValue(ReferenceStrings).SingleValue);
+    }
+
+    [Fact]
+    public void MultiValue_OnSingleValue_Throws()
+    {
+        _ = Assert.Throws<Exception>(() => _ = ClusterValue<int>.OfSingleValue(SingleValue).MultiValue);
+        _ = Assert.Throws<Exception>(() => _ = ClusterValue<string>.OfSingleValue(SingleReference).MultiValue);
+    }
+
+    [Fact]
+    public void Of_CreatesValue()
+    {
+        AssertSingleValue(ClusterValue<int>.Of(SingleValue), SingleValue);
+        AssertMultiValue(ClusterValue<int>.Of(ValueStrings), ValueStrings);
+        AssertMultiValue(ClusterValue<int>.Of(ValueGlideStrings), ValueStrings);
+    }
+
+    #endregion
+    #region Helpers
+
+    private static void AssertMultiValue<T>(ClusterValue<T> value, Dictionary<string, T> expected)
+    {
+        Assert.True(value.HasMultiData);
+        Assert.False(value.HasSingleData);
+        Assert.Equivalent(expected, value.MultiValue);
+    }
+
+    private static void AssertSingleValue<T>(ClusterValue<T> value, T expected)
+    {
+        Assert.True(value.HasSingleData);
+        Assert.False(value.HasMultiData);
+        Assert.Equivalent(expected, value.SingleValue);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Fixes `ClusterValue<T>.HasSingleData`, which incorrectly returned `true` for **any** value-type `T` even when the instance held a multi-value (per-node) result.

## Issue Link

Closes #547.

## Features and Behaviour Changes

For a multi-value `ClusterValue<T>` with value-type `T`, `HasSingleData` now correctly returns `false`.

## Limitations

:white_circle: None.

## Testing

Added `tests/Valkey.Glide.UnitTests/ClusterValueTests.cs`.

## Related Issues

:white_circle: None.

## Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass.
- [x] `CHANGELOG.md` updated. ~~`README.md`, `DEVELOPER.md`, and other documentation files~~.
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
