### PR TITLE
chore(deps): update chacha20 to an unyanked version

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -540,9 +540,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
## Summary

`chacha20 0.10.1` was **yanked** from [crates.io](https://crates.io/). `cargo deny check` now fails its advisories check:

```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
chacha20 0.10.1 registry+https://github.com/rust-lang/crates.io-index — yanked version
advisories FAILED
```

This PR bumps `chacha20` to the nearest non-yanked semver-compatible version (`0.10.1 → 0.10.2`). The change is confined to `rust/Cargo.lock` — no source or submodule changes.

## Issue Link

:white_circle: None.

## Features and Behaviour Changes

:white_circle: None. Lockfile-only dependency bump.

## Implementation

- Ran `cargo update -p chacha20` in `rust/`, which bumped `chacha20` from `0.10.1` to `0.10.2`
- No other yanked or advisory crates surfaced during the update.

## Limitations

:white_circle: None.

## Testing

- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`.

## Checklist

- [x] ~~This Pull Request is related to one issue.~~ (Dependency hygiene fix; no issue.)
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated and all checks pass. (Lockfile-only; `task lint:rust` passes.)
- [x] ~~`CHANGELOG.md`, `README.md`, `DEVELOPER.md`, and other documentation files are updated.~~ (Not applicable.)
- [x] Destination branch is correct - `main` or release
- [x] Create merge commit if merging release branch into `main`, squash otherwise.
